### PR TITLE
chore: remove jenkins CODE_VERSION param

### DIFF
--- a/jenkins/release.jenkins
+++ b/jenkins/release.jenkins
@@ -3,7 +3,6 @@ pipeline {
   parameters {
       string(name: 'BUCKET', defaultValue: 'openstax-sandbox-rex-primary', description: 'the bucket to add to. This should not change frequently')
       string(name: 'RELEASE_ID', description: 'A unique ID for the release. Can be anything but the CloudFormation -> Origins -> RexS3PrimaryOrigin will need to be updated when the build is complete')
-      string(name: 'CODE_VERSION', defaultValue: 'master', description: 'the branch or tag to build')
       string(name: 'BOOKS', defaultValue: '{"031da8d3-b525-429c-80cf-6c8ed997733a":{"defaultVersion":"14.4"}}', description: 'Configuration of which books to prerender')
   }
   stages {
@@ -26,7 +25,7 @@ pipeline {
           docker exec \
             -e NODE_ENV=production \
             -e BOOKS="${params.BOOKS.replace('"', '\\"')}" \
-            -e CODE_VERSION="${params.CODE_VERSION}" \
+            -e CODE_VERSION="$GIT_COMMIT" \
             -e RELEASE_ID="${params.RELEASE_ID}" \
             $BUILD_TAG yarn prerender
         """


### PR DESCRIPTION
It is not used and the Git sha is more descriptive