### PR TITLE
fix: Prealgebra should no longer link to 1st edition

### DIFF
--- a/src/config.books.js
+++ b/src/config.books.js
@@ -23,7 +23,7 @@ const books = {
   /* Introductory Statistics */ '30189442-6998-4686-ac05-ed152b91b9de': {defaultVersion: '24.1'},
   /* Microbiology */ 'e42bd376-624b-4c0f-972f-e0c57998e765': {defaultVersion: '8.6'},
   /* Organizational Behavior */ '2d941ab9-ac5b-4eb8-b21c-965d36a4f296': {defaultVersion: '7.2'},
-  /* Precalgebra 2e */ 'f0fa90be-fca8-43c9-9aad-715c0a2cee2b': {defaultVersion: '3.6'},
+  /* Prealgebra 2e */ 'f0fa90be-fca8-43c9-9aad-715c0a2cee2b': {defaultVersion: '6.2'},
   /* Precalculus */ 'fd53eae1-fa23-47c7-bb1b-972349835c3c': {defaultVersion: '13.30'},
   /* Principles of Accounting Vol 1 */ '9ab4ba6d-1e48-486d-a2de-38ae1617ca84': {defaultVersion: '5.2'},
   /* Principles of Accounting Vol 2 */ '920d1c8a-606c-4888-bfd4-d1ee27ce1795': {defaultVersion: '15.1'},


### PR DESCRIPTION
https://legacy.cnx.org/content/m81304/1.5/#fs-id4163622 contained a link in a title which pointed to a page in the 1st edition.

[Slack Chat](https://openstax.slack.com/archives/C0FU3MARF/p1583272886130300)


for: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/885

