### PR TITLE
chore: remove prettyhtml from content diff

### DIFF
--- a/script/content-diff.bash
+++ b/script/content-diff.bash
@@ -18,16 +18,6 @@ function stripToContent() {
   do
     path=$REPLY
 
-    # this bug is fixed, but the broken content still exists in some old releases
-    # and it breaks prettyhtml, remove this line when we no longer care about
-    # those older releases
-    sed -Ei '' \
-      -e '1h;2,$H;$!d;g' \
-      -e 's/a target="_blank" rel="noopener nofollow"nn/ann/' \
-      "$path"
-
-    prettyhtml --sortAttributes "$path"
-
     sed -Ei '' \
       -e '1h;2,$H;$!d;g' \
       -e 's/^.*id="main-content"[^>]*>(.*)<div class="PrevNextBar.*$/\1/' \


### PR DESCRIPTION
this was repeatedly breaking for stupid reasons, we'll just have to hope attribute order stays consistent from archive