### PR TITLE
short circuit sanitization logic when prerendered

### DIFF
--- a/src/app/content/components/Page/PageComponent.tsx
+++ b/src/app/content/components/Page/PageComponent.tsx
@@ -45,6 +45,11 @@ export default class PageComponent extends Component<PagePropTypes, PageState> {
     const {book, page, services} = this.props;
 
     const cleanContent = getCleanContent(book, page, services.archiveLoader);
+
+    if (!cleanContent) {
+      return '';
+    }
+
     const parsedContent = parser.parseFromString(cleanContent, 'text/html');
     contentLinks.reduceReferences(parsedContent, this.props.contentLinks);
 


### PR DESCRIPTION
the follownig logic here used to noop and produce an empty string but the changes made in #1025 are now throwing when the content is empty.

its legitimate for the content to be empty when the page is pre-rendered, but there is also no reason to run all that logic on an empty string so this should work probably

for: openstax/unified#1230

