### PR TITLE
Limit archive cache

### DIFF
--- a/script/prerender/contentPages.tsx
+++ b/script/prerender/contentPages.tsx
@@ -113,9 +113,10 @@ export const getStats = () => {
 };
 
 type MakeRenderPage = (services: AppOptions['services']) =>
-  (action: AnyMatch, expectedCode: number) => Promise<void>;
-const makeRenderPage: MakeRenderPage = (services) => async(action, expectedCode) => {
-  const {app, styles, state, url} = await prepareApp(services, action, expectedCode);
+  ({code, page}: {page: AnyMatch, code: number}) => Promise<void>;
+
+const makeRenderPage: MakeRenderPage = (services) => async({code, page}) => {
+  const {app, styles, state, url} = await prepareApp(services, page, code);
   console.info(`rendering ${url}`); // tslint:disable-line:no-console
   const html = await renderHtml(styles, app, state);
 
@@ -131,7 +132,10 @@ const makeRenderPage: MakeRenderPage = (services) => async(action, expectedCode)
 export const prepareBooks = async(
   archiveLoader: AppServices['archiveLoader'],
   osWebLoader: AppServices['osWebLoader']
-): Promise<Array<{book: BookWithOSWebData, loader: ReturnType<AppServices['archiveLoader']['book']>}>> => {
+): Promise<Array<{
+  book: BookWithOSWebData,
+  loader: ReturnType<AppServices['archiveLoader']['book']>
+}>> => {
   return Promise.all(Object.entries(BOOKS).map(async([bookId, {defaultVersion}]) => {
     const bookLoader = makeUnifiedBookLoader(archiveLoader, osWebLoader);
 
@@ -180,7 +184,7 @@ type RenderPages = (
 ) => Promise<void>;
 export const renderPages: RenderPages = async(services, pages) => {
   const renderPage = makeRenderPage(services);
-  await asyncPool(50, pages, ({code, page}) => renderPage(page, code));
+  await asyncPool(50, pages, renderPage);
 };
 
 interface Options {

--- a/script/prerender/index.ts
+++ b/script/prerender/index.ts
@@ -12,7 +12,6 @@
  */
 import * as fs from 'fs';
 import ignoreStyles, { DEFAULT_EXTENSIONS, noOp } from 'ignore-styles';
-import { JSDOM } from 'jsdom';
 import md5File from 'md5-file';
 import mime from 'mime';
 import * as path from 'path';
@@ -45,8 +44,6 @@ ignoreStyles(DEFAULT_EXTENSIONS, (mod, filename) => {
     }
   }
 });
-
-(global as any).DOMParser = new JSDOM().window.DOMParser;
 
 // tslint:disable-next-line:no-var-requires for some reason this doesn't work as an import
 require('./prerender');

--- a/script/prerender/prerender.tsx
+++ b/script/prerender/prerender.tsx
@@ -49,6 +49,7 @@ async function render() {
   const renderHelpers = {archiveLoader, osWebLoader, userLoader, searchClient, highlightClient};
 
   const books = await prepareBooks(archiveLoader, osWebLoader);
+
   for (const {loader, book} of books) {
     const bookPages = await prepareBookPages(loader, book);
 

--- a/src/helpers/createCache.spec.ts
+++ b/src/helpers/createCache.spec.ts
@@ -1,0 +1,49 @@
+import createCache from './createCache';
+
+describe('create cache', () => {
+
+  it('sets and gets things to cache', () => {
+    const cache = createCache<string, {[key: string]: string}>();
+    const thing = {asdf: 'qwer'};
+    cache.set('somekey', thing);
+
+    expect(cache.get('somekey')).toBe(thing);
+  });
+
+  it('removes things to cache when it reaches max size', () => {
+    const cache = createCache<string, {[key: string]: string}>({maxRecords: 1});
+    const thing1 = {asdf: 'qwer1'};
+    cache.set('somekey1', thing1);
+
+    expect(cache.get('somekey1')).toBe(thing1);
+
+    const thing2 = {asdf: 'qwer2'};
+    cache.set('somekey2', thing2);
+
+    expect(cache.get('somekey2')).toBe(thing2);
+
+    expect(cache.get('somekey1')).toBe(undefined);
+  });
+
+  it('doesn\'t removes things until it reaches max size', () => {
+    const cache = createCache<string, {[key: string]: string}>({maxRecords: 2});
+
+    const thing1 = {asdf: 'qwer1'};
+    cache.set('somekey1', thing1);
+
+    expect(cache.get('somekey1')).toBe(thing1);
+
+    const thing2 = {asdf: 'qwer2'};
+    cache.set('somekey2', thing2);
+
+    expect(cache.get('somekey2')).toBe(thing2);
+    expect(cache.get('somekey1')).toBe(thing1);
+
+    const thing3 = {asdf: 'qwer3'};
+    cache.set('somekey3', thing3);
+
+    expect(cache.get('somekey3')).toBe(thing3);
+    expect(cache.get('somekey2')).toBe(thing2);
+    expect(cache.get('somekey1')).toBe(undefined);
+  });
+});

--- a/src/helpers/createCache.ts
+++ b/src/helpers/createCache.ts
@@ -1,0 +1,23 @@
+interface Options {
+  maxRecords?: number;
+}
+
+const get = <K, V>(_options: Options, cache: Map<K, V>) => (key: K) => {
+  return cache.get(key);
+};
+
+const set = <K, V>(options: Options, cache: Map<K, V>) => (key: K, value: V) => {
+  if (options.maxRecords && cache.size >= options.maxRecords && cache.size >= 1) {
+    cache.delete(cache.keys().next().value);
+  }
+
+  return cache.set(key, value);
+};
+
+export default <K, V>(options: Options = {}) => {
+  const cache = new Map<K, V>();
+  return {
+    get: get(options, cache),
+    set: set(options, cache),
+  };
+};


### PR DESCRIPTION
this will hopefully fix the prerender failing due to very large books. my theory is that holding all the book pages in memory is the issue since there is an archive loader outside the individual app created for each page that is used for all pages in all books

for: openstax/unified#1359