### PR TITLE
ok really fix the build this time

### DIFF
--- a/script/prerender/contentPages.tsx
+++ b/script/prerender/contentPages.tsx
@@ -158,7 +158,7 @@ export const prepareBookPages = (book: BookWithOSWebData) => asyncPool(20, findT
 
 export const renderPages = async(services: AppOptions['services'], pages: Pages) => {
   const renderPage = makeRenderPage(services);
-  return await asyncPool(50, pages, renderPage);
+  return await asyncPool(10, pages, renderPage);
 };
 
 interface Options {


### PR DESCRIPTION
the loader is still shared between all renders so the 50 concurrency being less than the 20 cache limit was making some of them fall out of cache while rendering

for: openstax/unified#1359