### PR TITLE
rearrange scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,7 @@ node_js: "10"
 
 cache: yarn
 
+before_script:
+  - yarn build
+
 after_success: yarn run codecov

--- a/package.json
+++ b/package.json
@@ -23,10 +23,9 @@
     "build": "GENERATE_SOURCEMAP=true react-scripts build",
     "codecov": "codecov",
     "postinstall": "jq -Rs . node_modules/cnx-recipes/styles/output/intro-business.css > node_modules/cnx-recipes/styles/output/intro-business.json",
-    "pretest": "npm run-script build",
-    "test": "react-scripts test --coverage && npm run-script lint && npm run-script test:sourcemap",
-    "test:sourcemap": "node ./script/verifySourcemaps.js",
-    "watch": "react-scripts test --watch"
+    "test": "npm run-script test:unit && npm run-script lint && npm run-script test:sourcemap",
+    "test:unit": "react-scripts test --coverage",
+    "test:sourcemap": "node ./script/verifySourcemaps.js"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
I enjoy running `yarn test --watchAll` while developing, which wasn't working with the combined test commands so i made `yarn test:unit` which i can use for that purpose and reference it from `yarn test`.

running the build from `pretest` was wasted effort from the docker container because the build is known to be up to date, i switched travis to run it explicitly before testing