### PR TITLE
stronger types on route params

### DIFF
--- a/src/app/content/reducer.ts
+++ b/src/app/content/reducer.ts
@@ -2,6 +2,7 @@ import { Reducer } from 'redux';
 import { getType } from 'typesafe-actions';
 import * as navigation from '../navigation';
 import * as actions from './actions';
+import { content } from './routes';
 import { State } from './types';
 
 export const initialState = {
@@ -15,7 +16,7 @@ const reducer: Reducer<State, AnyAction> = (state = initialState, action) => {
     case getType(actions.closeToc):
       return {...state, tocOpen: false};
     case getType(navigation.actions.locationChange):
-      return navigation.utils.matchForRoute('Content', action.payload.match)
+      return navigation.utils.matchForRoute(content, action.payload.match)
         ? {...state, params: action.payload.match.params}
         : state;
     default:

--- a/src/app/content/routes.ts
+++ b/src/app/content/routes.ts
@@ -4,7 +4,7 @@ import { Params } from './types';
 
 const CONTENT_PATH = '/books/:bookId/pages/:pageId';
 
-export const content: Route = {
+export const content: Route<Params> = {
   component: components.Content,
   getUrl: (params: Params): string => pathToRegexp.compile(CONTENT_PATH)(params),
   name: 'Content',

--- a/src/app/errors/reducer.spec.ts
+++ b/src/app/errors/reducer.spec.ts
@@ -33,7 +33,7 @@ describe('content reducer', () => {
       search: '',
       state: {},
     };
-    const match = {route: notFound, params: {}};
+    const match = {route: notFound};
     const newState = reducer(state, locationChange({location, match}));
 
     expect(newState.code).toEqual(404);
@@ -50,7 +50,10 @@ describe('content reducer', () => {
       search: '',
       state: {},
     };
-    const match = {route: content, params: {}};
+    const match = {
+      params: {bookId: 'book', pageId: 'page'},
+      route: content,
+    };
     const newState = reducer(state, locationChange({location, match}));
 
     expect(newState.code).toEqual(200);

--- a/src/app/errors/reducer.ts
+++ b/src/app/errors/reducer.ts
@@ -1,14 +1,14 @@
 import { Reducer } from 'redux';
 import { getType } from 'typesafe-actions';
 import * as navigation from '../navigation';
+import { notFound } from './routes';
 import { State } from './types';
-
 export const initialState = {};
 
 const reducer: Reducer<State, AnyAction> = (state = {}, action) => {
   switch (action.type) {
     case getType(navigation.actions.locationChange):
-      return navigation.utils.matchForRoute('NotFound', action.payload.match)
+      return navigation.utils.matchForRoute(notFound, action.payload.match)
         || action.payload.match === undefined
         ? {...state, code: 404}
         : {...state, code: 200};

--- a/src/app/errors/routes.ts
+++ b/src/app/errors/routes.ts
@@ -2,7 +2,7 @@ import * as components from './components';
 
 const CATCH_ALL = '/(.*)';
 
-export const notFound: Route = {
+export const notFound: Route<undefined> = {
   component: components.PageNotFound,
   getUrl: () => '/404',
   name: 'NotFound',

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -6,6 +6,7 @@ import createStore from '../helpers/createStore';
 import * as content from './content';
 import * as errors from './errors';
 import * as navigation from './navigation';
+import { AppState } from './types';
 
 export const actions = {
   content: content.actions,
@@ -13,11 +14,10 @@ export const actions = {
   navigation: navigation.actions,
 };
 
-export interface AppState {
-  content: content.types.State;
-  errors: errors.types.State;
-  navigation: navigation.types.State;
-}
+export const routes = [
+  ...Object.values(content.routes),
+  ...Object.values(errors.routes),
+];
 
 interface Options {
   initialState?: AppState;
@@ -34,11 +34,6 @@ export default (options: Options = {}) => {
     errors: errors.reducer,
     navigation: navigation.createReducer(history.location),
   });
-
-  const routes = [
-    ...Object.values(content.routes),
-    ...Object.values(errors.routes),
-  ];
 
   const middleware: Middleware[] = [
     navigation.createMiddleware(routes, history),

--- a/src/app/navigation/actions.ts
+++ b/src/app/navigation/actions.ts
@@ -1,5 +1,6 @@
+import { Location } from 'history';
 import { createStandardAction } from 'typesafe-actions';
-import { historyActions, Match, State } from './types';
+import { AnyMatch, historyActions } from './types';
 
 export const callHistoryMethod = createStandardAction('Navigation/callHistoryMethod')<historyActions>();
-export const locationChange = createStandardAction('Navigation/locationChange')<{location: State, match?: Match<any>}>();
+export const locationChange = createStandardAction('Navigation/locationChange')<{location: Location, match?: AnyMatch}>();

--- a/src/app/navigation/actions.ts
+++ b/src/app/navigation/actions.ts
@@ -2,4 +2,4 @@ import { createStandardAction } from 'typesafe-actions';
 import { historyActions, Match, State } from './types';
 
 export const callHistoryMethod = createStandardAction('Navigation/callHistoryMethod')<historyActions>();
-export const locationChange = createStandardAction('Navigation/locationChange')<{location: State, match?: Match}>();
+export const locationChange = createStandardAction('Navigation/locationChange')<{location: State, match?: Match<any>}>();

--- a/src/app/navigation/components/NavigationProvider.ts
+++ b/src/app/navigation/components/NavigationProvider.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { AnyRoute } from '../../types';
 import * as selectors from '../selectors';
+import { AnyRoute } from '../types';
 import * as utils from '../utils';
 
 const connectNavigationProvider = connect((state: RootState) => ({

--- a/src/app/navigation/components/NavigationProvider.ts
+++ b/src/app/navigation/components/NavigationProvider.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { AnyRoute } from '../../types';
 import * as selectors from '../selectors';
 import * as utils from '../utils';
 
@@ -7,7 +8,7 @@ const connectNavigationProvider = connect((state: RootState) => ({
   pathname: selectors.pathname(state),
 }));
 
-export default connectNavigationProvider(({routes, pathname}: {routes: Route[], pathname: string}) => {
+export default connectNavigationProvider(({routes, pathname}: {routes: AnyRoute[], pathname: string}) => {
   const match = utils.findRouteMatch(routes, pathname);
 
   if (match) {

--- a/src/app/navigation/middleware.spec.ts
+++ b/src/app/navigation/middleware.spec.ts
@@ -59,7 +59,7 @@ describe('navigation middleware', () => {
 
     expect(dispatch).toHaveBeenCalledWith(actions.locationChange({
       location: history.location,
-      match: {route: routes[1], params: {}},
+      match: {route: routes[1]},
     }));
   });
 });

--- a/src/app/navigation/middleware.ts
+++ b/src/app/navigation/middleware.ts
@@ -1,8 +1,8 @@
 import { History } from 'history';
 import { Dispatch, Middleware, MiddlewareAPI } from 'redux';
 import { getType } from 'typesafe-actions';
-import { AnyRoute } from '../types';
 import * as actions from './actions';
+import { AnyRoute } from './types';
 import { findRouteMatch } from './utils';
 
 export default (routes: AnyRoute[], history: History): Middleware => ({dispatch}: MiddlewareAPI) => {

--- a/src/app/navigation/middleware.ts
+++ b/src/app/navigation/middleware.ts
@@ -1,10 +1,11 @@
 import { History } from 'history';
 import { Dispatch, Middleware, MiddlewareAPI } from 'redux';
 import { getType } from 'typesafe-actions';
+import { AnyRoute } from '../types';
 import * as actions from './actions';
 import { findRouteMatch } from './utils';
 
-export default (routes: Route[], history: History): Middleware => ({dispatch}: MiddlewareAPI) => {
+export default (routes: AnyRoute[], history: History): Middleware => ({dispatch}: MiddlewareAPI) => {
   history.listen((location) => {
     const match = findRouteMatch(routes, location.pathname);
     dispatch(actions.locationChange({location, match}));

--- a/src/app/navigation/types.ts
+++ b/src/app/navigation/types.ts
@@ -1,14 +1,28 @@
 import { Location } from 'history';
+import { routes } from '../';
 
 export type State = Location;
 
-export interface Match<Params> {
-  route: Route<Params>;
-  params: Params;
+type RouteParams<R> = R extends Route<infer P> ? P : never;
+type UnionRouteMatches<R> = R extends AnyRoute ? Match<R> : never;
+
+interface MatchWithParams<R extends AnyRoute> {
+  route: R;
+  params: RouteParams<R>;
 }
+interface MatchWithoutParams<R extends AnyRoute> {
+  route: R;
+}
+
+export type GenericMatch = MatchWithParams<AnyRoute> | MatchWithoutParams<AnyRoute>;
+
+export type Match<R extends AnyRoute> = RouteParams<R> extends undefined ? MatchWithoutParams<R> | MatchWithParams<R> : MatchWithParams<R>;
 
 export type historyActions =
   {method: 'push', url: string} |
   {method: 'replace', url: string};
 
 export type reducer = (state: State, action: AnyAction) => State;
+
+export type AnyRoute = typeof routes[number];
+export type AnyMatch = UnionRouteMatches<AnyRoute>;

--- a/src/app/navigation/types.ts
+++ b/src/app/navigation/types.ts
@@ -2,9 +2,9 @@ import { Location } from 'history';
 
 export type State = Location;
 
-export interface Match {
-  route: Route;
-  params: any;
+export interface Match<Params> {
+  route: Route<Params>;
+  params: Params;
 }
 
 export type historyActions =

--- a/src/app/navigation/utils.spec.ts
+++ b/src/app/navigation/utils.spec.ts
@@ -23,7 +23,7 @@ describe('findRouteMatch', () => {
 
   it('returns match for route without params', () => {
     const result = findRouteMatch(routes, '/basic');
-    expect(result).toEqual({route: routes[0], params: {}});
+    expect(result).toEqual({route: routes[0]});
   });
 
   it('returns match for route with params', () => {

--- a/src/app/navigation/utils.ts
+++ b/src/app/navigation/utils.ts
@@ -1,12 +1,13 @@
 import { Location } from 'history';
 import pathToRegexp, { Key } from 'path-to-regexp';
 import { Dispatch } from 'redux';
+import { AnyRoute } from '../types';
 import * as actions from './actions';
 import { Match } from './types';
 
-export const matchForRoute = (route: string, match?: Match): match is Match => !!match && match.route.name === route;
+export const matchForRoute = <P>(route: Route<P>, match?: Match<any>): match is Match<P> => !!match && match.route.name === route.name;
 
-export const findRouteMatch = (routes: Route[], pathname: string): {route: Route, params: any} | undefined => {
+export const findRouteMatch = (routes: AnyRoute[], pathname: string): {route: AnyRoute, params: any} | undefined => {
   for (const route of routes) {
     for (const path of route.paths) {
       const keys: Key[] = [];
@@ -26,7 +27,7 @@ export const findRouteMatch = (routes: Route[], pathname: string): {route: Route
   }
 };
 
-export const init = (routes: Route[], location: Location, dispatch: Dispatch) => {
+export const init = (routes: AnyRoute[], location: Location, dispatch: Dispatch) => {
   const match = findRouteMatch(routes, location.pathname);
   dispatch(actions.locationChange({location, match}));
 };

--- a/src/app/navigation/utils.ts
+++ b/src/app/navigation/utils.ts
@@ -1,13 +1,12 @@
 import { Location } from 'history';
 import pathToRegexp, { Key } from 'path-to-regexp';
 import { Dispatch } from 'redux';
-import { AnyRoute } from '../types';
 import * as actions from './actions';
-import { Match } from './types';
+import { AnyMatch, AnyRoute, GenericMatch, Match } from './types';
 
-export const matchForRoute = <P>(route: Route<P>, match?: Match<any>): match is Match<P> => !!match && match.route.name === route.name;
+export const matchForRoute = <R extends AnyRoute>(route: R, match: GenericMatch | undefined): match is Match<R> => !!match && match.route.name === route.name;
 
-export const findRouteMatch = (routes: AnyRoute[], pathname: string): {route: AnyRoute, params: any} | undefined => {
+export const findRouteMatch = (routes: AnyRoute[], pathname: string): AnyMatch | undefined => {
   for (const route of routes) {
     for (const path of route.paths) {
       const keys: Key[] = [];
@@ -21,7 +20,10 @@ export const findRouteMatch = (routes: AnyRoute[], pathname: string): {route: An
           return {...result, [key.name]: value};
         }, {});
 
-        return {route, params};
+        return {
+          route,
+          ...(keys.length > 0 ? {params} : {}),
+        } as AnyMatch;
       }
     }
   }

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -1,3 +1,3 @@
-import { AppState } from '.';
+import { AppState } from './types';
 
 export const localState = (state: RootState): AppState => state;

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,0 +1,12 @@
+import { routes } from '.';
+import { State as contentState } from './content/types';
+import { State as errorsState } from './errors/types';
+import { State as navigationState } from './navigation/types';
+
+export interface AppState {
+  content: contentState;
+  errors: errorsState;
+  navigation: navigationState;
+}
+
+export type AnyRoute = typeof routes[number];

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,4 +1,3 @@
-import { routes } from '.';
 import { State as contentState } from './content/types';
 import { State as errorsState } from './errors/types';
 import { State as navigationState } from './navigation/types';
@@ -8,5 +7,3 @@ export interface AppState {
   errors: errorsState;
   navigation: navigationState;
 }
-
-export type AnyRoute = typeof routes[number];

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -12,10 +12,10 @@ declare global {
 
   type RootState = AppState;
 
-  interface Route {
+  interface Route<Params> {
     name: string;
     paths: string[];
-    getUrl: (input?: any) => string;
+    getUrl: (...args: Params extends undefined ? []: [Params]) => string;
     component: ComponentType;
   }
 


### PR DESCRIPTION
this depends on #1 merge that one first and then change the base on this.

the guard `navigation.utils.matchForRoute` now narrows the type of `match` properly so that the match.route and match.params have the correct type