### PR TITLE
chore: add tsc to test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "reselect": "^4.0.0",
     "styled-components": "^4.0.3",
     "typesafe-actions": "^2.0.4",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2"
   },
   "scripts": {
     "lint": "tslint -p ./tsconfig.json",
@@ -28,7 +28,7 @@
     "server": "NODE_ENV=development node script/entry server/cli",
     "codecov": "codecov",
     "postinstall": "node ./script/postinstall",
-    "test": "npm run-script test:unit && npm run-script lint && npm run-script test:build",
+    "test": "npm run-script test:unit && npm run-script lint && npm run-script test:build && ./node_modules/.bin/tsc",
     "test:unit": "jest --coverage --testPathPattern=\"(\\.|/)(browser)?spec\\.tsx?\"",
     "test:build": "npm run-script build:clean && npm run-script test:sourcemap && npm run-script test:prerender",
     "test:sourcemap": "node ./script/verifySourcemaps.js",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "server": "NODE_ENV=development node script/entry server/cli",
     "codecov": "codecov",
     "postinstall": "node ./script/postinstall",
-    "test": "npm run-script test:unit && npm run-script lint && npm run-script test:build && ./node_modules/.bin/tsc",
+    "test": "npm run-script test:unit && npm run-script lint && npm run-script test:build && tsc",
     "test:unit": "jest --coverage --testPathPattern=\"(\\.|/)(browser)?spec\\.tsx?\"",
     "test:build": "npm run-script build:clean && npm run-script test:sourcemap && npm run-script test:prerender",
     "test:sourcemap": "node ./script/verifySourcemaps.js",

--- a/src/app/content/hooks/receiveContent.spec.ts
+++ b/src/app/content/hooks/receiveContent.spec.ts
@@ -2,7 +2,7 @@ import cloneDeep from 'lodash/fp/cloneDeep';
 import { ActionHookBody, AppServices, AppState, MiddlewareAPI } from '../../types';
 import { receiveBook, receivePage } from '../actions';
 import { initialState } from '../reducer';
-import { ArchiveContent, Book, Page, State } from '../types';
+import { ArchiveBook, ArchiveContent, Book, Page, State } from '../types';
 
 describe('setHead hook', () => {
   let hookBody: ActionHookBody<typeof receiveBook | typeof receivePage>;
@@ -32,7 +32,7 @@ describe('setHead hook', () => {
     localState.book = { title: 'book', id: 'book' } as Book;
     localState.page = { title: 'page', id: 'page' } as Page;
 
-    hookBody(helpers)(receiveBook({} as ArchiveContent));
+    hookBody(helpers)(receiveBook({} as ArchiveBook));
 
     expect(helpers.dispatch).toHaveBeenCalledWith(head);
   });
@@ -54,7 +54,7 @@ describe('setHead hook', () => {
     localState.page = { title: 'page', id: 'page' } as Page;
     localState.loading.book = 'book2';
 
-    hookBody(helpers)(receiveBook({} as ArchiveContent));
+    hookBody(helpers)(receiveBook({} as ArchiveBook));
 
     expect(helpers.dispatch).not.toHaveBeenCalled();
   });
@@ -64,7 +64,7 @@ describe('setHead hook', () => {
     localState.page = { title: 'page', id: 'page' } as Page;
     localState.loading.page = 'page2';
 
-    hookBody(helpers)(receiveBook({} as ArchiveContent));
+    hookBody(helpers)(receiveBook({} as ArchiveBook));
 
     expect(helpers.dispatch).not.toHaveBeenCalled();
   });
@@ -72,7 +72,7 @@ describe('setHead hook', () => {
   it('does nothing if page is not loaded', () => {
     localState.book = { title: 'book', id: 'book' } as Book;
 
-    hookBody(helpers)(receiveBook({} as ArchiveContent));
+    hookBody(helpers)(receiveBook({} as ArchiveBook));
 
     expect(helpers.dispatch).not.toHaveBeenCalled();
   });
@@ -80,7 +80,7 @@ describe('setHead hook', () => {
   it('does nothing if book is not loaded', () => {
     localState.page = { title: 'page', id: 'page' } as Page;
 
-    hookBody(helpers)(receiveBook({} as ArchiveContent));
+    hookBody(helpers)(receiveBook({} as ArchiveBook));
 
     expect(helpers.dispatch).not.toHaveBeenCalled();
   });

--- a/src/app/context/Services.tsx
+++ b/src/app/context/Services.tsx
@@ -1,4 +1,4 @@
-import React, { Attributes } from 'react';
+import React from 'react';
 import { AppServices } from '../types';
 
 const {Consumer, Provider} = React.createContext({} as AppServices);
@@ -13,7 +13,10 @@ interface ServiceConsumer {
 }
 
 /* tslint:disable-next-line:variable-name */
-export default <P extends ServiceConsumer & Attributes>(Component: React.ComponentType<P>) =>
+export default <P extends ServiceConsumer>(Component: React.ComponentClass<P>) =>
   (props: Pick<P, Exclude<keyof P, keyof ServiceConsumer>>) => <Consumer>
-    {(services) => <Component services={services} {...props} />}
+    {(services) => {
+      // @ts-ignore - remove this when https://github.com/Microsoft/TypeScript/issues/28748 is resolved
+      return <Component services={services} {...props} />;
+    }}
   </Consumer>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9938,10 +9938,10 @@ typesafe-actions@^2.0.4:
   resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-2.0.4.tgz#31c8f8df3566d549eb52edb64a75997e970c17d0"
   integrity sha512-3qnSDBNtH3mfekmM9w/IVlsqiUT4I5m+mpLp5tV2Ua/28BfaehqUg6eQNC8+cTk+oufbXcubLiWvKS/61qgleQ==
 
-typescript@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+typescript@^3.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
+  integrity sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
until now we've been catching type errors as a function of the build commands run as part of the tests, but some type error have leaked through in the tests themselves and in the scripts which aren't compiled with the app code.

adding tsc to the test command before was annoying because of this bug https://github.com/Microsoft/TypeScript/issues/28202

so i've upgraded typescript to the new release with that bug fixed but now there is a different bug
https://github.com/Microsoft/TypeScript/issues/28748

but that one is easier to ignore and document so i've pressed on anyway.