### PR TITLE
All <dt> tags should be bold in .summary-highlight-content

### DIFF
--- a/generic-styles/index.less
+++ b/generic-styles/index.less
@@ -116,3 +116,9 @@ body {
       margin: 0;
   }
 }
+
+.summary-highlight-content {
+  dt {
+    font-weight: 700;
+  }
+}


### PR DESCRIPTION
for: https://github.com/openstax/unified/issues/911

Key terms in the content are wrapped with a `div` with a `.os-glossary-container` class that has styles for all `dt` inside of it. However, when we highlight them, this div is gone so key terms in the MH do not have bold style.

Quick search using Elefind: https://content-finder.herokuapp.com/?books=all&element=dt shows that `<dt>` exists only in "Key terms" or "Glossary" sections and is applied only for key terms so I think it is safe to apply this style as:
```
.summary-highlight-content {
  dt {
    font-weight: 700;
  }
}
```