### PR TITLE
set executable on url checker script

### DIFF
--- a/concourse/verify-production-urls/script.bash
+++ b/concourse/verify-production-urls/script.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 production_url=https://openstax.org


### PR DESCRIPTION
the shebang is whatever but it needed the executable flag set on the file

for: openstax/unified#1050