### PR TITLE
chore: verify source maps are in the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typescript": "^3.1.6"
   },
   "scripts": {
-    "lint": "tslint --fix -p ./tsconfig.json",
+    "lint": "tslint -p ./tsconfig.json",
     "start": "react-scripts start",
     "build": "GENERATE_SOURCEMAP=true react-scripts build",
     "codecov": "codecov",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
     "typescript": "^3.1.6"
   },
   "scripts": {
-    "lint": "tslint -p ./tsconfig.json",
+    "lint": "tslint --fix -p ./tsconfig.json",
     "start": "react-scripts start",
     "build": "GENERATE_SOURCEMAP=true react-scripts build",
     "codecov": "codecov",
     "test": "react-scripts test --coverage",
+    "posttest": "npm run-script build && node ./script/verifySourcemaps.js",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -43,6 +44,8 @@
     "@types/react-test-renderer": "^16.0.3",
     "babel-core": "7.0.0-bridge.0",
     "codecov": "^3.1.0",
+    "glob": "^7.1.3",
+    "pify": "^4.0.1",
     "react-test-renderer": "^16.6.1",
     "tslint": "^5.11.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "start": "react-scripts start",
     "build": "GENERATE_SOURCEMAP=true react-scripts build",
     "codecov": "codecov",
-    "test": "react-scripts test --coverage",
-    "posttest": "npm run-script lint && npm run-script build && node ./script/verifySourcemaps.js",
+    "pretest": "npm run-script build",
+    "test": "react-scripts test --coverage && npm run-script lint && npm run-script test:sourcemap",
+    "test:sourcemap": "node ./script/verifySourcemaps.js",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "GENERATE_SOURCEMAP=true react-scripts build",
     "codecov": "codecov",
     "test": "react-scripts test --coverage",
-    "posttest": "npm run-script build && node ./script/verifySourcemaps.js",
+    "posttest": "npm run-script lint && npm run-script build && node ./script/verifySourcemaps.js",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/script/verifySourcemaps.js
+++ b/script/verifySourcemaps.js
@@ -6,7 +6,7 @@ const pify = require('pify')
 const jsGlobPattern = '../build/static/**/*.js'
 const sourcemapString = '//# sourceMappingURL='
 
-const toRelPath = (file) => path.relative(__dirname, file)
+const toRelPath = (file) => path.relative(process.cwd(), file)
 
 async function run() {
     const files = await pify(glob)(path.join(__dirname, jsGlobPattern))

--- a/script/verifySourcemaps.js
+++ b/script/verifySourcemaps.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
-const glob = require('glob')
 const pify = require('pify')
+const glob = require('glob')
 
 const jsGlobPattern = '../build/static/**/*.js'
 const sourcemapString = '//# sourceMappingURL='
@@ -20,24 +20,21 @@ async function run() {
         const mapFilename = contents.substring(index + sourcemapString.length).split('\n')[0]
         const mapPath = path.join(path.dirname(filename), mapFilename)
         const mapSource = JSON.parse(fs.readFileSync(mapPath))
-        // const sm = new SourceMapConsumer(mapSource)
+
         mapSource.sources.forEach((sourceFilename, index) => {
             const sourcePath = path.join(path.dirname(mapPath), sourceFilename)
             if (!fs.existsSync(sourcePath)) {
-                if (mapSource.sourcesContent[index]) {
-                    console.warn(`WARN: In '${toRelPath(mapPath)}': Unable to find source file but found sourceContent for '${toRelPath(sourceFilename)}'`)
-                } else {
-                    console.error(`Unable to find source='${toRelPath(sourcePath)}' from '${toRelPath(mapPath)} from '${toRelPath(filename)}`)
+                if (!mapSource.sourcesContent[index]) {
+                    console.error(`Unable to find source='${toRelPath(sourcePath)}' from '${toRelPath(mapPath)}' from '${toRelPath(filename)}`)
                     console.error(`Here are the relative paths: '${sourceFilenameRel}' from '${mapFilename}' from '${filename}'`)
                     throw new Error(`BUG: Could not find source file`)
                 }
             }
-
         })
     }
 
     if (files.length === 0) {
-        throw new Error(`BUG: Could not find js files`)
+        throw new Error(`BUG: Could not find js files to verify .map files exist. Check that '${jsGlobPattern}' still matches the JS files`)
     }
 }
 

--- a/script/verifySourcemaps.js
+++ b/script/verifySourcemaps.js
@@ -1,0 +1,45 @@
+const fs = require('fs')
+const path = require('path')
+const glob = require('glob')
+const pify = require('pify')
+
+const jsGlobPattern = '../build/static/**/*.js'
+const sourcemapString = '//# sourceMappingURL='
+
+const toRelPath = (file) => path.relative(__dirname, file)
+
+async function run() {
+    const files = await pify(glob)(path.join(__dirname, jsGlobPattern))
+
+    for (const filename of files) {
+        const contents = fs.readFileSync(filename, 'utf-8')
+        const index = contents.search(sourcemapString)
+        if (index < 0) {
+            throw new Error(`BUG: Sourcemap not found! file='${toRelPath(filename)}'`)
+        }
+        const mapFilename = contents.substring(index + sourcemapString.length).split('\n')[0]
+        const mapPath = path.join(path.dirname(filename), mapFilename)
+        const mapSource = JSON.parse(fs.readFileSync(mapPath))
+        // const sm = new SourceMapConsumer(mapSource)
+        mapSource.sources.forEach((sourceFilename, index) => {
+            const sourcePath = path.join(path.dirname(mapPath), sourceFilename)
+            if (!fs.existsSync(sourcePath)) {
+                if (mapSource.sourcesContent[index]) {
+                    console.warn(`WARN: In '${toRelPath(mapPath)}': Unable to find source file but found sourceContent for '${toRelPath(sourceFilename)}'`)
+                } else {
+                    console.error(`Unable to find source='${toRelPath(sourcePath)}' from '${toRelPath(mapPath)} from '${toRelPath(filename)}`)
+                    console.error(`Here are the relative paths: '${sourceFilenameRel}' from '${mapFilename}' from '${filename}'`)
+                    throw new Error(`BUG: Could not find source file`)
+                }
+            }
+
+        })
+    }
+
+    if (files.length === 0) {
+        throw new Error(`BUG: Could not find js files`)
+    }
+}
+
+
+run().then(null, (err) => { throw err })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1212,6 +1212,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+  integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
+
 aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
@@ -2221,6 +2226,17 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+codecov@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.1.0.tgz#340bd968d361f256976b5af782dd8ba9f82bc849"
+  integrity sha512-aWQc/rtHbcWEQLka6WmBAOpV58J2TwyXqlpAQGhQaSiEUoigTTUk6lLd2vB3kXkhnDyzyH74RXfmV4dq2txmdA==
+  dependencies:
+    argv "^0.0.2"
+    ignore-walk "^3.0.1"
+    js-yaml "^3.12.0"
+    request "^2.87.0"
+    urlgrey "^0.4.4"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -4032,7 +4048,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -6845,6 +6861,11 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -9427,6 +9448,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+urlgrey@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
+  integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This verifies that sourcemaps are included in the build (`yarn build`). 

To verify it works, one can:

- change `GENERATE_SOURCEMAP=true`  in `package.json` to be `GENERATE_SOURCEMAP=false`
- run `yarn test` and check that the exit status is non-zero

It is currently pretty verbose because I noticed that the sourcemap JSON does not actually have the correct relative path. It does however have the source code of the file in the `.map` file so it's probably ok. If it really is ok, then we can remove the `console.warn(...)` statement.

# Example outputs

### Warnings (expected)

```
WARN: In 'build/static/js/1.ba200448.chunk.js.map': Unable to find source file but found sourceContent for '../node_modules/webpack/buildin/harmony-module.js'
WARN: In 'build/static/js/main.398f5adf.chunk.js.map': Unable to find source file but found sourceContent for 'helpers/createStore.ts'
```

### Error (missing sourcemap file)

```
UnhandledPromiseRejectionWarning: Error: BUG: Sourcemap not found! file='build/static/js/1.ba200448.chunk.js'
```

### Error (no JS files found)

```
UnhandledPromiseRejectionWarning: Error: BUG: Could not find js files
```