### PR TITLE
Fixed table of contents button interactions

### DIFF
--- a/pytest-selenium/pages/base.py
+++ b/pytest-selenium/pages/base.py
@@ -22,7 +22,7 @@ class Page(pypom.Page):
 
     @property
     def is_desktop(self):
-        return self.window_width > 1025
+        return self.window_width > 1024
 
     def wait_for_region_to_display(self, region):
         self.wait.until(lambda _: region.is_displayed)

--- a/pytest-selenium/pages/base.py
+++ b/pytest-selenium/pages/base.py
@@ -8,6 +8,22 @@ class Page(pypom.Page):
     def __init__(self, driver, base_url=None, timeout=30, **url_kwargs):
         super().__init__(driver, base_url, timeout, **url_kwargs)
 
+    @property
+    def window_width(self):
+        return self.driver.get_window_size()["width"]
+
+    @property
+    def window_height(self):
+        return self.driver.get_window_size()["height"]
+
+    @property
+    def is_mobile(self):
+        return self.window_width <= 1024
+
+    @property
+    def is_desktop(self):
+        return self.window_width > 1025
+
     def wait_for_region_to_display(self, region):
         self.wait.until(lambda _: region.is_displayed)
         return self

--- a/pytest-selenium/pages/content.py
+++ b/pytest-selenium/pages/content.py
@@ -4,46 +4,73 @@ from selenium.webdriver.support import expected_conditions as expected
 from pages.base import Page
 from regions.base import Region
 
-# TODO: Ensure only 1 <nav> element exists on the Page
-NAV_SELECTOR = "#root > div > div > div > div > nav"
-
 
 class Content(Page):
     URL_TEMPLATE = "/books/{book_slug}/pages/{page_slug}"
 
     _body_locator = (By.TAG_NAME, "body")
     _main_content_locator = (By.CSS_SELECTOR, "h1")
-    _table_of_contents_button_locator = (
-        By.CSS_SELECTOR,
-        "[aria-label='Click to close the Table of Contents'], [aria-label='Click to open the Table of Contents']",
-    )
-    _table_of_contents_nav_locator = (By.CSS_SELECTOR, NAV_SELECTOR)
+    _sidebar_locator = (By.CSS_SELECTOR, "[aria-label='Table of Contents")
 
     @property
     def loaded(self):
         return self.find_element(*self._body_locator).get_attribute("data-rex-loaded")
 
     @property
-    def table_of_contents_nav(self):
-        return self.find_element(*self._table_of_contents_nav_locator)
+    def navbar(self):
+        return self.NavBar(self)
 
     @property
-    def table_of_contents_toggle_button(self):
-        return self.find_element(*self._table_of_contents_button_locator)
+    def toolbar(self):
+        return self.ToolBar(self)
 
-    def click_table_of_contents_button(self):
-        if self.table_of_contents.is_displayed:
-            self.offscreen_click(self.table_of_contents_toggle_button)
-            return self.wait.until(
-                expected.invisibility_of_element_located(self.table_of_contents_nav)
+    @property
+    def sidebar(self):
+        return self.SideBar(self)
+
+    class NavBar(Region):
+        _root_locator = (By.CSS_SELECTOR, "div[class^='NavBar__TopBar']")
+        _openstax_logo_link_locator = (By.CSS_SELECTOR, "div > a")
+
+        @property
+        def openstax_logo_link(self):
+            return self.find_element(*self._openstax_logo_link_locator).get_attribute("href")
+
+    class ToolBar(Region):
+        _root_locator = (By.CSS_SELECTOR, "div[class^='Toolbar__TopBar']")
+        _toc_toggle_button_locator = (
+            By.CSS_SELECTOR,
+            "[aria-label='Click to open the Table of Contents']",
+        )
+
+        @property
+        def toc_toggle_button(self):
+            return self.find_element(*self._toc_toggle_button_locator)
+
+        def click_toc_toggle_button(self):
+            self.offscreen_click(self.toc_toggle_button)
+            return self.page.sidebar.wait_for_region_to_display()
+
+    class SideBar(Region):
+        _root_locator = (By.CSS_SELECTOR, "[aria-label='Table of Contents")
+
+        @property
+        def header(self):
+            return self.Header(self.page)
+
+        class Header(Region):
+            _root_locator = (By.CSS_SELECTOR, "div[class^='Sidebar__ToCHeader']")
+            _toc_toggle_button_locator = (
+                By.CSS_SELECTOR,
+                "[aria-label='Click to close the Table of Contents']",
             )
-        else:
-            self.table_of_contents_toggle_button.click()
-        return self.table_of_contents.wait_for_region_to_display()
 
-    @property
-    def table_of_contents(self):
-        return self.TableOfContents(self)
+            @property
+            def toc_toggle_button(self):
+                return self.find_element(*self._toc_toggle_button_locator)
 
-    class TableOfContents(Region):
-        _root_locator = (By.CSS_SELECTOR, NAV_SELECTOR)
+            def click_toc_toggle_button(self):
+                self.offscreen_click(self.toc_toggle_button)
+                return self.wait.until(
+                    expected.invisibility_of_element_located(self.toc_toggle_button)
+                )

--- a/pytest-selenium/pages/content.py
+++ b/pytest-selenium/pages/content.py
@@ -28,7 +28,7 @@ class Content(Page):
         return self.SideBar(self)
 
     class NavBar(Region):
-        _root_locator = (By.CSS_SELECTOR, "div[class^='NavBar__TopBar']")
+        _root_locator = (By.CSS_SELECTOR, '[data-testid="navbar"]')
         _openstax_logo_link_locator = (By.CSS_SELECTOR, "div > a")
 
         @property
@@ -36,7 +36,7 @@ class Content(Page):
             return self.find_element(*self._openstax_logo_link_locator).get_attribute("href")
 
     class ToolBar(Region):
-        _root_locator = (By.CSS_SELECTOR, "div[class^='Toolbar__TopBar']")
+        _root_locator = (By.CSS_SELECTOR, '[data-testid="toolbar"]')
         _toc_toggle_button_locator = (
             By.CSS_SELECTOR,
             "[aria-label='Click to open the Table of Contents']",
@@ -58,7 +58,7 @@ class Content(Page):
             return self.Header(self.page)
 
         class Header(Region):
-            _root_locator = (By.CSS_SELECTOR, "div[class^='Sidebar__ToCHeader']")
+            _root_locator = (By.CSS_SELECTOR, '[data-testid="tocheader"]')
             _toc_toggle_button_locator = (
                 By.CSS_SELECTOR,
                 "[aria-label='Click to close the Table of Contents']",

--- a/pytest-selenium/pages/content.py
+++ b/pytest-selenium/pages/content.py
@@ -10,7 +10,6 @@ class Content(Page):
 
     _body_locator = (By.TAG_NAME, "body")
     _main_content_locator = (By.CSS_SELECTOR, "h1")
-    _sidebar_locator = (By.CSS_SELECTOR, "[aria-label='Table of Contents")
 
     @property
     def loaded(self):

--- a/pytest-selenium/pages/content.py
+++ b/pytest-selenium/pages/content.py
@@ -51,7 +51,7 @@ class Content(Page):
             return self.page.sidebar.wait_for_region_to_display()
 
     class SideBar(Region):
-        _root_locator = (By.CSS_SELECTOR, "[aria-label='Table of Contents")
+        _root_locator = (By.CSS_SELECTOR, "[aria-label='Table of Contents']")
 
         @property
         def header(self):

--- a/pytest-selenium/tests/test_toc.py
+++ b/pytest-selenium/tests/test_toc.py
@@ -12,8 +12,8 @@ def test_toc_toggle_button_opens_and_closes(selenium, base_url, book_slug, page_
     and closed for mobile and tablet. We need to do different actions based
     on the resolution. When the resolution is desktop we
     click the toc button on the sidebar to close and the toc button on the
-    toolbar to open. It's the other way around for mobile and tablet
-    resolutions and the sidebar is closed by default.
+    toolbar to open. It's the other way around for mobile and tablet because
+    the sidebar is closed by default.
 
     """
     # GIVEN: The selenium driver, base_url, book_slug, and page_slug

--- a/pytest-selenium/tests/test_toc.py
+++ b/pytest-selenium/tests/test_toc.py
@@ -34,7 +34,6 @@ def test_toc_toggle_button_opens_and_closes(selenium, base_url, book_slug, page_
         # THEN: The sidebar area has been closed
         # AND: The toc button on the toolbar is clicked
         # AND: The side bar is opened again
-
         sidebar.header.click_toc_toggle_button()
 
         assert not sidebar.header.is_displayed

--- a/pytest-selenium/tests/test_toc.py
+++ b/pytest-selenium/tests/test_toc.py
@@ -8,10 +8,12 @@ from . import markers
 def test_toc_toggle_button_opens_and_closes(selenium, base_url, book_slug, page_slug):
     """ Test that table of contents toggle button opens and closes the sidebar
 
-    The table of contents sidebar is open by default for Desktop resolutions
+    The table of contents sidebar is open by default for desktop resolutions
     and closed for mobile and tablet. We need to do different actions based
-    on the resolution. This test depending on the resolution should click the
-    appropriate button depending on the state of sidebar.
+    on the resolution. When the resolution is desktop we
+    click the toc button on the sidebar to close and the toc button on the
+    toolbar to open. It's the other way around for mobile and tablet
+    resolutions.
 
     """
     # GIVEN: The selenium driver, base_url, book_slug, and page_slug
@@ -48,7 +50,7 @@ def test_toc_toggle_button_opens_and_closes(selenium, base_url, book_slug, page_
         assert not sidebar.header.is_displayed
 
         # WHEN: The toc button on the toolbar is clicked
-        # THEN: The sidbar area is opened
+        # THEN: The sidebar area is opened
         # AND: The toc button on the sidebar is clicked
         # AND: the sidebar area is closed
         toolbar.click_toc_toggle_button()

--- a/pytest-selenium/tests/test_toc.py
+++ b/pytest-selenium/tests/test_toc.py
@@ -1,23 +1,60 @@
 from pages.content import Content
 from . import markers
 
-@markers.test_case('C250849')
+
+@markers.test_case("C250849")
 @markers.parametrize("book_slug,page_slug", [("college-physics", "preface")])
 @markers.nondestructive
 def test_toc_toggle_button_opens_and_closes(selenium, base_url, book_slug, page_slug):
+    """ Test that table of contents toggle button opens and closes the sidebar
+
+    The table of contents sidebar is open by default for Desktop resolutions
+    and closed for mobile and tablet. We need to do different actions based
+    on the resolution. This test depending on the resolution should click the
+    appropriate button depending on the state of sidebar.
+
+    """
     # GIVEN: The selenium driver, base_url, book_slug, and page_slug
 
     # WHEN: The book and page URL is loaded
-    #   AND: The table of contents toggle button is clicked
     content = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
 
-    toc = content.table_of_contents
-    content.click_table_of_contents_button()
+    toolbar = content.toolbar
+    sidebar = content.sidebar
 
-    # THEN:  The table of contents area has been closed
-    # AND:   The table of contents toggle button is clicked again
-    # AND:   The table of contents area is opened
-    assert not toc.is_displayed
+    # AND: Window width is 1024 or greater (Desktop)
+    if selenium.get_window_size()["width"] > 1024:
 
-    content.click_table_of_contents_button()
-    assert toc.is_displayed
+        # Sidebar is open by default
+        assert sidebar.header.is_displayed
+
+        # WHEN: The toc button on the sidebar is clicked
+        # THEN: The sidebar area has been closed
+        # AND: The toc button on the toolbar is clicked
+        # AND: The side bar is opened again
+
+        sidebar.header.click_toc_toggle_button()
+
+        assert not sidebar.header.is_displayed
+
+        toolbar.click_toc_toggle_button()
+
+        assert sidebar.header.is_displayed
+
+    # AND: Window Size is less than 1025 tablet or mobile
+    if selenium.get_window_size()["width"] <= 1024:
+
+        # Sidebar is closed by default
+        assert not sidebar.header.is_displayed
+
+        # WHEN: The toc button on the toolbar is clicked
+        # THEN: The sidbar area is opened
+        # AND: The toc button on the sidebar is clicked
+        # AND: the sidebar area is closed
+        toolbar.click_toc_toggle_button()
+
+        assert sidebar.header.is_displayed
+
+        sidebar.header.click_toc_toggle_button()
+
+        assert not sidebar.header.is_displayed

--- a/pytest-selenium/tests/test_toc.py
+++ b/pytest-selenium/tests/test_toc.py
@@ -25,7 +25,7 @@ def test_toc_toggle_button_opens_and_closes(selenium, base_url, book_slug, page_
     sidebar = content.sidebar
 
     # AND: Window width is 1024 or greater (Desktop)
-    if selenium.get_window_size()["width"] > 1024:
+    if content.is_desktop:
 
         # Sidebar is open by default
         assert sidebar.header.is_displayed
@@ -43,8 +43,8 @@ def test_toc_toggle_button_opens_and_closes(selenium, base_url, book_slug, page_
 
         assert sidebar.header.is_displayed
 
-    # AND: Window Size is less than 1025 tablet or mobile
-    if selenium.get_window_size()["width"] <= 1024:
+    # AND: Window Size is Mobile
+    if content.is_mobile:
 
         # Sidebar is closed by default
         assert not sidebar.header.is_displayed

--- a/pytest-selenium/tests/test_toc.py
+++ b/pytest-selenium/tests/test_toc.py
@@ -13,7 +13,7 @@ def test_toc_toggle_button_opens_and_closes(selenium, base_url, book_slug, page_
     on the resolution. When the resolution is desktop we
     click the toc button on the sidebar to close and the toc button on the
     toolbar to open. It's the other way around for mobile and tablet
-    resolutions.
+    resolutions and the sidebar is closed by default.
 
     """
     # GIVEN: The selenium driver, base_url, book_slug, and page_slug

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -83,7 +83,7 @@ const BarWrapper = styled.div`
 // tslint:disable-next-line:variable-name
 const NavigationBar: SFC = ({}) =>
   <BarWrapper>
-    <TopBar data-testid="navbar">
+    <TopBar data-testid='navbar'>
       <FormattedMessage id='i18n:nav:logo:alt'>
         {(msg: Element | string) => <a href='/'>
           <HeaderImage role='img' src={openstaxLogo} alt={assertString(msg, 'alt text must be a string')} />

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -83,7 +83,7 @@ const BarWrapper = styled.div`
 // tslint:disable-next-line:variable-name
 const NavigationBar: SFC = ({}) =>
   <BarWrapper>
-    <TopBar>
+    <TopBar data-testid="navbar">
       <FormattedMessage id='i18n:nav:logo:alt'>
         {(msg: Element | string) => <a href='/'>
           <HeaderImage role='img' src={openstaxLogo} alt={assertString(msg, 'alt text must be a string')} />

--- a/src/app/content/components/Sidebar.tsx
+++ b/src/app/content/components/Sidebar.tsx
@@ -251,7 +251,7 @@ export class Sidebar extends Component<SidebarProps> {
     </ol>
   </nav>
 
-  private renderTocHeader = () => <ToCHeader data-testid="tocheader">
+  private renderTocHeader = () => <ToCHeader data-testid='tocheader'>
     <SidebarHeaderButton><TimesIcon /></SidebarHeaderButton>
   </ToCHeader>
 

--- a/src/app/content/components/Sidebar.tsx
+++ b/src/app/content/components/Sidebar.tsx
@@ -251,7 +251,7 @@ export class Sidebar extends Component<SidebarProps> {
     </ol>
   </nav>
 
-  private renderTocHeader = () => <ToCHeader>
+  private renderTocHeader = () => <ToCHeader data-testid="tocheader">
     <SidebarHeaderButton><TimesIcon /></SidebarHeaderButton>
   </ToCHeader>
 

--- a/src/app/content/components/Toolbar.tsx
+++ b/src/app/content/components/Toolbar.tsx
@@ -143,7 +143,7 @@ const BarWrapper = styled.div`
 
 // tslint:disable-next-line:variable-name
 const Toolbar: SFC = () => <BarWrapper>
-  <TopBar data-testid="toolbar">
+  <TopBar data-testid='toolbar'>
     <SidebarControl />
     <SearchPrintWrapper>
       <FormattedMessage id='i18n:toolbar:search:placeholder'>

--- a/src/app/content/components/Toolbar.tsx
+++ b/src/app/content/components/Toolbar.tsx
@@ -143,7 +143,7 @@ const BarWrapper = styled.div`
 
 // tslint:disable-next-line:variable-name
 const Toolbar: SFC = () => <BarWrapper>
-  <TopBar>
+  <TopBar data-testid="toolbar">
     <SidebarControl />
     <SearchPrintWrapper>
       <FormattedMessage id='i18n:toolbar:search:placeholder'>

--- a/src/app/content/components/__snapshots__/Content.spec.tsx.snap
+++ b/src/app/content/components/__snapshots__/Content.spec.tsx.snap
@@ -142,6 +142,7 @@ Array [
   >
     <div
       className="c1"
+      data-testid="navbar"
     >
       <a
         href="/"
@@ -1281,6 +1282,7 @@ Array [
     >
       <div
         className="c11"
+        data-testid="toolbar"
       >
         <button
           aria-label="Click to open the Table of Contents"
@@ -1388,6 +1390,7 @@ Array [
         >
           <div
             className="c29 c30"
+            data-testid="tocheader"
           >
             <button
               aria-label="Click to close the Table of Contents"
@@ -1964,6 +1967,7 @@ Array [
   >
     <div
       className="c1"
+      data-testid="navbar"
     >
       <a
         href="/"
@@ -1983,7 +1987,13 @@ Array [
       </a>
     </div>
   </div>,
-  .c6 {
+  .c32 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+}
+
+.c6 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
@@ -2010,17 +2020,17 @@ Array [
   padding: 0 3.2rem;
 }
 
-.c34 {
+.c39 {
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c36 {
+.c41 {
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.c32 {
+.c37 {
   font-family: Neue Helvetica W01;
   color: #424242;
   font-size: 1.6rem;
@@ -2031,7 +2041,7 @@ Array [
   list-style: none;
 }
 
-.c32 a {
+.c37 a {
   color: #027EB5;
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -2039,16 +2049,16 @@ Array [
   border-bottom: #027EB5 solid 0.02em;
 }
 
-.c32 a:hover {
+.c37 a:hover {
   color: #0064A0;
 }
 
-.c32::-webkit-details-marker {
+.c37::-webkit-details-marker {
   display: none;
 }
 
-.c32,
-.c32 span {
+.c37,
+.c37 span {
   font-family: Neue Helvetica W01;
   color: #424242;
   font-size: 1.6rem;
@@ -2059,8 +2069,8 @@ Array [
   text-decoration: none;
 }
 
-.c32 a,
-.c32 span a {
+.c37 a,
+.c37 span a {
   color: #027EB5;
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -2068,19 +2078,19 @@ Array [
   border-bottom: #027EB5 solid 0.02em;
 }
 
-.c32 a:hover,
-.c32 span a:hover {
+.c37 a:hover,
+.c37 span a:hover {
   color: #0064A0;
 }
 
-.c32:hover,
-.c32 span:hover {
+.c37:hover,
+.c37 span:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0064A0;
 }
 
-.c30 {
+.c35 {
   font-family: Neue Helvetica W01;
   color: #424242;
   font-size: 1.6rem;
@@ -2092,7 +2102,7 @@ Array [
   padding-top: 1.8rem;
 }
 
-.c30 a {
+.c35 a {
   color: #027EB5;
   cursor: pointer;
   -webkit-text-decoration: none;
@@ -2100,25 +2110,36 @@ Array [
   border-bottom: #027EB5 solid 0.02em;
 }
 
-.c30 a:hover {
+.c35 a:hover {
   color: #0064A0;
 }
 
-.c30 > .c31 {
+.c35 > .c36 {
   margin-bottom: 1.8rem;
 }
 
-.c30[open] .c33 {
+.c35[open] .c38 {
   display: none;
 }
 
-.c30:not([open]) .c35 {
+.c35:not([open]) .c40 {
   display: none;
 }
 
-.c30 li {
+.c35 li {
   margin-bottom: 1rem;
   overflow: visible;
+}
+
+.c31 {
+  height: 2.5rem;
+  width: 2.5rem;
+}
+
+.c34 {
+  height: 2.5rem;
+  width: 2.5rem;
+  margin-top: 0.1rem;
 }
 
 .c29 {
@@ -2488,24 +2509,24 @@ Array [
 }
 
 @media screen and (max-width:64em) {
-  .c30 {
+  .c35 {
     padding: 0 1.6rem;
   }
 }
 
 @media screen and (max-width:64em) {
-  .c30 {
+  .c35 {
     min-height: 4rem;
     padding-top: 0.8rem;
   }
 
-  .c30 > .c31 {
+  .c35 > .c36 {
     margin-bottom: 0.8rem;
   }
 }
 
 @media print {
-  .c30 {
+  .c35 {
     display: none;
   }
 }
@@ -2528,6 +2549,18 @@ Array [
     margin-top: -12rem;
     height: 12rem;
     visibility: hidden;
+  }
+}
+
+@media screen and (max-width:64em) {
+  .c30 {
+    margin-left: -0.8rem;
+  }
+}
+
+@media screen and (max-width:64em) {
+  .c33 {
+    margin-right: -0.8rem;
   }
 }
 
@@ -2713,6 +2746,7 @@ Array [
     >
       <div
         className="c2"
+        data-testid="toolbar"
       >
         <button
           aria-label="Click to open the Table of Contents"
@@ -2820,6 +2854,7 @@ Array [
         >
           <div
             className="c20 c21"
+            data-testid="tocheader"
           >
             <button
               aria-label="Click to close the Table of Contents"
@@ -2914,21 +2949,53 @@ Array [
                 >
                   <span
                     aria-hidden={true}
-                  />
+                    aria-label="Previous Page"
+                    className="c30"
+                    side="left"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="c31 c32"
+                      fill="currentColor"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M13.293 6.293L7.586 12l5.707 5.707 1.414-1.414L10.414 12l4.293-4.293z"
+                      />
+                    </svg>
+                    Previous
+                  </span>
                   <span
                     aria-hidden={true}
-                  />
+                    aria-label="Next Page"
+                    className="c33"
+                    side="right"
+                  >
+                    Next
+                    <svg
+                      aria-hidden="true"
+                      className="c34 c32"
+                      fill="currentColor"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M10.707 17.707L16.414 12l-5.707-5.707-1.414 1.414L13.586 12l-4.293 4.293z"
+                      />
+                    </svg>
+                  </span>
                 </div>
               </div>
               <details
-                className="c30"
+                className="c35"
               >
                 <summary
-                  className="c31 c32"
+                  className="c36 c37"
                 >
                   <svg
                     aria-hidden="true"
-                    className="c33 c34 c6"
+                    className="c38 c39 c6"
                     fill="currentColor"
                     focusable="false"
                     viewBox="0 0 192 512"
@@ -2940,7 +3007,7 @@ Array [
                   </svg>
                   <svg
                     aria-hidden="true"
-                    className="c35 c36 c6"
+                    className="c40 c41 c6"
                     fill="currentColor"
                     focusable="false"
                     viewBox="0 0 320 512"

--- a/src/app/content/components/__snapshots__/PrevNextBar.spec.tsx.snap
+++ b/src/app/content/components/__snapshots__/PrevNextBar.spec.tsx.snap
@@ -10,6 +10,11 @@ exports[`PrevNextBar renders \`null\` when passed a page that isn't in the book 
 .c2 {
   height: 2.5rem;
   width: 2.5rem;
+}
+
+.c5 {
+  height: 2.5rem;
+  width: 2.5rem;
   margin-top: 0.1rem;
 }
 
@@ -60,6 +65,12 @@ exports[`PrevNextBar renders \`null\` when passed a page that isn't in the book 
 
 @media screen and (max-width:64em) {
   .c1 {
+    margin-left: -0.8rem;
+  }
+}
+
+@media screen and (max-width:64em) {
+  .c4 {
     margin-right: -0.8rem;
   }
 }
@@ -82,10 +93,26 @@ exports[`PrevNextBar renders \`null\` when passed a page that isn't in the book 
 >
   <span
     aria-hidden={true}
-  />
+    aria-label="Previous Page"
+    className="c1"
+    side="left"
+  >
+    <svg
+      aria-hidden="true"
+      className="c2 c3"
+      fill="currentColor"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M13.293 6.293L7.586 12l5.707 5.707 1.414-1.414L10.414 12l4.293-4.293z"
+      />
+    </svg>
+    Previous
+  </span>
   <a
     aria-label="Next Page"
-    className="c1"
+    className="c4"
     href="books/book-slug-1/pages/test-page-1"
     onClick={[Function]}
     side="right"
@@ -93,7 +120,7 @@ exports[`PrevNextBar renders \`null\` when passed a page that isn't in the book 
     Next
     <svg
       aria-hidden="true"
-      className="c2 c3"
+      className="c5 c3"
       fill="currentColor"
       focusable="false"
       viewBox="0 0 24 24"
@@ -107,6 +134,23 @@ exports[`PrevNextBar renders \`null\` when passed a page that isn't in the book 
 `;
 
 exports[`PrevNextBar renders \`null\` with no page or book 1`] = `
+.c3 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+}
+
+.c2 {
+  height: 2.5rem;
+  width: 2.5rem;
+}
+
+.c5 {
+  height: 2.5rem;
+  width: 2.5rem;
+  margin-top: 0.1rem;
+}
+
 .c0 {
   font-family: Neue Helvetica W01;
   color: #424242;
@@ -152,6 +196,18 @@ exports[`PrevNextBar renders \`null\` with no page or book 1`] = `
   display: flex;
 }
 
+@media screen and (max-width:64em) {
+  .c1 {
+    margin-left: -0.8rem;
+  }
+}
+
+@media screen and (max-width:64em) {
+  .c4 {
+    margin-right: -0.8rem;
+  }
+}
+
 @media print {
   .c0 {
     display: none;
@@ -170,10 +226,42 @@ exports[`PrevNextBar renders \`null\` with no page or book 1`] = `
 >
   <span
     aria-hidden={true}
-  />
+    aria-label="Previous Page"
+    className="c1"
+    side="left"
+  >
+    <svg
+      aria-hidden="true"
+      className="c2 c3"
+      fill="currentColor"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M13.293 6.293L7.586 12l5.707 5.707 1.414-1.414L10.414 12l4.293-4.293z"
+      />
+    </svg>
+    Previous
+  </span>
   <span
     aria-hidden={true}
-  />
+    aria-label="Next Page"
+    className="c4"
+    side="right"
+  >
+    Next
+    <svg
+      aria-hidden="true"
+      className="c5 c3"
+      fill="currentColor"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M10.707 17.707L16.414 12l-5.707-5.707-1.414 1.414L13.586 12l-4.293 4.293z"
+      />
+    </svg>
+  </span>
 </div>
 `;
 
@@ -321,112 +409,12 @@ exports[`PrevNextBar renders only \`next\` element correctly 1`] = `
 .c2 {
   height: 2.5rem;
   width: 2.5rem;
-  margin-top: 0.1rem;
 }
 
-.c0 {
-  font-family: Neue Helvetica W01;
-  color: #424242;
-  font-size: 1.6rem;
-  line-height: 2.5rem;
-  overflow: visible;
-  max-width: 57rem;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  height: 4rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin: 5rem auto 4rem auto;
-  border-top: solid 0.1rem #e5e5e5;
-  border-bottom: solid 0.1rem #e5e5e5;
-}
-
-.c0 a {
-  color: #027EB5;
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom: #027EB5 solid 0.02em;
-}
-
-.c0 a:hover {
-  color: #0064A0;
-}
-
-.c0 a {
-  border: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-@media screen and (max-width:64em) {
-  .c1 {
-    margin-right: -0.8rem;
-  }
-}
-
-@media print {
-  .c0 {
-    display: none;
-  }
-}
-
-@media screen and (max-width:64em) {
-  .c0 {
-    margin: 3.5rem auto 3.7rem auto;
-    border: 0;
-  }
-}
-
-<div
-  className="c0"
->
-  <span
-    aria-hidden={true}
-  />
-  <a
-    aria-label="Next Page"
-    className="c1"
-    href="books/book-slug-1/pages/1-test-page-2"
-    onClick={[Function]}
-    side="right"
-  >
-    Next
-    <svg
-      aria-hidden="true"
-      className="c2 c3"
-      fill="currentColor"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M10.707 17.707L16.414 12l-5.707-5.707-1.414 1.414L13.586 12l-4.293 4.293z"
-      />
-    </svg>
-  </a>
-</div>
-`;
-
-exports[`PrevNextBar renders only \`prev\` element correctly 1`] = `
-.c3 {
-  display: inline-block;
-  vertical-align: middle;
-  overflow: hidden;
-}
-
-.c2 {
+.c5 {
   height: 2.5rem;
   width: 2.5rem;
+  margin-top: 0.1rem;
 }
 
 .c0 {
@@ -480,6 +468,145 @@ exports[`PrevNextBar renders only \`prev\` element correctly 1`] = `
   }
 }
 
+@media screen and (max-width:64em) {
+  .c4 {
+    margin-right: -0.8rem;
+  }
+}
+
+@media print {
+  .c0 {
+    display: none;
+  }
+}
+
+@media screen and (max-width:64em) {
+  .c0 {
+    margin: 3.5rem auto 3.7rem auto;
+    border: 0;
+  }
+}
+
+<div
+  className="c0"
+>
+  <span
+    aria-hidden={true}
+    aria-label="Previous Page"
+    className="c1"
+    side="left"
+  >
+    <svg
+      aria-hidden="true"
+      className="c2 c3"
+      fill="currentColor"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M13.293 6.293L7.586 12l5.707 5.707 1.414-1.414L10.414 12l4.293-4.293z"
+      />
+    </svg>
+    Previous
+  </span>
+  <a
+    aria-label="Next Page"
+    className="c4"
+    href="books/book-slug-1/pages/1-test-page-2"
+    onClick={[Function]}
+    side="right"
+  >
+    Next
+    <svg
+      aria-hidden="true"
+      className="c5 c3"
+      fill="currentColor"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M10.707 17.707L16.414 12l-5.707-5.707-1.414 1.414L13.586 12l-4.293 4.293z"
+      />
+    </svg>
+  </a>
+</div>
+`;
+
+exports[`PrevNextBar renders only \`prev\` element correctly 1`] = `
+.c3 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+}
+
+.c2 {
+  height: 2.5rem;
+  width: 2.5rem;
+}
+
+.c5 {
+  height: 2.5rem;
+  width: 2.5rem;
+  margin-top: 0.1rem;
+}
+
+.c0 {
+  font-family: Neue Helvetica W01;
+  color: #424242;
+  font-size: 1.6rem;
+  line-height: 2.5rem;
+  overflow: visible;
+  max-width: 57rem;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  height: 4rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin: 5rem auto 4rem auto;
+  border-top: solid 0.1rem #e5e5e5;
+  border-bottom: solid 0.1rem #e5e5e5;
+}
+
+.c0 a {
+  color: #027EB5;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: #027EB5 solid 0.02em;
+}
+
+.c0 a:hover {
+  color: #0064A0;
+}
+
+.c0 a {
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+@media screen and (max-width:64em) {
+  .c1 {
+    margin-left: -0.8rem;
+  }
+}
+
+@media screen and (max-width:64em) {
+  .c4 {
+    margin-right: -0.8rem;
+  }
+}
+
 @media print {
   .c0 {
     display: none;
@@ -518,6 +645,22 @@ exports[`PrevNextBar renders only \`prev\` element correctly 1`] = `
   </a>
   <span
     aria-hidden={true}
-  />
+    aria-label="Next Page"
+    className="c4"
+    side="right"
+  >
+    Next
+    <svg
+      aria-hidden="true"
+      className="c5 c3"
+      fill="currentColor"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M10.707 17.707L16.414 12l-5.707-5.707-1.414 1.414L13.586 12l-4.293 4.293z"
+      />
+    </svg>
+  </span>
 </div>
 `;

--- a/src/app/developer/components/__snapshots__/Home.spec.tsx.snap
+++ b/src/app/developer/components/__snapshots__/Home.spec.tsx.snap
@@ -142,6 +142,7 @@ Array [
   >
     <div
       className="c1"
+      data-testid="navbar"
     >
       <a
         href="/"


### PR DESCRIPTION
* Refactored the content page object to include new regions that
describe the page. The regions are Navbar, Sidebar, Sidebar header, and
Toolbar.
* Refactored the test to account for the differences in resolutions and
the order of toggling the Sidebar. When the resolution is desktop we
click the toc button on the sidebar to close and the toc button on the
toolbar to open. It's the other way around for mobile and tablet
resolutions.