### PR TITLE
add separate page and book caches and reduce concurrency in prerender

### DIFF
--- a/script/prerender/contentPages.tsx
+++ b/script/prerender/contentPages.tsx
@@ -163,7 +163,7 @@ export const prepareBookPages = (book: BookWithOSWebData) => asyncPool(20, findT
 
 export const renderPages = async(services: AppOptions['services'], pages: Pages) => {
   const renderPage = makeRenderPage(services);
-  return await asyncPool(10, pages, renderPage);
+  return await asyncPool(5, pages, renderPage);
 };
 
 interface Options {

--- a/src/helpers/createCache.ts
+++ b/src/helpers/createCache.ts
@@ -2,11 +2,16 @@ interface Options {
   maxRecords?: number;
 }
 
-const get = <K, V>(_options: Options, cache: Map<K, V>) => (key: K) => {
+export interface Cache<K, V> {
+  get: (key: K) => V | undefined;
+  set: (key: K, value: V) => void;
+}
+
+const get = <K, V>(_options: Options, cache: Map<K, V>): Cache<K, V>['get'] => (key) => {
   return cache.get(key);
 };
 
-const set = <K, V>(options: Options, cache: Map<K, V>) => (key: K, value: V) => {
+const set = <K, V>(options: Options, cache: Map<K, V>): Cache<K, V>['set'] => (key, value) => {
   if (options.maxRecords && cache.size >= options.maxRecords && cache.size >= 1) {
     cache.delete(cache.keys().next().value);
   }
@@ -14,7 +19,7 @@ const set = <K, V>(options: Options, cache: Map<K, V>) => (key: K, value: V) => 
   return cache.set(key, value);
 };
 
-export default <K, V>(options: Options = {}) => {
+export default <K, V>(options: Options = {}): Cache<K, V> => {
   const cache = new Map<K, V>();
   return {
     get: get(options, cache),


### PR DESCRIPTION
so i noticed a lot of the failures were on loading books, which we have fewer of and are referenced on every page, so it makes sense to cache those separately

pages are mostly only used for the current render, so they can drop out of cache after and its fine.

reduce concurrency because i think the archive connection issues might be a local load issue, when i ran the script locally it made it a lot farther than the concourse job until i eventually stopped it manually

for: openstax/unified#1359