### PR TITLE
allow setting the archive url via query param

### DIFF
--- a/src/config.development.js
+++ b/src/config.development.js
@@ -1,7 +1,16 @@
+const query = require('query-string');
+
+const REACT_APP_ARCHIVE_URL = typeof(window) === 'undefined'
+  ? undefined
+  : query.parse(window.location.search).archive
+;
+
 module.exports = {
   RELEASE_ID: 'development',
   CODE_VERSION: 'development',
   DEPLOYED_ENV: 'development',
+
+  REACT_APP_ARCHIVE_URL: REACT_APP_ARCHIVE_URL || '',
 
   ACCOUNTS_URL: process.env.ACCOUNTS_URL || 'https://accounts-dev.openstax.org',
   OS_WEB_URL: process.env.OS_WEB_URL || 'https://cms-dev.openstax.org',


### PR DESCRIPTION
for: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/122

allowing you to use urls like `/books/55af40d6-34da-4649-9780-b1760d6e9dfc@latest/pages/preface?archive=https://archive-content02.cnx.org`

this is super quick and dirty because nobody knows how long we're even going to be using multiple content servers, but this should help with testing for now