### PR TITLE
FE Selenium test: Login state while redirected from openstax.org 

### DIFF
--- a/pytest-selenium/pages/base.py
+++ b/pytest-selenium/pages/base.py
@@ -199,3 +199,8 @@ class Page(pypom.Page):
 
         self.driver.execute_script('window.open("","_blank");')
         self.wait.until(lambda b: len(b.window_handles) != 1)
+
+    def username(self, element):
+        """Get the username of a logged in user."""
+
+        return element.get_attribute("textContent")

--- a/pytest-selenium/pages/content.py
+++ b/pytest-selenium/pages/content.py
@@ -1456,6 +1456,10 @@ class Content(Page):
             return self.find_element(*self._login_locator)
 
         @property
+        def user_nav_toggle(self):
+            return self.find_element(*self._user_nav_toggle_locator)
+
+        @property
         def user_is_not_logged_in(self) -> bool:
             try:
                 self.wait.until(expected.visibility_of_element_located(self._login_locator))

--- a/pytest-selenium/pages/osweb.py
+++ b/pytest-selenium/pages/osweb.py
@@ -79,8 +79,7 @@ class WebBase(Page):
     def view_online(self):
         if self.is_desktop:
             return self.find_element(*self._view_online_desktop_locator)
-        elif self.is_mobile:
-            return self.find_element(*self._view_online_mobile_locator)
+        return self.find_element(*self._view_online_mobile_locator)
 
     def open_toggle(self):
         """Click the toggle to open the menu."""

--- a/pytest-selenium/pages/osweb.py
+++ b/pytest-selenium/pages/osweb.py
@@ -10,9 +10,18 @@ class WebBase(Page):
     URL_TEMPLATE = "/details/books/{book_slug}"
     _async_hide_locator = (By.CSS_SELECTOR, ".async-hide")
     _user_nav_locator = (By.CSS_SELECTOR, '[class*="login-menu"]')
+    _login_locator = (By.CSS_SELECTOR, '[class="pardotTrackClick"]')
     _logout_locator = (By.CSS_SELECTOR, "[href*=logout]")
     _mobile_user_nav_locator = (By.CSS_SELECTOR, '[aria-label="Toggle Meta Navigation Menu"]')
     _mobile_user_nav_loaded_locator = (By.CSS_SELECTOR, '[aria-expanded="true"]')
+    _view_online_desktop_locator = (
+        By.XPATH,
+        "//div[@class='bigger-view']//span[text()='View online']/..",
+    )
+    _view_online_mobile_locator = (
+        By.XPATH,
+        "//div[@class='phone-view']//span[text()='View online']/..",
+    )
 
     @property
     def loaded(self):
@@ -31,6 +40,10 @@ class WebBase(Page):
 
     def wait_for_load(self):
         return self.wait.until(lambda _: self.loaded)
+
+    @property
+    def login(self):
+        return self.find_element(*self._login_locator)
 
     @property
     def user_nav(self):
@@ -62,6 +75,13 @@ class WebBase(Page):
                 )
                 return True
 
+    @property
+    def view_online(self):
+        if self.is_desktop:
+            return self.find_element(*self._view_online_desktop_locator)
+        elif self.is_mobile:
+            return self.find_element(*self._view_online_mobile_locator)
+
     def open_toggle(self):
         """Click the toggle to open the menu."""
         toggle = self.find_element(*self._user_nav_locator)
@@ -72,6 +92,13 @@ class WebBase(Page):
         target = self.find_element(*locator)
         Utilities.click_option(self.driver, element=target)
 
+    def click_login(self):
+        if self.is_desktop:
+            self.login.click()
+        elif self.is_mobile:
+            self.click_mobile_user_nav()
+            self.login.click()
+
     def click_logout(self):
         if self.is_desktop:
             self.open_toggle()
@@ -81,3 +108,14 @@ class WebBase(Page):
             Utilities.click_option(self.driver, element=self.user_nav)
             Utilities.click_option(self.driver, element=self.logout)
         self.wait_for_load()
+
+    def click_view_online(self):
+        self.offscreen_click(self.view_online)
+
+    def click_mobile_user_nav(self):
+        self.offscreen_click(self.mobile_user_nav)
+
+    def osweb_username(self, element):
+        """Get the username of the logged in user."""
+        element1 = self.username(element)
+        return " ".join(element1.split()[:2])

--- a/pytest-selenium/pages/osweb.py
+++ b/pytest-selenium/pages/osweb.py
@@ -93,11 +93,9 @@ class WebBase(Page):
         Utilities.click_option(self.driver, element=target)
 
     def click_login(self):
-        if self.is_desktop:
-            self.login.click()
-        elif self.is_mobile:
+        if self.is_mobile:
             self.click_mobile_user_nav()
-            self.login.click()
+        self.login.click()
 
     def click_logout(self):
         if self.is_desktop:


### PR DESCRIPTION
Given: User is logged into {base_url}
When: user clicks 'view online' option for a book that is available in REX 
Then: the book is opened in REX with the header showing <Hi {firstname}> with the same user as openstax.org
And: the user stays logged-in while navigating to other pages in REX

For: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/1051