### PR TITLE
wip - add highlight debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@formatjs/intl-pluralrules": "^1.1.2",
-    "@openstax/highlighter": "1.6.1",
+    "@openstax/highlighter": "1.6.3",
     "@openstax/open-search-client": "0.1.0",
     "@sentry/browser": "^5.6.1",
     "@sentry/integrations": "^5.6.1",

--- a/src/config.development.js
+++ b/src/config.development.js
@@ -29,7 +29,7 @@ module.exports = {
 
   ACCOUNTS_URL: process.env.ACCOUNTS_URL || 'https://accounts-dev.openstax.org',
   OS_WEB_URL: process.env.OS_WEB_URL || 'https://cms-dev.openstax.org',
-  HIGHLIGHTS_URL: 'https://highlights-HL-3e9d314.sandbox.openstax.org',
+  HIGHLIGHTS_URL: 'https://highlights-hl-d4179a7.sandbox.openstax.org',
 
   SKIP_OS_WEB_PROXY: process.env.SKIP_OS_WEB_PROXY !== undefined,
   FIXTURES: false,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -103,3 +103,18 @@ serviceWorker.register()
   .catch((e) => {
     Sentry.captureException(e);
   });
+
+(window as any).__DEBUG_HIGHLIGHT = async(id: string) => {
+  const data = await window.__APP_SERVICES.highlightClient.getHighlight({id});
+  const path = `/books/${data.scopeId}@latest/pages/${data.sourceId}`;
+  window.__APP_SERVICES.history.push(path, {});
+
+  // not sure if this is required or not, the highlights seem to be loading
+  // with it here, but it might be bypassing some race condition that caused
+  // the user issues
+  await window.__APP_SERVICES.promiseCollector.calm();
+
+  window.__APP_STORE.dispatch(
+    {type: 'Content/Highlights/receive', payload: {highlights: [data], pageId: data.sourceId}}
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,20 +1767,20 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@openstax/highlighter@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@openstax/highlighter/-/highlighter-1.6.1.tgz#715bb7e08fec53416d6397b2f09c0e57fe1e325a"
-  integrity sha512-U3ceVLmMyV5cdfLLaOBPGIKFqvXAh0UCMRdDTIhsxL8Q9j6uEqxY4tjihYYkiV2cXx3o9q8XYqYgT0Jahjli1g==
+"@openstax/highlighter@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@openstax/highlighter/-/highlighter-1.6.3.tgz#e265293efd90bfc485da4b86bd04b389f5c52e63"
+  integrity sha512-CpQ9EIICfCGQeyglPcMyw5R9Eq+B3mLa0hSdRlEHzwzk1ecfbesTjC2GPkmoyP3XIOMEvwKOjxia7EdM7R4vQw==
   dependencies:
-    "@openstax/highlights-client" "0.2.1"
+    "@openstax/highlights-client" "0.2.2"
     change-case "^4.0.0"
     serialize-selection "^1.1.1"
     uuid "^3.3.3"
 
-"@openstax/highlights-client@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@openstax/highlights-client/-/highlights-client-0.2.1.tgz#cd79e69046150012e1fa3c0c9bf79ba8432442f0"
-  integrity sha512-9evi36UcJ1ke8TeyGOgSYWFq1V5rX82st/QjT0Bl7x8rxt5Xo8x8vNuq9oC1rexAkJl6CF00FJx4aRdpKzw01A==
+"@openstax/highlights-client@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@openstax/highlights-client/-/highlights-client-0.2.2.tgz#093272a3066e4c10ad0e260e698ff59b1af02544"
+  integrity sha512-9Y8fz9D0injJde1f122AYOs6eQlo73tZuenuIJkiIHwterZUC+hgbHEhmJU2U5ZHgnuq3nTRmEw57SMWRXja8A==
 
 "@openstax/open-search-client@0.1.0":
   version "0.1.0"


### PR DESCRIPTION
adds a helper that takes a highlight id, loads it, navigates to the correct page, and injects it into the highlight state, causing it to be highlighted on the page.

```
__DEBUG_HIGHLIGHT('0a2176d3-f85e-46ba-8f2e-594ca2057b7b')
```