### PR TITLE
Focus dropdown after esc

### DIFF
--- a/src/app/components/Dropdown.spec.tsx
+++ b/src/app/components/Dropdown.spec.tsx
@@ -100,5 +100,40 @@ describe('Dropdown', () => {
     });
 
     expect(() => component.root.findByType(DropdownList)).toThrow();
+
+    useOnEscSpy.mockClear();
+  });
+
+  it('tab hidden focus after Esc', () => {
+    const useOnEscSpy = jest.spyOn(utils, 'useOnEsc');
+
+    const focus = jest.fn();
+    const addEventListener = jest.fn();
+    const removeEventListener = jest.fn();
+    const createNodeMock = () => ({focus, addEventListener, removeEventListener});
+
+    const component = renderer.create(<MessageProvider>
+      <Dropdown transparentTab={false} toggle={<button>show more</button>}>
+        <DropdownList>
+          <DropdownItem onClick={() => null} message='i18n:highlighting:dropdown:delete' />
+          <DropdownItem onClick={() => null} href='/wooo' message='i18n:highlighting:dropdown:edit' />
+        </DropdownList>
+      </Dropdown>
+    </MessageProvider>, {createNodeMock});
+
+    renderer.act(() => {
+      component.root.findByType('button').props.onClick();
+    });
+
+    expect(() => component.root.findByType(DropdownList)).not.toThrow();
+
+    renderer.act(() => {
+      useOnEscSpy.mock.calls[0][2]();
+    });
+
+    expect(() => component.root.findByType(DropdownList)).toThrow();
+    expect(focus).toHaveBeenCalled();
+
+    useOnEscSpy.mockClear();
   });
 });

--- a/src/app/components/Dropdown.tsx
+++ b/src/app/components/Dropdown.tsx
@@ -63,7 +63,7 @@ const TabHiddenDropDown = styled(({toggle, children, className}: Props) => {
     if (container.current) { container.current.focus(); }
   });
 
-  return <div className={className} ref={container} tabIndex={0}>
+  return <div className={className} ref={container} tabIndex={-1}>
     <DropdownToggle component={toggle} onClick={() => setOpen(!open)} />
     {open && children}
   </div>;

--- a/src/app/components/Dropdown.tsx
+++ b/src/app/components/Dropdown.tsx
@@ -58,9 +58,12 @@ const TabHiddenDropDown = styled(({toggle, children, className}: Props) => {
   const container = React.useRef<HTMLElement>(null);
 
   useOnClickOutside(container, open, () => setOpen(false));
-  useOnEsc(container, open, () => setOpen(false));
+  useOnEsc(container, open, () => {
+    setOpen(false);
+    if (container.current) { container.current.focus(); }
+  });
 
-  return <div className={className} ref={container}>
+  return <div className={className} ref={container} tabIndex={0}>
     <DropdownToggle component={toggle} onClick={() => setOpen(!open)} />
     {open && children}
   </div>;

--- a/src/app/components/__snapshots__/Dropdown.spec.tsx.snap
+++ b/src/app/components/__snapshots__/Dropdown.spec.tsx.snap
@@ -287,7 +287,7 @@ exports[`Dropdown matches snapshot for tab hidden (closed) 1`] = `
 
 <div
   className="c0 c1"
-  tabIndex={0}
+  tabIndex={-1}
 >
   <button
     className="c2 c3"
@@ -446,7 +446,7 @@ exports[`Dropdown matches snapshot for tab hidden (open) 1`] = `
 
 <div
   className="c0 c1"
-  tabIndex={0}
+  tabIndex={-1}
 >
   <button
     className="c2 c3"

--- a/src/app/components/__snapshots__/Dropdown.spec.tsx.snap
+++ b/src/app/components/__snapshots__/Dropdown.spec.tsx.snap
@@ -287,6 +287,7 @@ exports[`Dropdown matches snapshot for tab hidden (closed) 1`] = `
 
 <div
   className="c0 c1"
+  tabIndex={0}
 >
   <button
     className="c2 c3"
@@ -445,6 +446,7 @@ exports[`Dropdown matches snapshot for tab hidden (open) 1`] = `
 
 <div
   className="c0 c1"
+  tabIndex={0}
 >
   <button
     className="c2 c3"

--- a/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
+++ b/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
@@ -256,6 +256,7 @@ exports[`Filters matches snapshot 1`] = `
 >
   <div
     className="c1 c2 c3"
+    tabIndex={0}
   >
     <button
       className="c4 c5 c6 c7"
@@ -282,6 +283,7 @@ exports[`Filters matches snapshot 1`] = `
   </div>
   <div
     className="c1 c2 c3"
+    tabIndex={0}
   >
     <button
       className="c4 c5 c6 c7"

--- a/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
+++ b/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
@@ -256,7 +256,7 @@ exports[`Filters matches snapshot 1`] = `
 >
   <div
     className="c1 c2 c3"
-    tabIndex={0}
+    tabIndex={-1}
   >
     <button
       className="c4 c5 c6 c7"
@@ -283,7 +283,7 @@ exports[`Filters matches snapshot 1`] = `
   </div>
   <div
     className="c1 c2 c3"
-    tabIndex={0}
+    tabIndex={-1}
   >
     <button
       className="c4 c5 c6 c7"

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -210,5 +210,5 @@ export const onEscHandler = (element: React.RefObject<HTMLElement>, isEnabled: b
 };
 
 export const useOnEsc = (element: React.RefObject<HTMLElement>, isEnabled: boolean, cb: () => void) => {
-  React.useEffect(onEscHandler(element, isEnabled, cb), [element, isEnabled, cb]);
+  React.useEffect(onEscHandler(element, isEnabled, cb), [element, isEnabled]);
 };


### PR DESCRIPTION
When clicking on a child of dropdown focus is moved to this child and when we click `Escape` it is hiding, but the focus is lost which disturbs how ESC events are working.
This pr is setting focus on the main dropdown component after it is closed with ESC.

PS. Actually probably using `useDrawFocus` hook would be sufficient. I don't remember on which pr it was implemented.