### PR TITLE
FE selenium tests: fix test failures and 404 error tests

### DIFF
--- a/pytest-selenium/pages/content.py
+++ b/pytest-selenium/pages/content.py
@@ -53,9 +53,6 @@ class Content(Page):
     def loaded(self) -> bool:
         return bool(self.find_element(*self._body_locator).get_attribute("data-rex-loaded"))
 
-    def wait_for_load(self):
-        return self.wait.until(lambda _: self.loaded)
-
     @property
     def attribution(self) -> Content.Attribution:
         return self.Attribution(self)

--- a/pytest-selenium/pages/content.py
+++ b/pytest-selenium/pages/content.py
@@ -405,17 +405,20 @@ class Content(Page):
 
         @property
         def page_error_displayed(self) -> bool:
+            """Return true if rex 404 error is displayed"""
             return bool(self.wait.until(lambda _: self.find_element(*self._page_error_locator)))
 
         @property
         def page_error(self):
+            """Return the rex 404 error text"""
             return self.find_element(*self._page_error_locator).get_attribute("textContent")
 
         @property
-        def page_error_toc_button(self):
+        def page_error_toc_button(self) -> WebElement:
             return self.find_element(*self._page_error_toc_button_locator)
 
         def click_page_error_toc_button(self):
+            """Click the TOC icon in the rex 404 error page"""
             return Utilities.click_option(self.driver, element=self.page_error_toc_button)
 
         @property

--- a/pytest-selenium/pages/content.py
+++ b/pytest-selenium/pages/content.py
@@ -53,6 +53,9 @@ class Content(Page):
     def loaded(self) -> bool:
         return bool(self.find_element(*self._body_locator).get_attribute("data-rex-loaded"))
 
+    def wait_for_load(self):
+        return self.wait.until(lambda _: self.loaded)
+
     @property
     def attribution(self) -> Content.Attribution:
         return self.Attribution(self)
@@ -397,6 +400,23 @@ class Content(Page):
             ":not([data-bullet-style]):not([type]), "
             "p[id^='eip'], p[id^='import-auto']",
         )  # Phys
+        _page_error_locator = (By.CSS_SELECTOR, "[class*=PageNotFoundWrapper]")
+        _page_error_toc_button_locator = (By.CSS_SELECTOR, "[data-testid = toc-button]")
+
+        @property
+        def page_error_displayed(self) -> bool:
+            return bool(self.wait.until(lambda _: self.find_element(*self._page_error_locator)))
+
+        @property
+        def page_error(self):
+            return self.find_element(*self._page_error_locator).get_attribute("textContent")
+
+        @property
+        def page_error_toc_button(self):
+            return self.find_element(*self._page_error_toc_button_locator)
+
+        def click_page_error_toc_button(self):
+            return Utilities.click_option(self.driver, element=self.page_error_toc_button)
 
         @property
         def captions(self) -> List[WebElement]:

--- a/pytest-selenium/pages/osweb.py
+++ b/pytest-selenium/pages/osweb.py
@@ -29,9 +29,10 @@ class WebBase(Page):
     _dialog_locator = (By.CSS_SELECTOR, '[aria-labelledby="dialog-title"]')
     _dialog_title_locator = (By.CSS_SELECTOR, "#dialog-title")
     _got_it_button_locator = (By.CSS_SELECTOR, ".cookie-notice button")
-    _print_copy_locator = (By.CSS_SELECTOR, ".show-print-submenu")
+    _print_copy_locator = (By.XPATH, "//*[contains(text(), 'Order a print copy')]/..")
     _order_on_amazon_locator = (By.CSS_SELECTOR, '[class="btn primary"]')
     _close_locator = (By.CSS_SELECTOR, '[class="put-away"]')
+    _osweb_404_locator = (By.CSS_SELECTOR, '[class*="not-found"]')
 
     @property
     def loaded(self):
@@ -50,6 +51,15 @@ class WebBase(Page):
 
     def wait_for_load(self):
         return self.wait.until(lambda _: self.loaded)
+
+    def osweb_404_displayed(self) -> bool:
+        """Return true if osweb 404 error is displayed"""
+        return bool(self.wait.until(lambda _: self.find_element(*self._osweb_404_locator)))
+
+    @property
+    def osweb_404_error(self):
+        """Return the 404 error text"""
+        return self.find_element(*self._osweb_404_locator).get_attribute("textContent")
 
     @property
     def login(self):

--- a/pytest-selenium/regions/my_highlights.py
+++ b/pytest-selenium/regions/my_highlights.py
@@ -209,6 +209,9 @@ class MyHighlights(Region):
         """
         return not bool(self.find_elements(*self._loading_animation_locator))
 
+    def wait_for_load(self):
+        return self.wait.until(lambda _: self.loaded)
+
     @property
     def all_highlights(self) -> List[Highlight]:
         """Access the page highlights.

--- a/pytest-selenium/regions/my_highlights.py
+++ b/pytest-selenium/regions/my_highlights.py
@@ -209,9 +209,6 @@ class MyHighlights(Region):
         """
         return not bool(self.find_elements(*self._loading_animation_locator))
 
-    def wait_for_load(self):
-        return self.wait.until(lambda _: self.loaded)
-
     @property
     def all_highlights(self) -> List[Highlight]:
         """Access the page highlights.
@@ -572,7 +569,7 @@ class MyHighlights(Region):
         _chapter_locator = (By.XPATH, "//div[@data-testid='chapter-title']")
         _section_locator = (By.XPATH, "//div[@data-testid='section-title']")
         _no_results_message_locator = (By.CSS_SELECTOR, "[class*=GeneralTextWrapper]")
-        _highlight_locator = (By.CSS_SELECTOR, "[class*=summary-highlight]")
+        _highlight_locator = (By.CSS_SELECTOR, "[class*=content-excerpt]")
         _empty_state_nudge_locator = (By.CSS_SELECTOR, "[class*=MyHighlightsWrapper]")
 
         @property

--- a/pytest-selenium/tests/test_book.py
+++ b/pytest-selenium/tests/test_book.py
@@ -65,3 +65,50 @@ def test_order_print_copy(selenium, base_url, book_slug, page_slug):
             assert (
                 not rex.order_print_copy
             ), "amazon print option present in rex but not present in osweb"
+
+
+@markers.test_case("C613212")
+@markers.parametrize("page_slug", ["preface"])
+@markers.nondestructive
+def test_book_error(selenium, base_url, book_slug, page_slug):
+
+    # GIVEN: A page is loaded
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
+    book.wait_for_load()
+    toolbar = book.toolbar
+    sidebar = book.sidebar
+
+    from time import sleep
+
+    x = book.current_url
+    print(x)
+    y = "testing"
+    z = f"{x}{y}"
+    print(z)
+
+    selenium.get(z)
+
+    # book(selenium, base_url, book_slug=book_slug, page_slug="xfjfycj").open()
+    book.wait_for_load()
+
+    assert book.content.page_error_displayed
+    assert (
+        book.content.page_error
+        == "Uh oh, we can't find the page you requested.Try another page in theTable of contents"
+    )
+    sleep(3)
+
+    # AND TOC is displayed
+    if book.is_desktop:
+        sidebar.header.click_toc_toggle_button()
+        assert not sidebar.header.is_displayed
+
+        book.content.click_page_error_toc_button()
+
+    if book.is_mobile:
+        book.content.click_page_error_toc_button()
+
+        assert sidebar.header.is_displayed
+        toolbar.click_toc_toggle_button()
+    sleep(3)
+    # AND Links in TOC, citation, footer, navbar, toolbar, bookbanner all work as usual

--- a/pytest-selenium/tests/test_highlighting_47.py
+++ b/pytest-selenium/tests/test_highlighting_47.py
@@ -189,7 +189,6 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
         )
 
         my_highlights = book.toolbar.my_highlights()
-        my_highlights.wait_for_load()
         mh_highlight_ids = mh_highlight_ids + list(
             set(my_highlights.highlights.mh_highlight_ids) - set(mh_highlight_ids)
         )
@@ -211,7 +210,6 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
     x[1].remove_tag()
 
     my_highlights = book.toolbar.my_highlights()
-    my_highlights.wait_for_load()
     mh_filtered_list = my_highlights.highlights.mh_highlight_ids
     my_highlights.close()
 
@@ -221,7 +219,6 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
     toc.expand_chapter(2)
     toc.sections[14].click()
     my_highlights = book.toolbar.my_highlights()
-    my_highlights.wait_for_load()
     mh_list_from_chapter_with_highlights = my_highlights.highlights.mh_highlight_ids
 
     # THEN: Filter changes made earlier are retained
@@ -236,7 +233,6 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
     toc.sections[-40].click()
 
     my_highlights = book.toolbar.my_highlights()
-    my_highlights.wait_for_load()
     mh_list_from_chapter_without_highlights = my_highlights.highlights.mh_highlight_ids
 
     # THEN: Filter changes made earlier are retained
@@ -259,7 +255,6 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
 
     # THEN: The MH list is updated with the highlight from re-added chapter
     my_highlights = book.toolbar.my_highlights()
-    my_highlights.wait_for_load()
     mh_list_after_page_navigation = my_highlights.highlights.mh_highlight_ids
 
     assert set(mh_list_after_page_navigation) == set(mh_updated_filtered_list)
@@ -269,7 +264,6 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
 
     # THEN: MH filters resets to display highlights from all the chapters
     my_highlights = book.toolbar.my_highlights()
-    my_highlights.wait_for_load()
     mh_list_after_reload = my_highlights.highlights.mh_highlight_ids
     assert set(mh_list_after_reload) == set(content_highlight_ids)
 

--- a/pytest-selenium/tests/test_highlighting_47.py
+++ b/pytest-selenium/tests/test_highlighting_47.py
@@ -189,6 +189,7 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
         )
 
         my_highlights = book.toolbar.my_highlights()
+        my_highlights.wait_for_load()
         mh_highlight_ids = mh_highlight_ids + list(
             set(my_highlights.highlights.mh_highlight_ids) - set(mh_highlight_ids)
         )
@@ -210,6 +211,7 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
     x[1].remove_tag()
 
     my_highlights = book.toolbar.my_highlights()
+    my_highlights.wait_for_load()
     mh_filtered_list = my_highlights.highlights.mh_highlight_ids
     my_highlights.close()
 
@@ -219,6 +221,7 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
     toc.expand_chapter(2)
     toc.sections[14].click()
     my_highlights = book.toolbar.my_highlights()
+    my_highlights.wait_for_load()
     mh_list_from_chapter_with_highlights = my_highlights.highlights.mh_highlight_ids
 
     # THEN: Filter changes made earlier are retained
@@ -233,6 +236,7 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
     toc.sections[-40].click()
 
     my_highlights = book.toolbar.my_highlights()
+    my_highlights.wait_for_load()
     mh_list_from_chapter_without_highlights = my_highlights.highlights.mh_highlight_ids
 
     # THEN: Filter changes made earlier are retained
@@ -255,6 +259,7 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
 
     # THEN: The MH list is updated with the highlight from re-added chapter
     my_highlights = book.toolbar.my_highlights()
+    my_highlights.wait_for_load()
     mh_list_after_page_navigation = my_highlights.highlights.mh_highlight_ids
 
     assert set(mh_list_after_page_navigation) == set(mh_updated_filtered_list)
@@ -264,6 +269,7 @@ def test_filter_state_preserved_throughout_session(selenium, base_url, book_slug
 
     # THEN: MH filters resets to display highlights from all the chapters
     my_highlights = book.toolbar.my_highlights()
+    my_highlights.wait_for_load()
     mh_list_after_reload = my_highlights.highlights.mh_highlight_ids
     assert set(mh_list_after_reload) == set(content_highlight_ids)
 


### PR DESCRIPTION
for: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/1385

1. [User is redirected to osweb 404 page when book doesn't exist](https://openstax.testrail.com/index.php?/cases/view/613211)
2. [User with first session in REX is redirected to osweb 404 page if page slug is incorrect](https://openstax.testrail.com/index.php?/cases/view/614212)
3. Fix existing test failure - change in selector for the MH page -> highlight class element
4. Fix existing test failure - change in selector for the 'Order print copy' link in osweb
5. Added page objects for the rex 404 page