### PR TITLE
Fix margin for key-equations sections in MH

### DIFF
--- a/generic-styles/index.less
+++ b/generic-styles/index.less
@@ -116,3 +116,9 @@ body {
       margin: 0;
   }
 }
+
+.summary-highlight-content {
+  > section {
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
for: https://github.com/openstax/unified/issues/913 and https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/912

This was about `margin-top` for `section`s like those in https://localhost:3000/books/calculus-volume-1/pages/1-key-equations

Those are not the same in the MH and in the content because selector is `#main-content, .summary... > section` and in the content, they are wrapped with an additional `div` which prevent `margin-top` to be added.