### PR TITLE
fix: always update totals when deleting highlight, not only if it is loaded in summary

### DIFF
--- a/src/app/content/highlights/reducer.ts
+++ b/src/app/content/highlights/reducer.ts
@@ -11,12 +11,12 @@ import { highlightingFeatureFlag, highlightStyles } from './constants';
 import { State } from './types';
 import {
   addToTotalCounts,
-  getHighlightByIdFromSummaryHighlights,
   removeFromTotalCounts,
   removeSummaryHighlight,
   updateInTotalCounts,
   updateSummaryHighlightsDependOnFilters
 } from './utils';
+import { findHighlight } from './utils/reducerUtils';
 
 const defaultColors = highlightStyles.map(({label}) => label);
 export const initialState: State = {
@@ -75,11 +75,11 @@ const reducer: Reducer<State, AnyAction> = (state = initialState, action) => {
     case getType(actions.closeMyHighlights):
       return {...state, myHighlightsOpen: false};
     case getType(actions.updateHighlight): {
-      if (!state.highlights) { return state; }
+      const oldHighlight = findHighlight(state, action.payload.id);
 
-      const oldHighlight = state.highlights.find((highlight) => highlight.id === action.payload.id)
-        || getHighlightByIdFromSummaryHighlights(state.summary.highlights || {}, action.payload.id);
-      if (!oldHighlight) { return state; }
+      if (!state.highlights || !oldHighlight) {
+        return state;
+      }
 
       const newHighlight = {
         ...oldHighlight,
@@ -115,20 +115,22 @@ const reducer: Reducer<State, AnyAction> = (state = initialState, action) => {
       };
     }
     case getType(actions.deleteHighlight): {
-      if (!state.highlights) {
+      const highlightToRemove = findHighlight(state, action.payload);
+
+      if (!state.highlights || !highlightToRemove) {
         return state;
       }
 
-      const [newSummaryHighlights, removedHighlight] = state.summary.highlights
+      const newSummaryHighlights = state.summary.highlights
         ? removeSummaryHighlight(state.summary.highlights, {
           ...action.meta,
           id: action.payload,
         })
-        : [state.summary.highlights, null]
+        : state.summary.highlights
       ;
 
-      const totalCountsPerPage = state.summary.totalCountsPerPage && removedHighlight
-        ? removeFromTotalCounts(state.summary.totalCountsPerPage, removedHighlight)
+      const totalCountsPerPage = state.summary.totalCountsPerPage && highlightToRemove
+        ? removeFromTotalCounts(state.summary.totalCountsPerPage, highlightToRemove)
         : state.summary.totalCountsPerPage
       ;
 

--- a/src/app/content/highlights/utils/reducerUtils.ts
+++ b/src/app/content/highlights/utils/reducerUtils.ts
@@ -1,0 +1,7 @@
+import { State } from '../types';
+import { getHighlightByIdFromSummaryHighlights } from './summaryHighlightsUtils';
+
+export const findHighlight = (state: State, id: string) => {
+  return (state.highlights || []).find((highlight) => highlight.id === id)
+    || getHighlightByIdFromSummaryHighlights(state.summary.highlights || {}, id);
+};

--- a/src/app/content/highlights/utils/summaryHighlightsUtils.spec.ts
+++ b/src/app/content/highlights/utils/summaryHighlightsUtils.spec.ts
@@ -177,7 +177,7 @@ describe('removeSummaryHighlight', () => {
       id: highlight.id,
       locationFilterId: 'location',
       pageId: 'page',
-    })[0]).toMatchObject(expectedResult);
+    })).toMatchObject(expectedResult);
   });
 
   it('remove highlight and page if it does not have more highlights', () => {
@@ -198,7 +198,7 @@ describe('removeSummaryHighlight', () => {
       id: highlight.id,
       locationFilterId: 'location',
       pageId: 'page',
-    })[0]).toMatchObject(expectedResult);
+    })).toMatchObject(expectedResult);
   });
 
   it('remove highlight, page and location if it does not have more highlights', () => {

--- a/src/app/content/highlights/utils/summaryHighlightsUtils.ts
+++ b/src/app/content/highlights/utils/summaryHighlightsUtils.ts
@@ -120,7 +120,7 @@ interface DataRemove extends BaseData {
 export const removeSummaryHighlight = (
   summaryHighlights: SummaryHighlights,
   data: DataRemove
-): [SummaryHighlights, Highlight | null] => {
+): SummaryHighlights => {
   const { locationFilterId, pageId, id } = data;
 
   const pageHighlights: Highlight[] | undefined =
@@ -132,7 +132,7 @@ export const removeSummaryHighlight = (
   const removedHighlight = removedHighlights[0];
 
   if (!filteredHighlights || !removedHighlight) {
-    return [summaryHighlights, null];
+    return summaryHighlights;
   }
 
   const newHighlights: SummaryHighlights = {
@@ -150,7 +150,7 @@ export const removeSummaryHighlight = (
     delete newHighlights[locationFilterId];
   }
 
-  return [newHighlights, removedHighlight];
+  return newHighlights;
 };
 
 interface DataUpdate extends BaseData, UpdateHighlightRequest {}
@@ -210,7 +210,7 @@ export const updateSummaryHighlightsDependOnFilters = (
       id: updatedHighlight.id,
       locationFilterId,
       pageId,
-    })[0];
+    });
   }
 
   // If color is in filters and highlight was already in summary highlights


### PR DESCRIPTION
fixes the first issue of https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/806#issuecomment-589182224