### PR TITLE
spike highlighting search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@openstax/highlighter": "^1.1.9",
     "cnx-recipes": "github:connexions/cnx-recipes#master",
     "history": "^4.7.2",
     "html-entities": "^1.2.1",

--- a/src/app/content/components/ContentPane.tsx
+++ b/src/app/content/components/ContentPane.tsx
@@ -15,6 +15,10 @@ export default styled(MainContent)`
     padding: 0 50px;
   }
 
+  .highlight {
+    background-color: yellow;
+  }
+
   // these are only here because the cnx-recipes styles are broken
   font-size: 18px;
   font-family: "Noto Sans";

--- a/src/app/navigation/selectors.ts
+++ b/src/app/navigation/selectors.ts
@@ -16,4 +16,9 @@ export const hash = createSelector(
   (state) => state.hash
 );
 
+export const query = createSelector(
+  localState,
+  (state) => state.query
+);
+
 export const location = localState;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,6 +5,25 @@ import { compose } from 'redux';
 import { AppServices, AppState } from './app/types';
 import PromiseCollector from './helpers/PromiseCollector';
 
+declare var NodeFilter: {
+  readonly FILTER_ACCEPT: number;
+  readonly FILTER_REJECT: number;
+  readonly FILTER_SKIP: number;
+  readonly SHOW_ALL: number;
+  readonly SHOW_ATTRIBUTE: number;
+  readonly SHOW_CDATA_SECTION: number;
+  readonly SHOW_COMMENT: number;
+  readonly SHOW_DOCUMENT: number;
+  readonly SHOW_DOCUMENT_FRAGMENT: number;
+  readonly SHOW_DOCUMENT_TYPE: number;
+  readonly SHOW_ELEMENT: number;
+  readonly SHOW_ENTITY: number;
+  readonly SHOW_ENTITY_REFERENCE: number;
+  readonly SHOW_NOTATION: number;
+  readonly SHOW_PROCESSING_INSTRUCTION: number;
+  readonly SHOW_TEXT: number;
+};
+
 declare global {
 
   interface Window extends dom.Window {
@@ -13,6 +32,7 @@ declare global {
     __APP_SERVICES: AppServices;
     __APP_ASYNC_HOOKS: PromiseCollector;
 
+    NodeFilter: NodeFilter;
     MouseEvent: {
       prototype: dom.MouseEvent;
       new(typeArg: string, eventInitDict?: dom.MouseEventInit): dom.MouseEvent;

--- a/src/highlighter.d.ts
+++ b/src/highlighter.d.ts
@@ -1,0 +1,1 @@
+declare module '@openstax/highlighter';

--- a/yarn.lock
+++ b/yarn.lock
@@ -948,6 +948,13 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@openstax/highlighter@^1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@openstax/highlighter/-/highlighter-1.1.9.tgz#03cd0379ae84e30df72ce4a8b193e4c16ef43d59"
+  integrity sha512-ZqACYRivEsS5aXb56awWUW5cCrWEBA6swAMvVjD0GgniX/i+zJMRRt7sGScyU6qi9niXxYpYG1JMrIa+NVCVNg==
+  dependencies:
+    serialize-selection "^1.1.1"
+
 "@openstax/types@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@openstax/types/-/types-1.0.2.tgz#8421a412f9ea279c5bebf43f2bb8814f0bfd13c9"
@@ -9678,6 +9685,11 @@ serialize-javascript@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
   integrity sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==
+
+serialize-selection@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/serialize-selection/-/serialize-selection-1.1.1.tgz#d77d17ca999220d40019e23f4383dca4ff6ace35"
+  integrity sha1-130XypmSINQAGeI/Q4PcpP9qzjU=
 
 serve-index@^1.7.2:
   version "1.9.1"


### PR DESCRIPTION
findings:
- types for NodeFilter need to be updated to differentiate between the variable and the interface
- using openstax/highlighter as typescript module is broken, need to update that repo to include type definitions 
- searching for a single letter like "a" results in all the math being highlighted, probably need skip trying to highlight any text node that is inside math
- there is no real identifying information in the elasticsearch results, so this is doing a totally separate search of the current page.
  - this example parses the user input, if elasticsearch is doing some fancy logic, we might want to parse out the matched terms from the search result. (if elasticsearch is stemming words or something)
  - some effort will need to be made to line up the matching logic, for instance elasticsearch by default only matches on whole words, but my implementation would match a subword, leading to many more matches on the page.