### PR TITLE
add search hook and persist search state in sessionStorage

### DIFF
--- a/src/app/content/hooks/index.ts
+++ b/src/app/content/hooks/index.ts
@@ -2,10 +2,13 @@ import { routeHook } from '../../navigation/utils';
 import { actionHook } from '../../utils';
 import * as actions from '../actions';
 import * as routes from '../routes';
+import searchHooks from '../search/hooks';
 import locationChangeBody from './locationChange';
 import receiveContentBody from './receiveContent';
 
-export { searchHook } from '../search/hooks';
-export const locationChange = routeHook(routes.content, locationChangeBody);
-export const receivePage = actionHook(actions.receivePage, receiveContentBody);
-export const receiveBook = actionHook(actions.receiveBook, receiveContentBody);
+export default [
+  ...searchHooks,
+  routeHook(routes.content, locationChangeBody),
+  actionHook(actions.receivePage, receiveContentBody),
+  actionHook(actions.receiveBook, receiveContentBody),
+];

--- a/src/app/content/hooks/index.ts
+++ b/src/app/content/hooks/index.ts
@@ -5,6 +5,7 @@ import * as routes from '../routes';
 import locationChangeBody from './locationChange';
 import receiveContentBody from './receiveContent';
 
+export { searchHook } from '../search/hooks';
 export const locationChange = routeHook(routes.content, locationChangeBody);
 export const receivePage = actionHook(actions.receivePage, receiveContentBody);
 export const receiveBook = actionHook(actions.receiveBook, receiveContentBody);

--- a/src/app/content/index.ts
+++ b/src/app/content/index.ts
@@ -1,5 +1,5 @@
 import * as actions from './actions';
-import * as hooks from './hooks';
+import hooks from './hooks';
 import reducer from './reducer';
 import * as routes from './routes';
 import * as types from './types';

--- a/src/app/content/search/hooks.spec.ts
+++ b/src/app/content/search/hooks.spec.ts
@@ -1,0 +1,51 @@
+import createTestServices from '../../../test/createTestServices';
+import createTestStore from '../../../test/createTestStore';
+import { book } from '../../../test/mocks/archiveLoader';
+import { mockCmsBook } from '../../../test/mocks/osWebLoader';
+import { AppServices, MiddlewareAPI, Store } from '../../types';
+import { receiveBook } from '../actions';
+import { formatBookData } from '../utils';
+import { receiveSearchResults, requestSearch } from './actions';
+import { searchHookBody } from './hooks';
+
+describe('searchHook', () => {
+  let store: Store;
+  let dispatch: jest.SpyInstance;
+  let helpers: MiddlewareAPI & AppServices;
+  let hook: ReturnType<typeof searchHookBody>;
+
+  beforeEach(() => {
+    store = createTestStore();
+    helpers = {
+      ...createTestServices(),
+      dispatch: store.dispatch,
+      getState: store.getState,
+    };
+    hook = searchHookBody(helpers);
+    dispatch = jest.spyOn(helpers, 'dispatch');
+  });
+
+  it('searches', async() => {
+    store.dispatch(receiveBook(formatBookData(book, mockCmsBook)));
+    await hook(requestSearch('asdf'));
+    expect(helpers.searchClient.search).toHaveBeenCalled();
+  });
+
+  it('noops when there isn\'t a book', async() => {
+    await hook(requestSearch('asdf'));
+    expect(helpers.searchClient.search).not.toHaveBeenCalled();
+  });
+
+  it('noops when query is empty', async() => {
+    store.dispatch(receiveBook(formatBookData(book, mockCmsBook)));
+    await hook(requestSearch(''));
+    expect(helpers.searchClient.search).not.toHaveBeenCalled();
+  });
+
+  it('dispatches receiveSearchResults', async() => {
+    store.dispatch(receiveBook(formatBookData(book, mockCmsBook)));
+    (helpers.searchClient.search as any).mockReturnValue('searchresults');
+    await hook(requestSearch('asdf'));
+    expect(dispatch).toHaveBeenCalledWith(receiveSearchResults('searchresults' as any));
+  });
+});

--- a/src/app/content/search/hooks.ts
+++ b/src/app/content/search/hooks.ts
@@ -1,0 +1,24 @@
+import { ActionHookBody } from '../../types';
+import { actionHook } from '../../utils';
+import * as contentSelectors from '../selectors';
+import { receiveSearchResults, requestSearch } from './actions';
+
+export const searchHookBody: ActionHookBody<typeof requestSearch> = (services) => async({payload}) => {
+  const state = services.getState();
+  const book = contentSelectors.book(state);
+
+  if (!book || !payload) {
+    return;
+  }
+
+  const results = await services.searchClient.search({
+    books: [`${book.id}@${book.version}`],
+    indexStrategy: 'i1',
+    q: payload,
+    searchStrategy: 's1',
+  });
+
+  services.dispatch(receiveSearchResults(results));
+};
+
+export const searchHook = actionHook(requestSearch, searchHookBody);

--- a/src/app/content/search/hooks.ts
+++ b/src/app/content/search/hooks.ts
@@ -21,4 +21,6 @@ export const searchHookBody: ActionHookBody<typeof requestSearch> = (services) =
   services.dispatch(receiveSearchResults(results));
 };
 
-export const searchHook = actionHook(requestSearch, searchHookBody);
+export default [
+  actionHook(requestSearch, searchHookBody),
+];

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,7 +1,6 @@
 import { createBrowserHistory, createMemoryHistory } from 'history';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { combineReducers } from 'redux';
 import createStore from '../helpers/createStore';
 import FontCollector from '../helpers/FontCollector';
 import PromiseCollector from '../helpers/PromiseCollector';
@@ -18,7 +17,8 @@ import { hasState } from './navigation/guards';
 import { AnyMatch } from './navigation/types';
 import { matchUrl } from './navigation/utils';
 import * as notifications from './notifications';
-import { AnyAction, AppServices, AppState, Middleware } from './types';
+import createReducer from './reducer';
+import { AppServices, AppState, Middleware } from './types';
 
 export const actions = {
   auth: auth.actions,
@@ -75,14 +75,7 @@ export default (options: AppOptions) => {
     }
   }
 
-  const reducer = combineReducers<AppState, AnyAction>({
-    auth: auth.reducer,
-    content: content.reducer,
-    errors: errors.reducer,
-    head: head.reducer,
-    navigation: navigation.createReducer(history.location),
-    notifications: notifications.reducer,
-  });
+  const reducer = createReducer(history);
 
   const services = {
     ...defaultServices(),

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -44,7 +44,7 @@ const init = [
 ];
 
 const hooks = [
-  ...Object.values(content.hooks),
+  ...content.hooks,
   ...Object.values(head.hooks),
 ];
 

--- a/src/app/reducer.ts
+++ b/src/app/reducer.ts
@@ -1,0 +1,26 @@
+import { History } from 'history';
+import { combineReducers } from 'redux';
+import auth, {initialState as authInitialState } from './auth/reducer';
+import content, {initialState as contentInitialState } from './content/reducer';
+import errors, {initialState as errorsInitialState } from './errors/reducer';
+import head, {initialState as headInitialState } from './head/reducer';
+import navigation from './navigation/reducer';
+import notifications, {initialState as notificationsInitialState } from './notifications/reducer';
+import { AnyAction, AppState } from './types';
+
+export const initialState = {
+  auth: authInitialState,
+  content: contentInitialState,
+  errors: errorsInitialState,
+  head: headInitialState,
+  notifications: notificationsInitialState,
+};
+
+export default (history: History) => combineReducers<AppState, AnyAction>({
+  auth,
+  content,
+  errors,
+  head,
+  navigation: navigation(history.location),
+  notifications,
+});

--- a/src/helpers/createStore.ts
+++ b/src/helpers/createStore.ts
@@ -1,6 +1,18 @@
-import { applyMiddleware, compose, createStore, Middleware, Reducer } from 'redux';
+import {
+  applyMiddleware,
+  compose,
+  createStore,
+  Middleware,
+  Reducer,
+  StoreEnhancerStoreCreator
+} from 'redux';
 import { AnyAction, AppState, Store } from '../app/types';
 import config from '../config';
+import persistState from './persistState';
+
+const persistPaths = [
+  'content.search',
+];
 
 interface Options {
   reducer: Reducer<AppState, AnyAction>;
@@ -17,7 +29,15 @@ export default function({middleware, reducer, initialState}: Options): Store {
     ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
     : compose;
 
-  const enhancer = composeEnhancers(applyMiddleware(...middleware));
+  const enhancers = [
+    applyMiddleware(...middleware),
+  ];
+
+  if (typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined' ) {
+    enhancers.push(persistState(persistPaths, window.sessionStorage));
+  }
+
+  const enhancer = composeEnhancers<StoreEnhancerStoreCreator<{}, {}>>(...enhancers);
 
   const store = createStore(reducer, initialState, enhancer);
 

--- a/src/helpers/persistState.ts
+++ b/src/helpers/persistState.ts
@@ -1,0 +1,26 @@
+import { Storage } from '@openstax/types/lib.dom';
+import merge from 'lodash/fp/merge';
+import pick from 'lodash/fp/pick';
+import { StoreEnhancer } from 'redux';
+import config from '../config';
+
+export default (paths: string[], storage: Storage): StoreEnhancer<{}, {}> => (next) => (reducer, preloadedState) => {
+  const key = config.RELEASE_ID;
+  const savedString = storage.getItem(key);
+  const savedState = savedString && JSON.parse(savedString);
+
+  const nextState = savedState || preloadedState
+    ? merge(preloadedState, savedState)
+    : undefined;
+
+  const store = next(reducer, nextState);
+
+  store.subscribe(() => {
+    const state = store.getState();
+    const subset = pick(paths, state);
+
+    storage.setItem(key, JSON.stringify(subset));
+  });
+
+  return store;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Loadable from 'react-loadable';
 import createApp from './app';
+import { initialState } from './app/reducer';
 import { assertDefined, assertWindow } from './app/utils';
 import config from './config';
 import './content.css';
@@ -33,7 +34,7 @@ const accountsUrl = assertDefined(config.REACT_APP_ACCOUNTS_URL, 'REACT_APP_ACCO
 const searchUrl = assertDefined(config.REACT_APP_SEARCH_URL, 'REACT_APP_SEARCH_URL must be defined');
 
 const app = createApp({
-  initialState: window.__PRELOADED_STATE__,
+  initialState: window.__PRELOADED_STATE__ || initialState,
   services: {
     archiveLoader: createArchiveLoader(config.REACT_APP_ARCHIVE_URL),
     osWebLoader: createOSWebLoader(config.REACT_APP_OS_WEB_API_URL),


### PR DESCRIPTION
adds mechanism to store sections of the state in sessionstorage so they survive page reloads.

this is the proposed solution to solving the search persisting page load problem without making history management super complicated. not totally sure some edge cases are going to fly with UX, but i think this mechanism will be useful in general in the future (for instance to store auth state and stuff)