### PR TITLE
chore: Colorize summary

### DIFF
--- a/src/app/content/highlights/components/Highlights.spec.tsx
+++ b/src/app/content/highlights/components/Highlights.spec.tsx
@@ -49,8 +49,8 @@ describe('Highlights', () => {
 
     store.dispatch(setSummaryFilters({locationIds: [location!.id, pageId]}));
     store.dispatch(receiveHighlightsTotalCounts({
-      [pageId]: 5,
-      [location!.id]: 2,
+      [pageId]: {[HighlightColorEnum.Green]: 5},
+      [location!.id]: {[HighlightColorEnum.Green]: 2},
     }));
 
     const summaryHighlights = {
@@ -100,8 +100,8 @@ describe('Highlights', () => {
     expect(location).toBeDefined();
 
     store.dispatch(receiveHighlightsTotalCounts({
-      [pageId]: 5,
-      [location!.id]: 2,
+      [pageId]: {[HighlightColorEnum.Green]: 5},
+      [location!.id]: {[HighlightColorEnum.Green]: 2},
     }));
 
     const summaryHighlights = {
@@ -139,8 +139,8 @@ describe('Highlights', () => {
 
   it('show no highlights tip when there are no highlights for selected filters', () => {
     store.dispatch(receiveHighlightsTotalCounts({
-      pageId: 5,
-      pageId2: 2,
+      pageId: {[HighlightColorEnum.Green]: 5},
+      pageId2: {[HighlightColorEnum.Green]: 2},
     }));
     store.dispatch(setSummaryFilters({locationIds: ['not-in-book']}));
     store.dispatch(receiveSummaryHighlights({}, null));
@@ -171,7 +171,7 @@ describe('Highlights', () => {
     const pageId = stripIdVersion(pageInChapter.id);
     const locations = highlightLocationFilters(store.getState());
     const location = getHighlightLocationFilterForPage(locations, pageInChapter.id);
-    store.dispatch(receiveHighlightsTotalCounts({ [location!.id]: 5 }));
+    store.dispatch(receiveHighlightsTotalCounts({ [location!.id]: {[HighlightColorEnum.Green]: 5} }));
 
     const summaryHighlights = {
       [location!.id]: {

--- a/src/app/content/highlights/components/SummaryPopup/ChapterFilter.spec.tsx
+++ b/src/app/content/highlights/components/SummaryPopup/ChapterFilter.spec.tsx
@@ -1,3 +1,4 @@
+import { HighlightColorEnum } from '@openstax/highlighter/dist/api';
 import React from 'react';
 import { Provider } from 'react-redux';
 import renderer from 'react-test-renderer';
@@ -35,7 +36,7 @@ describe('ChapterFilter', () => {
   it('matches snapshot', () => {
     store.dispatch(receiveBook(book));
     store.dispatch(receiveHighlightsTotalCounts({
-      'testbook1-testpage1-uuid': 1,
+      'testbook1-testpage1-uuid': {[HighlightColorEnum.Green]: 1},
     }));
     addCurrentPageToSummaryFilters(helpers);
 
@@ -164,7 +165,7 @@ describe('ChapterFilter', () => {
   it('selects all select only chapters with highlights', () => {
     store.dispatch(receiveBook(book));
     store.dispatch(receiveHighlightsTotalCounts({
-      'testbook1-testpage1-uuid': 1,
+      'testbook1-testpage1-uuid': {[HighlightColorEnum.Green]: 1},
     }));
     addCurrentPageToSummaryFilters(helpers);
 
@@ -195,7 +196,7 @@ describe('ChapterFilter', () => {
   it('chapters without highlights are disabled', () => {
     store.dispatch(receiveBook(book));
     store.dispatch(receiveHighlightsTotalCounts({
-      'testbook1-testpage1-uuid': 1,
+      'testbook1-testpage1-uuid': {[HighlightColorEnum.Green]: 1},
     }));
     addCurrentPageToSummaryFilters(helpers);
 

--- a/src/app/content/highlights/hooks/loadMore.spec.ts
+++ b/src/app/content/highlights/hooks/loadMore.spec.ts
@@ -44,9 +44,9 @@ describe('filtersChange', () => {
     store.dispatch(receiveBook(book));
     store.dispatch(receivePage(page));
     store.dispatch(receiveHighlightsTotalCounts({
-      'testbook1-testpage1-uuid': 15,
-      'testbook1-testpage11-uuid': 5,
-      'testbook1-testpage2-uuid': 15,
+      'testbook1-testpage1-uuid': {[HighlightColorEnum.Green]: 15},
+      'testbook1-testpage11-uuid': {[HighlightColorEnum.Green]: 5},
+      'testbook1-testpage2-uuid': {[HighlightColorEnum.Green]: 15},
     }));
 
     const page1 = Array.from(new Array(15).keys()).map((index) => ({
@@ -140,7 +140,7 @@ describe('filtersChange', () => {
     store.dispatch(receiveBook(book));
     store.dispatch(receivePage(page));
     store.dispatch(receiveHighlightsTotalCounts({
-      [pageId]: 1,
+      [pageId]: {[HighlightColorEnum.Green]: 1},
     }));
 
     const {content: {highlights: {summary: {filters}}}} = store.getState();
@@ -183,7 +183,7 @@ describe('filtersChange', () => {
     store.dispatch(receiveBook(book));
     store.dispatch(receivePage({...pageInChapter, references: []}));
     store.dispatch(receiveHighlightsTotalCounts({
-      [pageInChapter.id]: 1,
+      [pageInChapter.id]: {[HighlightColorEnum.Green]: 1},
     }));
 
     const {content: {highlights: {summary: {filters}}}} = store.getState();

--- a/src/app/content/highlights/hooks/locationChange.spec.ts
+++ b/src/app/content/highlights/hooks/locationChange.spec.ts
@@ -1,3 +1,4 @@
+import { HighlightColorEnum } from '@openstax/highlighter/dist/api';
 import createTestServices from '../../../../test/createTestServices';
 import createTestStore from '../../../../test/createTestStore';
 import { book, page } from '../../../../test/mocks/archiveLoader';
@@ -97,13 +98,14 @@ describe('locationChange', () => {
     store.dispatch(receiveBook(formatBookData(book, mockCmsBook)));
     store.dispatch(receivePage({...page, references: []}));
     store.dispatch(receiveUser(formatUser(testAccountsUser)));
-    const totalCountsInState = { somePage: 1 };
+    const totalCountsInState = { somePage: {[HighlightColorEnum.Green]: 1} };
     store.dispatch(receiveHighlightsTotalCounts(totalCountsInState));
 
     jest.spyOn(helpers.highlightClient, 'getHighlights')
       .mockReturnValue(Promise.resolve({}));
     jest.spyOn(helpers.highlightClient, 'getHighlightsSummary')
-      .mockReturnValue(Promise.resolve({ countsPerSource: { pageId: 1 }}));
+      // TODO remove cast when swagger updated
+      .mockReturnValue(Promise.resolve({ countsPerSource: { pageId: {[HighlightColorEnum.Green]: 1} }} as any));
 
     await hook();
 
@@ -117,17 +119,18 @@ describe('locationChange', () => {
     store.dispatch(receiveUser(formatUser(testAccountsUser)));
 
     const totalCountsPerPage = {
-      'testbook1-testpage1-uuid': 1,
-      'testbook1-testpage2-uuid': 2,
+      'testbook1-testpage1-uuid': {[HighlightColorEnum.Green]: 1},
+      'testbook1-testpage2-uuid': {[HighlightColorEnum.Green]: 1},
       // tslint:disable-next-line: object-literal-sort-keys
-      'testbook1-testpage11-uuid': 1,
-      'testbook1-testpage4-uuid': 5,
+      'testbook1-testpage11-uuid': {[HighlightColorEnum.Green]: 1},
+      'testbook1-testpage4-uuid': {[HighlightColorEnum.Green]: 1},
     };
 
     jest.spyOn(helpers.highlightClient, 'getHighlights')
       .mockReturnValue(Promise.resolve({}));
     jest.spyOn(helpers.highlightClient, 'getHighlightsSummary')
-      .mockReturnValue(Promise.resolve({ countsPerSource: totalCountsPerPage }));
+      // TODO remove cast when swagger updated
+      .mockReturnValue(Promise.resolve({ countsPerSource: totalCountsPerPage } as any));
 
     await hook();
 

--- a/src/app/content/highlights/hooks/locationChange.ts
+++ b/src/app/content/highlights/hooks/locationChange.ts
@@ -4,6 +4,7 @@ import { AppServices, MiddlewareAPI } from '../../../types';
 import { bookAndPage } from '../../selectors';
 import { receiveHighlights, receiveHighlightsTotalCounts } from '../actions';
 import * as select from '../selectors';
+import { CountsPerSource } from '../types';
 
 const hookBody = (services: MiddlewareAPI & AppServices) => async() => {
   const {dispatch, getState, highlightClient} = services;
@@ -36,7 +37,8 @@ const hookBody = (services: MiddlewareAPI & AppServices) => async() => {
   });
 
   if (totalCounts.countsPerSource) {
-    dispatch(receiveHighlightsTotalCounts(totalCounts.countsPerSource));
+    // TODO remove cast when swagger is updated
+    dispatch(receiveHighlightsTotalCounts(totalCounts.countsPerSource as unknown as CountsPerSource));
   }
 };
 

--- a/src/app/content/highlights/reducer.spec.ts
+++ b/src/app/content/highlights/reducer.spec.ts
@@ -203,8 +203,8 @@ describe('highlight reducer', () => {
     });
 
     it('remove highlight from summary highlights if color filters does not match', () => {
-      const mock1 = mockHighlight;
-      const mock3 = {...mockHighlight, id: 'qwer'};
+      const mock1 = {...mockHighlight, sourceId: 'highlightSource'};
+      const mock3 = {...mockHighlight, id: 'qwer', sourceId: 'highlightSource'};
 
       const state = reducer({
         ...initialState,
@@ -219,6 +219,9 @@ describe('highlight reducer', () => {
             highlightChapter: {
               highlightSource: [mock1, mock3],
             },
+          },
+          totalCountsPerPage: {
+            highlightSource: {[HighlightColorEnum.Blue]: 2},
           },
         },
       }, actions.updateHighlight({id: mock1.id, highlight: {color: HighlightUpdateColorEnum.Green}}, {
@@ -235,6 +238,8 @@ describe('highlight reducer', () => {
       const highlights = state.summary.highlights.highlightChapter.highlightSource;
       expect(highlights.length).toEqual(1);
       expect(highlights[0]).toEqual(mock3);
+      expect(state.summary.totalCountsPerPage!.highlightSource.blue).toEqual(1);
+      expect(state.summary.totalCountsPerPage!.highlightSource.green).toEqual(1);
     });
 
     it('add highlight to summary highlights if new color match current filters', () => {

--- a/src/app/content/highlights/reducer.spec.ts
+++ b/src/app/content/highlights/reducer.spec.ts
@@ -63,8 +63,8 @@ describe('highlight reducer', () => {
 
   it('receive total counts', () => {
     const totalCountsPerPage: CountsPerSource = {
-      page1: 1,
-      page2: 2,
+      page1: {[HighlightColorEnum.Green]: 1},
+      page2: {[HighlightColorEnum.Pink]: 3},
     };
 
     const state = reducer({
@@ -92,7 +92,7 @@ describe('highlight reducer', () => {
           locationIds: ['highlightChapter'],
         },
       },
-    }, actions.createHighlight(mockHighlight as any, {
+    }, actions.createHighlight({...mockHighlight, sourceId: 'highlightSource'} as any, {
       locationFilterId: 'highlightChapter',
       pageId: 'highlightSource',
     }));
@@ -102,7 +102,7 @@ describe('highlight reducer', () => {
     }
     expect(state.highlights.length).toEqual(1);
     expect(state.highlights[0].id).toEqual('asdf');
-    expect(state.summary.totalCountsPerPage).toEqual({ highlightSource: 1 });
+    expect(state.summary.totalCountsPerPage).toEqual({ highlightSource: {blue: 1} });
     const highlights = state.summary.highlights.highlightChapter.highlightSource;
     expect(highlights.length).toEqual(1);
     expect(highlights.find((h) => h.id === mockHighlight.id)).toBeTruthy();
@@ -129,12 +129,12 @@ describe('highlight reducer', () => {
           ...initialState.summary,
           highlights: {
             highlightChapter: {
-              highlightSource: [mockHighlight],
+              highlightSource: [{...mockHighlight, sourceId: 'highlightSource'}],
               otherHighlightSource: [mockHighlight],
             },
           },
           totalCountsPerPage: {
-            highlightSource: 2,
+            highlightSource: {[HighlightColorEnum.Green]: 1},
           },
         },
       }, actions.deleteHighlight(mockHighlight.id, {
@@ -147,7 +147,7 @@ describe('highlight reducer', () => {
       }
 
       expect(state.highlights.length).toEqual(0);
-      expect(state.summary.totalCountsPerPage).toEqual({ highlightSource: 1 });
+      expect(state.summary.totalCountsPerPage).toEqual({ highlightSource: {green: 1} });
       const chapterHighlights = state.summary.highlights.highlightChapter;
       expect(Object.keys(chapterHighlights).length).toEqual(1);
       expect(chapterHighlights.highlightSource).toBeUndefined();

--- a/src/app/content/highlights/reducer.ts
+++ b/src/app/content/highlights/reducer.ts
@@ -11,10 +11,12 @@ import { highlightingFeatureFlag, highlightStyles } from './constants';
 import { State } from './types';
 import {
   addSummaryHighlight,
+  addToTotalCounts,
+  removeFromTotalCounts,
   removeSummaryHighlight,
-  updateSummaryHighlightsDependOnFilters,
+  updateInTotalCounts,
+  updateSummaryHighlightsDependOnFilters
 } from './utils';
-import { addToTotalCounts, removeFromTotalCounts, updateInTotalCounts } from './utils/summaryHighlightsUtils';
 
 const defaultColors = highlightStyles.map(({label}) => label);
 export const initialState: State = {

--- a/src/app/content/highlights/reducer.ts
+++ b/src/app/content/highlights/reducer.ts
@@ -10,12 +10,11 @@ import * as actions from './actions';
 import { highlightingFeatureFlag, highlightStyles } from './constants';
 import { State } from './types';
 import {
-  addOneToTotalCounts,
   addSummaryHighlight,
-  removeOneFromTotalCounts,
   removeSummaryHighlight,
   updateSummaryHighlightsDependOnFilters,
 } from './utils';
+import { addToTotalCounts, removeFromTotalCounts, updateInTotalCounts } from './utils/summaryHighlightsUtils';
 
 const defaultColors = highlightStyles.map(({label}) => label);
 export const initialState: State = {
@@ -56,8 +55,7 @@ const reducer: Reducer<State, AnyAction> = (state = initialState, action) => {
         });
       }
 
-      const { pageId } = action.meta;
-      const totalCountsPerPage = addOneToTotalCounts(state.summary.totalCountsPerPage || {}, pageId);
+      const totalCountsPerPage = addToTotalCounts(state.summary.totalCountsPerPage || {}, highlight);
 
       return {
         ...state,
@@ -80,8 +78,10 @@ const reducer: Reducer<State, AnyAction> = (state = initialState, action) => {
         (highlight) => highlight.id === action.payload.id);
       if (oldHiglightIndex < 0) { return state; }
 
+      const oldHighlight = state.highlights[oldHiglightIndex];
+
       const newHighlight = {
-        ...state.highlights[oldHiglightIndex],
+        ...oldHighlight,
         ...action.payload.highlight,
       } as Highlight;
 
@@ -93,12 +93,18 @@ const reducer: Reducer<State, AnyAction> = (state = initialState, action) => {
         state.summary.filters,
         {...action.meta, highlight: newHighlight});
 
+      const totalCountsPerPage = state.summary.totalCountsPerPage
+        ? updateInTotalCounts(state.summary.totalCountsPerPage, oldHighlight, newHighlight)
+        : state.summary.totalCountsPerPage
+      ;
+
       return {
         ...state,
         highlights: newHighlights,
         summary: {
           ...state.summary,
           highlights: newSummaryHighlights,
+          totalCountsPerPage,
         },
       };
     }
@@ -107,13 +113,15 @@ const reducer: Reducer<State, AnyAction> = (state = initialState, action) => {
         return state;
       }
 
-      const newSummaryHighlights = removeSummaryHighlight(state.summary.highlights, {
+      const [newSummaryHighlights, removedHighlight] = removeSummaryHighlight(state.summary.highlights, {
         ...action.meta,
         id: action.payload,
       });
 
-      const { pageId } = action.meta;
-      const totalCountsPerPage = removeOneFromTotalCounts(state.summary.totalCountsPerPage || {}, pageId);
+      const totalCountsPerPage = state.summary.totalCountsPerPage && removedHighlight
+        ? removeFromTotalCounts(state.summary.totalCountsPerPage, removedHighlight)
+        : state.summary.totalCountsPerPage
+      ;
 
       return {
         ...state,

--- a/src/app/content/highlights/types.ts
+++ b/src/app/content/highlights/types.ts
@@ -11,8 +11,8 @@ export interface SummaryFilters {
 }
 
 export interface CountsPerSource {
-  [key: string]: Partial<{
-    [key in HighlightColorEnum]: number
+  [sourceId: string]: Partial<{
+    [color in HighlightColorEnum]: number
   }>;
 }
 

--- a/src/app/content/highlights/types.ts
+++ b/src/app/content/highlights/types.ts
@@ -1,4 +1,4 @@
-import { Highlight, HighlightColorEnum, HighlightsSummary } from '@openstax/highlighter/dist/api';
+import { Highlight, HighlightColorEnum } from '@openstax/highlighter/dist/api';
 import { LinkedArchiveTree, LinkedArchiveTreeSection } from '../types';
 
 export type HighlightData = Highlight;
@@ -10,7 +10,11 @@ export interface SummaryFilters {
   colors: HighlightColorEnum[];
 }
 
-export type CountsPerSource = Exclude<HighlightsSummary['countsPerSource'], undefined>;
+export interface CountsPerSource {
+  [key: string]: Partial<{
+    [key in HighlightColorEnum]: number
+  }>;
+}
 
 export type SummaryHighlightsPagination = null | {
   sourceIds: string[];

--- a/src/app/content/highlights/utils/getHighlightLocationFiltersWithContent.spec.ts
+++ b/src/app/content/highlights/utils/getHighlightLocationFiltersWithContent.spec.ts
@@ -2,7 +2,7 @@ import { book } from '../../../../test/mocks/archiveLoader';
 import { getHighlightLocationFilters, getHighlightLocationFiltersWithContent } from '../utils';
 
 describe('getHighlightLocationFiltersWithContent', () => {
-  it('should merge total counts per page to their locationFilterId', () => {
+  it('should return a set of locationFilterIds with content', () => {
     const totalCountsPerPage = {
       'testbook1-testpage1-uuid': {},
       'testbook1-testpage2-uuid': {},

--- a/src/app/content/highlights/utils/getHighlightLocationFiltersWithContent.spec.ts
+++ b/src/app/content/highlights/utils/getHighlightLocationFiltersWithContent.spec.ts
@@ -4,11 +4,11 @@ import { getHighlightLocationFilters, getHighlightLocationFiltersWithContent } f
 describe('getHighlightLocationFiltersWithContent', () => {
   it('should merge total counts per page to their locationFilterId', () => {
     const totalCountsPerPage = {
-      'testbook1-testpage1-uuid': 1,
-      'testbook1-testpage2-uuid': 2,
+      'testbook1-testpage1-uuid': {},
+      'testbook1-testpage2-uuid': {},
       // tslint:disable-next-line: object-literal-sort-keys
-      'testbook1-testpage11-uuid': 1,
-      'testbook1-testpage4-uuid': 5,
+      'testbook1-testpage11-uuid': {},
+      'testbook1-testpage4-uuid': {},
     };
     const filterLocations = getHighlightLocationFilters(book);
 

--- a/src/app/content/highlights/utils/index.ts
+++ b/src/app/content/highlights/utils/index.ts
@@ -3,9 +3,9 @@ export { default as getHighlightLocationFilterForPage } from './getHighlightLoca
 export { default as getHighlightLocationFilters } from './getHighlightLocationFilters';
 export { default as getHighlightLocationFiltersWithContent } from './getHighlightLocationFiltersWithContent';
 export {
-  addOneToTotalCounts,
+  addToTotalCounts,
   addSummaryHighlight,
-  removeOneFromTotalCounts,
+  removeFromTotalCounts,
   removeSummaryHighlight,
   updateSummaryHighlight,
   updateSummaryHighlightsDependOnFilters,

--- a/src/app/content/highlights/utils/index.ts
+++ b/src/app/content/highlights/utils/index.ts
@@ -4,8 +4,9 @@ export { default as getHighlightLocationFilters } from './getHighlightLocationFi
 export { default as getHighlightLocationFiltersWithContent } from './getHighlightLocationFiltersWithContent';
 export {
   addToTotalCounts,
-  addSummaryHighlight,
+  updateInTotalCounts,
   removeFromTotalCounts,
+  addSummaryHighlight,
   removeSummaryHighlight,
   updateSummaryHighlight,
   updateSummaryHighlightsDependOnFilters,

--- a/src/app/content/highlights/utils/paginationUtils.spec.ts
+++ b/src/app/content/highlights/utils/paginationUtils.spec.ts
@@ -1,3 +1,4 @@
+import { HighlightColorEnum } from '@openstax/highlighter/dist/api';
 import { treeWithUnits } from '../../../../test/trees';
 import { findArchiveTreeNode } from '../../utils/archiveTreeUtils';
 import { filterCountsPerSourceByLocationFilter, getNextPageSources } from './paginationUtils';
@@ -5,22 +6,22 @@ import { filterCountsPerSourceByLocationFilter, getNextPageSources } from './pag
 describe('getNextPageSources', () => {
   it('gets one page id if it has enough records left to fill a response', () => {
     expect(getNextPageSources({
-      page1: 10,
-      page2: 10,
+      page1: {[HighlightColorEnum.Green]: 10},
+      page2: {[HighlightColorEnum.Pink]: 10},
     }, treeWithUnits, 10)).toEqual(['page1']);
   });
 
   it('fails over to next page if more records are needed', () => {
     expect(getNextPageSources({
-      page1: 5,
-      page2: 10,
+      page1: {[HighlightColorEnum.Green]: 5},
+      page2: {[HighlightColorEnum.Pink]: 10},
     }, treeWithUnits, 10)).toEqual(['page1', 'page2']);
   });
 
   it('skips pages with no highlights', () => {
     expect(getNextPageSources({
-      page1: 0,
-      page2: 10,
+      page1: {[HighlightColorEnum.Green]: 0},
+      page2: {[HighlightColorEnum.Pink]: 10},
     }, treeWithUnits, 10)).toEqual(['page2']);
   });
 });
@@ -29,9 +30,14 @@ describe('filterCountsPerSourceByLocationFilter', () => {
   it('filters by chapters', () => {
     expect(filterCountsPerSourceByLocationFilter(
       new Map([['chapter1', findArchiveTreeNode(treeWithUnits, 'chapter1')!]]),
-      {page1: 2, preface: 3}
+      {
+        page1: {[HighlightColorEnum.Green]: 2},
+        preface: {[HighlightColorEnum.Pink]: 3},
+      }
     )).toEqual(
-      {page1: 2}
+      {
+        page1: {[HighlightColorEnum.Green]: 2},
+      }
     );
   });
 
@@ -41,9 +47,15 @@ describe('filterCountsPerSourceByLocationFilter', () => {
         ['chapter1', findArchiveTreeNode(treeWithUnits, 'chapter1')!],
         ['preface', findArchiveTreeNode(treeWithUnits, 'preface')!]]
       ),
-      {page1: 2, preface: 3}
+      {
+        page1: {[HighlightColorEnum.Green]: 2},
+        preface: {[HighlightColorEnum.Pink]: 3},
+      }
     )).toEqual(
-      {page1: 2, preface: 3}
+      {
+        page1: {[HighlightColorEnum.Green]: 2},
+        preface: {[HighlightColorEnum.Pink]: 3},
+      }
     );
   });
 });

--- a/src/app/content/highlights/utils/summaryHighlightsUtils.spec.ts
+++ b/src/app/content/highlights/utils/summaryHighlightsUtils.spec.ts
@@ -10,6 +10,7 @@ import {
   addToTotalCounts,
   removeFromTotalCounts,
   removeSummaryHighlight,
+  updateInTotalCounts,
   updateSummaryHighlight,
   updateSummaryHighlightsDependOnFilters,
 } from './summaryHighlightsUtils';
@@ -384,5 +385,32 @@ describe('addOneToTotalCounts', () => {
     };
 
     expect(addToTotalCounts(totalCounts, highlight)).toEqual(expectedResult);
+  });
+});
+
+describe('updateInTotalCounts', () => {
+  it('updates', () => {
+    const totalCounts: CountsPerSource = {
+      page1: {[HighlightColorEnum.Green]: 1},
+      page2: {[HighlightColorEnum.Pink]: 3},
+    };
+
+    const expectedResult: CountsPerSource = {
+      page1: {[HighlightColorEnum.Pink]: 1},
+      page2: {[HighlightColorEnum.Pink]: 3},
+    };
+
+    expect(updateInTotalCounts(totalCounts, highlight, {...highlight, color: HighlightColorEnum.Pink}))
+      .toEqual(expectedResult);
+  });
+
+  it('noops if there is nothing to change', () => {
+    const totalCounts: CountsPerSource = {
+      page1: {[HighlightColorEnum.Green]: 1},
+      page2: {[HighlightColorEnum.Pink]: 3},
+    };
+
+    expect(updateInTotalCounts(totalCounts, highlight, highlight))
+      .toBe(totalCounts);
   });
 });

--- a/src/app/content/highlights/utils/summaryHighlightsUtils.spec.ts
+++ b/src/app/content/highlights/utils/summaryHighlightsUtils.spec.ts
@@ -4,16 +4,22 @@ import {
   HighlightUpdate,
   HighlightUpdateColorEnum,
 } from '@openstax/highlighter/dist/api';
+import { CountsPerSource } from '../types';
 import {
-  addOneToTotalCounts,
   addSummaryHighlight,
-  removeOneFromTotalCounts,
+  addToTotalCounts,
+  removeFromTotalCounts,
   removeSummaryHighlight,
   updateSummaryHighlight,
   updateSummaryHighlightsDependOnFilters,
 } from './summaryHighlightsUtils';
 
-const highlight = { id: 'highlight', color: HighlightColorEnum.Green, annotation: 'asd' } as Highlight;
+const highlight = {
+  annotation: 'asd',
+  color: HighlightColorEnum.Green,
+  id: 'highlight',
+  sourceId: 'page1',
+} as Highlight;
 const highlight2 = { id: 'highlight2' } as Highlight;
 
 describe('addSummaryHighlight', () => {
@@ -91,7 +97,7 @@ describe('removeSummaryHighlight', () => {
       id: highlight.id,
       locationFilterId: 'location',
       pageId: 'page',
-    })).toMatchObject(expectedResult);
+    })[0]).toMatchObject(expectedResult);
   });
 
   it('remove highlight and page if it does not have more highlights', () => {
@@ -112,7 +118,7 @@ describe('removeSummaryHighlight', () => {
       id: highlight.id,
       locationFilterId: 'location',
       pageId: 'page',
-    })).toMatchObject(expectedResult);
+    })[0]).toMatchObject(expectedResult);
   });
 
   it('remove highlight, page and location if it does not have more highlights', () => {
@@ -323,63 +329,60 @@ describe('updateSummaryHighlightsDependOnFilters', () => {
   });
 });
 
-describe('removeOneFromTotalCounts', () => {
+describe('removeFromTotalCounts', () => {
   it('remove one from total counts from given id', () => {
-    const totalCounts = {
-      page1: 1,
-      page2: 3,
+    const totalCounts: CountsPerSource = {
+      page1: {[HighlightColorEnum.Green]: 1},
+      page2: {[HighlightColorEnum.Pink]: 3},
     };
 
-    const expectedResult = {
-      page1: 0,
-      page2: 3,
+    const expectedResult: CountsPerSource = {
+      page2: {[HighlightColorEnum.Pink]: 3},
     };
 
-    expect(removeOneFromTotalCounts(totalCounts, 'page1')).toEqual(expectedResult);
+    expect(removeFromTotalCounts(totalCounts, highlight)).toEqual(expectedResult);
   });
 
   it('do nothing if if given id doesn\'t not exists', () => {
-    const totalCounts = {
-      page1: 1,
-      page2: 3,
+    const totalCounts: CountsPerSource = {
+      page1: {[HighlightColorEnum.Green]: 1},
+      page2: {[HighlightColorEnum.Pink]: 3},
     };
 
-    const expectedResult = {
-      page1: 1,
-      page2: 3,
+    const expectedResult: CountsPerSource = {
+      page1: {[HighlightColorEnum.Green]: 1},
+      page2: {[HighlightColorEnum.Pink]: 3},
     };
 
-    expect(removeOneFromTotalCounts(totalCounts, 'wrong-id')).toEqual(expectedResult);
+    expect(removeFromTotalCounts(totalCounts, {...highlight, sourceId: 'asdf'})).toEqual(expectedResult);
   });
 });
 
 describe('addOneToTotalCounts', () => {
   it('add one to total counts for given id', () => {
-    const totalCounts = {
-      page1: 1,
-      page2: 3,
+    const totalCounts: CountsPerSource = {
+      page1: {[HighlightColorEnum.Green]: 1},
+      page2: {[HighlightColorEnum.Pink]: 3},
     };
 
-    const expectedResult = {
-      page1: 2,
-      page2: 3,
+    const expectedResult: CountsPerSource = {
+      page1: {[HighlightColorEnum.Green]: 2},
+      page2: {[HighlightColorEnum.Pink]: 3},
     };
 
-    expect(addOneToTotalCounts(totalCounts, 'page1')).toEqual(expectedResult);
+    expect(addToTotalCounts(totalCounts, highlight)).toEqual(expectedResult);
   });
 
   it('create new prop if there is no result for given id', () => {
-    const totalCounts = {
-      page1: 1,
-      page2: 3,
+    const totalCounts: CountsPerSource = {
+      page2: {[HighlightColorEnum.Pink]: 3},
     };
 
-    const expectedResult = {
-      newPage: 1,
-      page1: 1,
-      page2: 3,
+    const expectedResult: CountsPerSource = {
+      page1: {[HighlightColorEnum.Green]: 1},
+      page2: {[HighlightColorEnum.Pink]: 3},
     };
 
-    expect(addOneToTotalCounts(totalCounts, 'newPage')).toEqual(expectedResult);
+    expect(addToTotalCounts(totalCounts, highlight)).toEqual(expectedResult);
   });
 });

--- a/src/app/content/highlights/utils/summaryHighlightsUtils.ts
+++ b/src/app/content/highlights/utils/summaryHighlightsUtils.ts
@@ -215,8 +215,8 @@ export const updateInTotalCounts = (
   newHighlight: Highlight
 ) => {
   if (
-    totalCounts[oldHighlight.sourceId] === totalCounts[newHighlight.sourceId]
-    && totalCounts[oldHighlight.color] === totalCounts[newHighlight.color]
+    oldHighlight.sourceId === newHighlight.sourceId
+    && oldHighlight.color === newHighlight.color
   ) {
     return totalCounts;
   }

--- a/src/app/content/highlights/utils/summaryHighlightsUtils.ts
+++ b/src/app/content/highlights/utils/summaryHighlightsUtils.ts
@@ -5,6 +5,7 @@ import {
   UpdateHighlightRequest,
 } from '@openstax/highlighter/dist/api';
 import flow from 'lodash/fp/flow';
+import partition from 'lodash/fp/partition';
 import {
   CountsPerSource,
   SummaryFilters,
@@ -45,13 +46,13 @@ export const removeSummaryHighlight = (
 ): [SummaryHighlights, Highlight | null] => {
   const { locationFilterId, pageId, id } = data;
 
-  const filteredHighlights = summaryHighlights[locationFilterId] && summaryHighlights[locationFilterId][pageId]
-    ? summaryHighlights[locationFilterId][pageId].filter((highlight) => highlight.id !== id)
-    : null;
-
-  const removedHighlight = summaryHighlights[locationFilterId] && summaryHighlights[locationFilterId][pageId]
-    ? summaryHighlights[locationFilterId][pageId].find((highlight) => highlight.id === id)
-    : null;
+  const pageHighlights: Highlight[] | undefined =
+    summaryHighlights[locationFilterId] && summaryHighlights[locationFilterId][pageId];
+  const [filteredHighlights, removedHighlights] = pageHighlights
+    ? partition((highlight) => highlight.id !== id, pageHighlights)
+    : [null, []]
+  ;
+  const removedHighlight = removedHighlights[0];
 
   if (!filteredHighlights || !removedHighlight) {
     return [summaryHighlights, null];

--- a/src/app/content/highlights/utils/summaryHighlightsUtils.ts
+++ b/src/app/content/highlights/utils/summaryHighlightsUtils.ts
@@ -4,6 +4,7 @@ import {
   HighlightUpdateColorEnum,
   UpdateHighlightRequest,
 } from '@openstax/highlighter/dist/api';
+import flow from 'lodash/fp/flow';
 import {
   CountsPerSource,
   SummaryFilters,
@@ -38,12 +39,23 @@ interface DataRemove extends BaseData {
   id: string;
 }
 
-export const removeSummaryHighlight = (summaryHighlights: SummaryHighlights, data: DataRemove) => {
+export const removeSummaryHighlight = (
+  summaryHighlights: SummaryHighlights,
+  data: DataRemove
+): [SummaryHighlights, Highlight | null] => {
   const { locationFilterId, pageId, id } = data;
 
   const filteredHighlights = summaryHighlights[locationFilterId] && summaryHighlights[locationFilterId][pageId]
     ? summaryHighlights[locationFilterId][pageId].filter((highlight) => highlight.id !== id)
-    : [];
+    : null;
+
+  const removedHighlight = summaryHighlights[locationFilterId] && summaryHighlights[locationFilterId][pageId]
+    ? summaryHighlights[locationFilterId][pageId].find((highlight) => highlight.id === id)
+    : null;
+
+  if (!filteredHighlights || !removedHighlight) {
+    return [summaryHighlights, null];
+  }
 
   const newHighlights: SummaryHighlights = {
     ...summaryHighlights,
@@ -60,7 +72,7 @@ export const removeSummaryHighlight = (summaryHighlights: SummaryHighlights, dat
     delete newHighlights[locationFilterId];
   }
 
-  return newHighlights;
+  return [newHighlights, removedHighlight];
 };
 
 interface DataUpdate extends BaseData, UpdateHighlightRequest {}
@@ -123,7 +135,7 @@ export const updateSummaryHighlightsDependOnFilters = (
   // If highlight's color has changed and it's no longer in filters
   // remove this highlight from summary highlights...
   if (!colors.includes(color)) {
-    newHighlights = removeSummaryHighlight(newHighlights, {
+    [newHighlights] = removeSummaryHighlight(newHighlights, {
       id: updatedHighlight.id,
       locationFilterId,
       pageId,
@@ -157,28 +169,60 @@ export const updateSummaryHighlightsDependOnFilters = (
   return newHighlights;
 };
 
-export const removeOneFromTotalCounts = (
-  totalCounts: CountsPerSource, id: string
+export const removeFromTotalCounts = (
+  totalCounts: CountsPerSource,
+  highlight: Highlight
 ) => {
-  const newTotalCounts = {...totalCounts};
+  if (totalCounts[highlight.sourceId] && totalCounts[highlight.sourceId][highlight.color]) {
+    const newTotal = {
+      ...totalCounts,
+      [highlight.sourceId]: {
+        ...totalCounts[highlight.sourceId],
+        [highlight.color]: totalCounts[highlight.sourceId][highlight.color]! - 1,
+      },
+    };
 
-  if (newTotalCounts[id]) {
-    newTotalCounts[id] -= 1;
+    if (newTotal[highlight.sourceId][highlight.color] === 0) {
+      delete newTotal[highlight.sourceId][highlight.color];
+    }
+
+    if (Object.keys(newTotal[highlight.sourceId]).length === 0) {
+      delete newTotal[highlight.sourceId];
+    }
+
+    return newTotal;
   }
 
-  return newTotalCounts;
+  return totalCounts;
 };
 
-export const addOneToTotalCounts = (
-  totalCounts: CountsPerSource, id: string
+export const addToTotalCounts = (
+  totalCounts: CountsPerSource,
+  highlight: Highlight
 ) => {
-  const newTotalCounts = {...totalCounts};
+  return {
+    ...totalCounts,
+    [highlight.sourceId]: {
+      ...totalCounts[highlight.sourceId] || {},
+      [highlight.color]: ((totalCounts[highlight.sourceId] || {})[highlight.color] || 0) + 1,
+    },
+  };
+};
 
-  if (newTotalCounts[id]) {
-    newTotalCounts[id] += 1;
-  } else {
-    newTotalCounts[id] = 1;
+export const updateInTotalCounts = (
+  totalCounts: CountsPerSource,
+  oldHighlight: Highlight,
+  newHighlight: Highlight
+) => {
+  if (
+    totalCounts[oldHighlight.sourceId] === totalCounts[newHighlight.sourceId]
+    && totalCounts[oldHighlight.color] === totalCounts[newHighlight.color]
+  ) {
+    return totalCounts;
   }
 
-  return newTotalCounts;
+  return flow(
+    (counts) => removeFromTotalCounts(counts, oldHighlight),
+    (counts) => addToTotalCounts(counts, newHighlight)
+  )(totalCounts);
 };

--- a/src/config.development.js
+++ b/src/config.development.js
@@ -5,7 +5,7 @@ module.exports = {
 
   ACCOUNTS_URL: process.env.ACCOUNTS_URL || 'https://accounts-dev.openstax.org',
   OS_WEB_URL: process.env.OS_WEB_URL || 'https://cms-dev.openstax.org',
-  HIGHLIGHTS_URL: 'https://highlights-dev1.sandbox.openstax.org',
+  HIGHLIGHTS_URL: 'https://highlights-jan16pl.sandbox.openstax.org',
 
   SKIP_OS_WEB_PROXY: process.env.SKIP_OS_WEB_PROXY !== undefined,
   FIXTURES: false,


### PR DESCRIPTION
changes the dev highlighting endpoint to one that supports the new summary with colors, unfortunately the swagger file was not updated correctly so i've hardcoded the type and am overriding the swagger response in some places.

this doesn't change any functionality it just changes the format and fixes all the resulting errors