### PR TITLE
Visual fixes for filters

### DIFF
--- a/src/app/content/highlights/components/SummaryPopup/Filters.tsx
+++ b/src/app/content/highlights/components/SummaryPopup/Filters.tsx
@@ -64,6 +64,7 @@ export default styled(Filters)`
   align-items: center;
   padding: 2rem ${popupPadding}rem 0 ${popupPadding}rem;
   background: ${theme.color.neutral.base};
+  border-bottom: 1px solid ${theme.color.neutral.formBorder};
   ${theme.breakpoints.mobile(css`
     padding: 0 ${mobilePadding}rem;
     height: 3.6rem;

--- a/src/app/content/highlights/components/SummaryPopup/FiltersList.tsx
+++ b/src/app/content/highlights/components/SummaryPopup/FiltersList.tsx
@@ -13,21 +13,24 @@ import { highlightLocationFilters, summaryFilters } from '../../selectors';
 
 // tslint:disable-next-line: variable-name
 export const StyledPlainButton = styled(PlainButton)`
-  padding: 0.5rem;
+  height: 1.7rem;
+  margin-right: 0.4rem;
 
   svg {
-    height: 1rem;
-    width: 1rem;
+    height: 0.8rem;
+    width: 0.8rem;
   }
 `;
 
 // tslint:disable-next-line: variable-name
 const ItemLabel = styled.span`
+  ${textStyle}
   max-width: 80px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   text-transform: capitalize;
+  line-height: 1.5rem;
 `;
 
 interface FiltersListColorProps {
@@ -113,7 +116,7 @@ export default styled(FiltersList)`
   `)}
 
   li {
-    margin-right: 2rem;
+    margin-right: 3.2rem;
     display: flex;
     align-items: center;
   }

--- a/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
+++ b/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
@@ -38,20 +38,24 @@ exports[`Filters matches snapshot 1`] = `
   border: none;
   padding: 0;
   background: none;
-  padding: 0.5rem;
+  height: 1.7rem;
+  margin-right: 0.4rem;
 }
 
 .c11 svg {
-  height: 1rem;
-  width: 1rem;
+  height: 0.8rem;
+  width: 0.8rem;
 }
 
 .c12 {
+  font-family: Neue Helvetica W01;
+  color: #424242;
   max-width: 80px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   text-transform: capitalize;
+  line-height: 1.5rem;
 }
 
 .c10 {
@@ -72,7 +76,7 @@ exports[`Filters matches snapshot 1`] = `
 }
 
 .c10 li {
-  margin-right: 2rem;
+  margin-right: 3.2rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -124,6 +128,7 @@ exports[`Filters matches snapshot 1`] = `
   align-items: center;
   padding: 2rem 3.2rem 0 3.2rem;
   background: #fff;
+  border-bottom: 1px solid #d5d5d5;
 }
 
 .c0 .c4 {


### PR DESCRIPTION
Some fixes for filters from https://docs.google.com/document/d/1YehKYfKngLXPi2uRc5EgneZl9ZqEHcH55MtybOeOY9g/edit?ts=5e1656ef
- The X icon before the tags is incorrect. See reference 1
- The separator line between the toolbar and the main body is missing. See reference 1
- The first filter tag isn’t left-aligned with the rest of the content. See reference 3. 