### PR TITLE
Fix resources dynamic archive

### DIFF
--- a/src/app/content/components/Page/PageComponent.tsx
+++ b/src/app/content/components/Page/PageComponent.tsx
@@ -31,14 +31,17 @@ export default class PageComponent extends Component<PagePropTypes> {
   private scrollTargetManager = stubScrollTargetManager;
   private processing: Promise<void> = Promise.resolve();
 
-  public getTrasnformedContent = () => {
+  public getTransformedContent = () => {
     const {book, page, services} = this.props;
-    const cleanContent = parser.parseFromString(
-      getCleanContent(book, page, services.archiveLoader, contentLinks.reduceReferences(this.props.contentLinks)),
-      'text/html'
+
+    const cleanContent = getCleanContent(book, page, services.archiveLoader,
+      contentLinks.reduceReferences(this.props.contentLinks)
     );
-    transformContent(cleanContent, cleanContent.body, this.props.intl);
-    return cleanContent.body.innerHTML;
+    const parsedContent = parser.parseFromString(cleanContent, 'text/html');
+
+    transformContent(parsedContent, parsedContent.body, this.props.intl);
+
+    return parsedContent.body.innerHTML;
   };
 
   public componentDidMount() {
@@ -94,7 +97,7 @@ export default class PageComponent extends Component<PagePropTypes> {
   }
 
   private renderContent = () => {
-    const html = this.getTrasnformedContent() || this.getPrerenderedContent();
+    const html = this.getTransformedContent() || this.getPrerenderedContent();
 
     return <PageContent
       key='main-content'

--- a/src/app/content/components/Page/contentDOMTransformations.ts
+++ b/src/app/content/components/Page/contentDOMTransformations.ts
@@ -1,5 +1,6 @@
-import { Document, HTMLButtonElement, HTMLElement } from '@openstax/types/lib.dom';
+import { Document, HTMLButtonElement, HTMLElement, HTMLImageElement } from '@openstax/types/lib.dom';
 import { IntlShape } from 'react-intl';
+import { REACT_APP_ARCHIVE_URL } from '../../../../config';
 import { assertNotNull } from '../../../utils';
 
 // from https://github.com/openstax/webview/blob/f95b1d0696a70f0b61d83a85c173102e248354cd
@@ -11,6 +12,7 @@ export const transformContent = (document: Document, rootEl: HTMLElement, intl: 
   tweakFigures(rootEl);
   fixLists(rootEl);
   wrapSolutions(rootEl, intl);
+  prefixResources(rootEl);
 };
 
 const toggleSolutionAttributes = (solution: HTMLElement, intl: IntlShape) => {
@@ -116,4 +118,10 @@ function wrapSolutions(rootEl: HTMLElement, intl: IntlShape) {
       <section class="ui-body" role="alert">${contents}</section>
     `;
   });
+}
+
+function prefixResources(rootEl: HTMLElement) {
+  rootEl.querySelectorAll<HTMLImageElement>('img[src^="/resources/"]').forEach(
+    (el) => el.src = REACT_APP_ARCHIVE_URL + el.getAttribute('src')
+  );
 }

--- a/src/app/content/utils/getCleanContent.ts
+++ b/src/app/content/utils/getCleanContent.ts
@@ -1,21 +1,20 @@
+import identity from 'lodash/fp/identity';
 import createArchiveLoader from '../../../gateways/createArchiveLoader';
 import { Book, Page } from '../types';
 
-function ident(x: string) { return x; }
-
 export default function getCleanContent(
-    book: Book | undefined,
-    page: Page | undefined,
-    archiveLoader: ReturnType<typeof createArchiveLoader>,
-    reducer = ident) {
-
+  book: Book | undefined,
+  page: Page | undefined,
+  archiveLoader: ReturnType<typeof createArchiveLoader>,
+  transformer: (content: string) => string = identity
+) {
   const cachedPage = book && page &&
     archiveLoader.book(book.id, book.version).page(page.id).cached()
   ;
 
   const pageContent = cachedPage ? cachedPage.content : '';
 
-  return reducer(pageContent)
+  return transformer(pageContent)
     // remove body and surrounding content
     .replace(/^[\s\S]*<body.*?>|<\/body>[\s\S]*$/g, '')
     // fix assorted self closing tags


### PR DESCRIPTION
for: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/897

when archive was set dynamically, such as on `/books/4dd6fbe2-bbc4-4e67-8e5e-760bf0803bc5@9.1/pages/1-6-your-safety/?archive=https://archive-content03.cnx.org` the resources would try to load via the original proxy, and might not have existed there. this change makes the resources use the react archive url if its set.