### PR TITLE
register custom mobile marker and the unregistered testrail plugin marker

### DIFF
--- a/pytest-selenium/setup.cfg
+++ b/pytest-selenium/setup.cfg
@@ -1,3 +1,6 @@
 [tool:pytest]
 addopts=-vs --tb=long --showlocals --html ui-test.html --self-contained-html
 sensitive_url=^(?:https?\:\/\/)?openstax\.org
+markers =
+    mobile_only: test should only be run for mobile devices
+    testrail: TestRail marker


### PR DESCRIPTION
pytest currently warns if unregistered markers are used in test files and associated plugins

Register rex-web's `mobile` marker along with pytest-testrail's `testrail` marker.