### PR TITLE
fix: don't load from osweb if the book slug is already known

### DIFF
--- a/src/app/content/hooks/locationChange.spec.ts
+++ b/src/app/content/hooks/locationChange.spec.ts
@@ -254,4 +254,24 @@ describe('locationChange', () => {
 
     expect(message).toEqual('Page not found');
   });
+
+  it('loads book details from osweb', async() => {
+    await hook(payload);
+    expect(helpers.osWebLoader.getBookIdFromSlug).toHaveBeenCalledWith('book-slug-1');
+  });
+
+  it('caches book details from osweb', async() => {
+    await hook(payload);
+    await hook(payload);
+    expect(helpers.osWebLoader.getBookIdFromSlug).toHaveBeenCalledTimes(1);
+  });
+
+  it('doesn\'t call osweb if book slug is already known', async() => {
+    localState.book = {
+      ...book,
+      slug: 'book-slug-1',
+    };
+    await hook(payload);
+    expect(helpers.osWebLoader.getBookIdFromSlug).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/content/hooks/locationChange.ts
+++ b/src/app/content/hooks/locationChange.ts
@@ -56,16 +56,21 @@ const resolveBook = async(
 };
 
 const resolveBookReference = async(
-  {osWebLoader}: AppServices & MiddlewareAPI,
+  {osWebLoader, getState}: AppServices & MiddlewareAPI,
   match: Match<typeof content>
 ): Promise<[string, string, string]> => {
+  const state = getState();
   const bookSlug = match.params.book;
+  const currentBook = select.book(state);
 
   if (match.state) {
     return [bookSlug, match.state.bookUid, match.state.bookVersion];
   }
 
-  const bookUid = await osWebLoader.getBookIdFromSlug(bookSlug);
+  const bookUid = currentBook && currentBook.slug === bookSlug
+    ? currentBook.id
+    : await osWebLoader.getBookIdFromSlug(bookSlug);
+
   const bookVersion = assertDefined(BOOKS[bookUid], `BUG: ${bookSlug} (${bookUid}) is not in BOOKS configuration`
   ).defaultVersion;
 

--- a/src/test/mocks/osWebLoader.ts
+++ b/src/test/mocks/osWebLoader.ts
@@ -1,4 +1,4 @@
 export default () => ({
-  getBookIdFromSlug: () => Promise.resolve('testbook1-uuid'),
-  getBookSlugFromId: () => Promise.resolve('book-slug-1'),
+  getBookIdFromSlug: jest.fn(() => Promise.resolve('testbook1-uuid')),
+  getBookSlugFromId: jest.fn(() => Promise.resolve('book-slug-1')),
 });


### PR DESCRIPTION
fixes issue found in release 3 testing