### PR TITLE
feat: highlight math in summary dialog

### DIFF
--- a/src/app/content/highlights/components/ShowMyHighlights.tsx
+++ b/src/app/content/highlights/components/ShowMyHighlights.tsx
@@ -1,8 +1,10 @@
 import { HTMLElement } from '@openstax/types/lib.dom';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { typesetMath } from '../../../../helpers/mathjax';
 import { isHtmlElement } from '../../../guards';
 import { AppState } from '../../../types';
+import { assertWindow } from '../../../utils';
 import * as selectors from '../selectors';
 import { HighlightData } from '../types';
 import * as Styled from './ShowMyHighlightsStyles';
@@ -43,6 +45,7 @@ class ShowMyHighlights extends Component<Props, { showGoToTop: boolean }> {
     if (isHtmlElement(highlightsBodyRef)) {
       this.scrollHandler = this.updateGoToTop(highlightsBodyRef);
       highlightsBodyRef.addEventListener('scroll', this.scrollHandler);
+      typesetMath(highlightsBodyRef, assertWindow());
     }
   }
 

--- a/src/app/content/highlights/components/ShowMyHighlightsStyles.tsx
+++ b/src/app/content/highlights/components/ShowMyHighlightsStyles.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 import { AngleUp } from 'styled-icons/fa-solid/AngleUp';
-import { labelStyle, textRegularStyle } from '../../../components/Typography';
+import { bodyCopyRegularStyle, labelStyle, textRegularStyle } from '../../../components/Typography';
 import { h4Style } from '../../../components/Typography/headings';
 import theme from '../../../theme';
 import { highlightStyles } from '../constants';
@@ -55,8 +55,11 @@ export const HighlightOuterWrapper = styled.div`
 
 // tslint:disable-next-line:variable-name
 export const HighlightContent = styled.span`
-  ${textRegularStyle}
-  line-height: unset;
+  ${bodyCopyRegularStyle}
+
+  * {
+    overflow: initial;
+  }
 `;
 
 // tslint:disable-next-line:variable-name


### PR DESCRIPTION
@KarinaMendez2 turns out it was the overflow that was hiding the math, it needed `overflow: initial` which is also set in PageContent