### PR TITLE
Update highlight tests

### DIFF
--- a/pytest-selenium/tests/test_highlighting_36.py
+++ b/pytest-selenium/tests/test_highlighting_36.py
@@ -1,5 +1,6 @@
 """Reading Experience highlighting."""
-
+# fmt: off
+# flake8: noqa
 import logging
 import random
 import re
@@ -123,7 +124,7 @@ def test_highlighting_different_content(
     total_highlight_count = book.content.highlight_ids
 
     # WHEN: the page is refreshed
-    book = book.reload(True)
+    book = book.reload()
 
     # THEN: all of the preceding highlights should still be highlighted
     current_highlights = book.content.highlight_ids
@@ -1592,3 +1593,4 @@ def test_change_color_of_highlighted_text(
 @markers.skip_test(reason="not prioritized")
 def test_create_note_box_position_and_size_for_long_notes():
     """Verify the create note box position for long notes."""
+# fmt: on

--- a/pytest-selenium/tests/test_highlighting_39.py
+++ b/pytest-selenium/tests/test_highlighting_39.py
@@ -1,5 +1,5 @@
 """Reading Experience highlighting."""
-
+# fmt: off
 import random
 
 import pytest
@@ -78,7 +78,6 @@ def test_keyboard_navigation_for_my_highlights_button_on_content_page(
     assert(book.my_highlights.root.is_displayed()), \
         "My Highlights modal not displayed"
 
-    ''' *** Accessibility feature for a later date ***
     # WHEN: they hit the escape key
     (ActionChains(selenium)
         .send_keys(Keys.ESCAPE)
@@ -86,7 +85,7 @@ def test_keyboard_navigation_for_my_highlights_button_on_content_page(
 
     # THEN: the My Highlights and Notes modal is closed
     assert(not book.my_highlights_open), \
-        "My Highlights modal is still open"'''
+        "My Highlights modal is still open"
 
 
 @markers.test_case("C592629")
@@ -353,3 +352,4 @@ def test_note_indicator_added_when_highlight_without_a_note_has_a_note_added(
     # THEN: the note indicator is present on the highlight
     assert(selenium.execute_script(HAS_INDICATOR, highlight)), \
         "indicator not found after adding a note"
+# fmt: on


### PR DESCRIPTION
for: https://github.com/openstax/unified/issues/959

1. The bug for [Math highlighting doesn't show after reload](https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/762) is fixed. So removing the force math reload check in first test of highlighting_36 test suite

2. Esc key on MH page works now. So uncommenting corresponding code (https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/814)