### PR TITLE
issue 945 typeset math in questions

### DIFF
--- a/src/app/content/practiceQuestions/components/PracticeQuestionScreen.spec.tsx
+++ b/src/app/content/practiceQuestions/components/PracticeQuestionScreen.spec.tsx
@@ -79,7 +79,7 @@ describe('Practice questions screen', () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
-  it('adds promises to the promiseCollector', () => {
+  it('adds typesetMath promise to the promiseCollector', () => {
     store.dispatch(receiveBook(archiveBook));
     store.dispatch(setSelectedSection(source));
     store.dispatch(receivePracticeQuestionsSummary({

--- a/src/app/content/practiceQuestions/components/PracticeQuestionScreen.spec.tsx
+++ b/src/app/content/practiceQuestions/components/PracticeQuestionScreen.spec.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import renderer from 'react-test-renderer';
 import { routes } from '../..';
+import * as mathjaxHelpers from '../../../../helpers/mathjax';
 import createTestServices from '../../../../test/createTestServices';
 import createTestStore from '../../../../test/createTestStore';
 import { book as archiveBook, shortPage } from '../../../../test/mocks/archiveLoader';
 import * as Services from '../../../context/Services';
 import MessageProvider from '../../../MessageProvider';
 import { Store } from '../../../types';
+import { assertDocument, assertWindow } from '../../../utils/browser-assertions';
 import { receiveBook } from '../../actions';
 import { LinkedArchiveTreeSection } from '../../types';
 import { findArchiveTreeNodeById } from '../../utils/archiveTreeUtils';
@@ -75,5 +77,23 @@ describe('Practice questions screen', () => {
     });
 
     expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('adds promises to the promiseCollector', () => {
+    store.dispatch(receiveBook(archiveBook));
+    store.dispatch(setSelectedSection(source));
+    store.dispatch(receivePracticeQuestionsSummary({
+      countsPerSource: { [source.id]: 1 },
+    }));
+    store.dispatch(setQuestions([mockQuestionData] as PracticeQuestions));
+
+    jest.spyOn(routes.content, 'getUrl').mockReturnValue('/book/book1/page/testbook1-testpage1-uuid');
+
+    const spyPromiseCollectorAdd = jest.spyOn(services.promiseCollector, 'add');
+
+    const container = assertDocument().createElement('div');
+    renderer.create(render(), { createNodeMock: () => container });
+
+    expect(spyPromiseCollectorAdd).toHaveBeenCalledWith(mathjaxHelpers.typesetMath(container, assertWindow()));
   });
 });

--- a/src/app/content/practiceQuestions/components/Question.tsx
+++ b/src/app/content/practiceQuestions/components/Question.tsx
@@ -1,7 +1,11 @@
+import { HTMLElement } from '@openstax/types/lib.dom';
 import React from 'react';
 import styled, { css } from 'styled-components/macro';
+import { typesetMath } from '../../../../helpers/mathjax';
 import { h4Style } from '../../../components/Typography';
+import { useServices } from '../../../context/Services';
 import theme from '../../../theme';
+import { assertWindow } from '../../../utils/browser-assertions';
 import ContentExcerpt from '../../components/ContentExcerpt';
 import { LinkedArchiveTreeSection } from '../../types';
 import { PracticeAnswer, PracticeQuestion } from '../types';
@@ -41,9 +45,19 @@ const getChoiceLetter = (value: number) => {
 
 // tslint:disable-next-line: variable-name
 const Question = (props: QuestionProps) => {
+  const container = React.useRef<HTMLElement | null>(null);
+  const services = useServices();
+
   const [selectedAnswer, setSelectedAnswer] = React.useState<PracticeAnswer | null>(null);
 
-  return <QuestionWrapper>
+  React.useLayoutEffect(() => {
+    if (container.current) {
+      services.promiseCollector.add(typesetMath(container.current, assertWindow()));
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps, ignore promiseCollector
+  }, [props.question]);
+
+  return <QuestionWrapper ref={container}>
     <QuestionContent content={props.question.stem_html} source={props.source} />
     <AnswersWrapper>
       { props.question.answers.map((answer, index) =>


### PR DESCRIPTION
for: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/rex-web/945

For testing you can use this snippet:
```ts
...
{section && <Question question={mockQuestion} source={section} />}
...
const mockQuestion: PracticeQuestion = {
  group_uuid: '123',
  uid: '123',
  stem_html: `
  MathML:
  <math xmlns = "http://www.w3.org/1998/Math/MathML">
    <mrow>
      <msup><mi>a</mi><mn>2</mn></msup>
      <mo>+</mo>
      <msup><mi>b</mi><mn>2</mn></msup>
      <mo> = </mo>
      <msup><mi>c</mi><mn>2</mn></msup>
    </mrow>
  </math>
  LATEX:
  <span data-math="0.1\,\text{m}">0.1\,\text{m}</span>
  `,
  answers: [],
};
```