### PR TITLE
1585 - Style page content depending on the book slug

### DIFF
--- a/generic-styles/biology.less
+++ b/generic-styles/biology.less
@@ -1,0 +1,2638 @@
+@charset "UTF-8";
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@400;700&display=swap&subset=latin,latin-ext");
+@import url("https://fonts.googleapis.com/css?family=IBM+Plex+Sans:200,400,500,700&display=swap&subset=latin,latin-ext");
+@import url("https://fonts.googleapis.com/css2?family=Mulish:wght@400;700;900&display=swap&subset=latin,latin-ext");
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@400;700&display=swap&subset=latin,latin-ext");
+@import url("https://fonts.googleapis.com/css?family=IBM+Plex+Sans:200,400,500,700&display=swap&subset=latin,latin-ext");
+@import url("https://fonts.googleapis.com/css2?family=Mulish:wght@400;700;900&display=swap&subset=latin,latin-ext");
+  nav#toc > ol > .os-toc-unit > a > .os-text,
+nav#toc > ol > .os-toc-unit > a,
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > a > .os-number,
+nav#toc > ol > .os-toc-chapter > a > .os-number {
+  page-break-after: avoid; }
+
+nav#toc {
+  page-break-after: always; }
+
+h1, h2, h3, h4, h5, h6,
+[data-type="document-title"],
+[data-type="title"] {
+  break-after: avoid;
+  break-inside: avoid; }
+
+.learning-objectives,
+.learning-objective,
+[data-type="page"]:not(.introduction) > [data-type="abstract"] {
+  page-break-inside: avoid;
+  page-break-before: avoid; }
+
+[data-type="chapter"] .os-table,
+.os-table {
+  page-break-inside: auto; }
+  [data-type="chapter"] .os-table thead,
+  .os-table thead {
+    page-break-after: avoid; }
+  [data-type="chapter"] .os-table tr,
+  .os-table tr {
+    page-break-inside: avoid; }
+
+.os-table.os-top-titled-container > .os-table-title {
+  page-break-after: avoid; }
+
+.os-table.os-top-captioned-container > .os-top-caption {
+  page-break-after: avoid; }
+
+.footnote {
+  page-break-inside: avoid; }
+
+[data-type="footnote-refs"]::before {
+  page-break-after: avoid; }
+
+p.has-noteref {
+  page-break-inside: avoid; }
+
+.os-index-container {
+  page-break-before: right;
+  page-break-after: left; }
+  .os-index-container .group-label {
+    page-break-after: avoid; }
+  .os-index-container .group-by > .os-index-item:first-of-type {
+    break-before: avoid; }
+  .os-index-container .index-term, .os-index-container .os-term {
+    page-break-inside: avoid; }
+  .os-index-container .os-term-section-link {
+    page-break-after: avoid; }
+
+.os-eoc > section > [data-type="exercise"] {
+  page-break-inside: avoid; }
+
+.os-eos > section.section-exercises > section > [data-type="exercise"] {
+  page-break-inside: avoid; }
+
+div.preface,
+div[data-type="chapter"],
+div.appendix,
+div.os-solution-container[data-type="composite-chapter"],
+div.os-solutions-container[data-type="composite-chapter"],
+div.os-eob.os-references-container[data-type="composite-page"] {
+  page-break-before: right;
+  page-break-after: left; }
+
+.os-caption-container {
+  page-break-before: avoid; }
+
+[data-type="equation"] {
+  page-break-inside: avoid; }
+
+.introduction > .intro-body > .os-chapter-outline > div.os-chapter-objective > a.os-chapter-objective {
+  page-break-after: avoid; }
+  .introduction > .intro-body > .os-chapter-outline > div.os-chapter-objective > a.os-chapter-objective > .os-number,
+  .introduction > .intro-body > .os-chapter-outline > div.os-chapter-objective > a.os-chapter-objective > .os-text {
+    page-break-after: avoid; }
+
+.os-chapter-outline > div.os-chapter-objective > div.learning-objective {
+  page-break-inside: auto; }
+
+/* stylelint-disable-next-line meowtec/no-px */
+* {
+  box-sizing: border-box; }
+
+[data-type="composite-chapter"] p, [data-type="composite-chapter"] section, [data-type="composite-chapter"] table, [data-type="composite-chapter"] ul, [data-type="composite-chapter"] ol, [data-type="composite-chapter"] li, [data-type="composite-chapter"] dl, [data-type="composite-chapter"] h1, [data-type="composite-chapter"] h2, [data-type="composite-chapter"] h3, [data-type="composite-chapter"] h4, [data-type="composite-chapter"] h5,
+[data-type="page"] p,
+[data-type="page"] section,
+[data-type="page"] table,
+[data-type="page"] ul,
+[data-type="page"] ol,
+[data-type="page"] li,
+[data-type="page"] dl,
+[data-type="page"] h1,
+[data-type="page"] h2,
+[data-type="page"] h3,
+[data-type="page"] h4,
+[data-type="page"] h5,
+[data-type="composite-page"] p,
+[data-type="composite-page"] section,
+[data-type="composite-page"] table,
+[data-type="composite-page"] ul,
+[data-type="composite-page"] ol,
+[data-type="composite-page"] li,
+[data-type="composite-page"] dl,
+[data-type="composite-page"] h1,
+[data-type="composite-page"] h2,
+[data-type="composite-page"] h3,
+[data-type="composite-page"] h4,
+[data-type="composite-page"] h5 {
+  margin: 0;
+  padding: 0; }
+
+[data-type="composite-chapter"] p,
+[data-type="page"] p,
+[data-type="composite-page"] p {
+  margin-bottom: 0.7rem; }
+
+[data-type="composite-chapter"] section,
+[data-type="page"] section,
+[data-type="composite-page"] section {
+  margin-bottom: 0.7rem; }
+
+[data-type="composite-chapter"] table,
+[data-type="page"] table,
+[data-type="composite-page"] table {
+  margin-bottom: 0.7rem; }
+
+[data-type="composite-chapter"] ul,
+[data-type="page"] ul,
+[data-type="composite-page"] ul {
+  margin-bottom: 0.7rem; }
+
+[data-type="composite-chapter"] ol,
+[data-type="page"] ol,
+[data-type="composite-page"] ol {
+  margin-bottom: 0.7rem; }
+
+math {
+  vertical-align: middle; }
+
+sub, sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline; }
+
+sup {
+  top: -0.5em; }
+
+sub {
+  bottom: -0.25em; }
+
+blockquote {
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0; }
+
+/* stylelint-disable-next-line meowtec/no-px */
+a[href^="http"]::after {
+  content: " (" attr(href) ") ";
+  overflow-wrap: break-word; }
+
+ol.os-stepwise {
+  list-style-type: none; }
+
+ul[data-labeled-item="true"] {
+  list-style-type: none; }
+
+.os-math-in-para {
+  white-space: nowrap; }
+
+span[data-type="term"]:not(.no-emphasis) {
+  font-weight: bold; }
+
+h3, h4, h5 {
+  bookmark-level: none; }
+
+p.has-noteref {
+  margin-bottom: -0.7rem; }
+
+pre > span {
+  white-space: normal;
+  vertical-align: top;
+  display: inline-block; }
+
+.os-eoc.os-glossary-container {
+  page: eoc;
+  prince-page-group: start; }
+
+.os-eoc {
+  page: eoc; }
+
+.os-eob.os-index-container {
+  page: eob;
+  prince-page-group: start; }
+
+.os-eob {
+  page: eob; }
+
+.appendix {
+  page: appendix;
+  prince-page-group: start; }
+
+.appendix {
+  page: appendix; }
+
+@page eoc:left {
+  @left-middle {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @top-left-corner {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @bottom-left-corner {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @left-bottom {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @left-top {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; } }
+
+@page eoc:right {
+  @right-middle {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @top-right-corner {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @bottom-right-corner {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @right-bottom {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @right-top {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; } }
+
+@page eoc:blank {
+  @left-middle {
+    content: none;
+    border: none; }
+  @top-left-corner {
+    content: none;
+    border: none; }
+  @bottom-left-corner {
+    content: none;
+    border: none; }
+  @left-bottom {
+    content: none;
+    border: none; }
+  @left-top {
+    content: none;
+    border: none; } }
+
+@page eoc:blank {
+  @right-middle {
+    content: none;
+    border: none; }
+  @top-right-corner {
+    content: none;
+    border: none; }
+  @bottom-right-corner {
+    content: none;
+    border: none; }
+  @right-bottom {
+    content: none;
+    border: none; }
+  @right-top {
+    content: none;
+    border: none; } }
+
+@page eob:left {
+  @left-middle {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @top-left-corner {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @bottom-left-corner {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @left-bottom {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @left-top {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; } }
+
+@page eob:right {
+  @right-middle {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @top-right-corner {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @bottom-right-corner {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @right-bottom {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @right-top {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; } }
+
+@page eob:blank {
+  @left-middle {
+    content: none;
+    border: none; }
+  @top-left-corner {
+    content: none;
+    border: none; }
+  @bottom-left-corner {
+    content: none;
+    border: none; }
+  @left-bottom {
+    content: none;
+    border: none; }
+  @left-top {
+    content: none;
+    border: none; } }
+
+@page eob:blank {
+  @right-middle {
+    content: none;
+    border: none; }
+  @top-right-corner {
+    content: none;
+    border: none; }
+  @bottom-right-corner {
+    content: none;
+    border: none; }
+  @right-bottom {
+    content: none;
+    border: none; }
+  @right-top {
+    content: none;
+    border: none; } }
+
+@page appendix:left {
+  @left-middle {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @top-left-corner {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @bottom-left-corner {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @left-bottom {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @left-top {
+    content: " ";
+    border-left: 0.65in solid #0074BC;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; } }
+
+@page appendix:right {
+  @right-middle {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @top-right-corner {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @bottom-right-corner {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @right-bottom {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @right-top {
+    content: " ";
+    border-right: 0.65in solid #0074BC;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; } }
+
+@page appendix:blank {
+  @left-middle {
+    content: none;
+    border: none; }
+  @top-left-corner {
+    content: none;
+    border: none; }
+  @bottom-left-corner {
+    content: none;
+    border: none; }
+  @left-bottom {
+    content: none;
+    border: none; }
+  @left-top {
+    content: none;
+    border: none; } }
+
+@page appendix:blank {
+  @right-middle {
+    content: none;
+    border: none; }
+  @top-right-corner {
+    content: none;
+    border: none; }
+  @bottom-right-corner {
+    content: none;
+    border: none; }
+  @right-bottom {
+    content: none;
+    border: none; }
+  @right-top {
+    content: none;
+    border: none; } }
+
+@page {
+  @footnotes {
+    border-top-color: #000000;
+    border-top-width: 0.5pt;
+    border-top-style: solid;
+    display: block;
+    margin-top: 0.7rem; } }
+
+/* stylelint-disable-next-line meowtec/no-px */
+/* stylelint-disable-next-line meowtec/no-px */
+[data-type="chapter"] > h1[data-type="document-title"] .os-number {
+  string-set: chapter-number content(); }
+
+[data-type="chapter"] > h1[data-type="document-title"] .os-text {
+  string-set: chapter-title content(); }
+
+[data-type="chapter"] > [data-type="page"].introduction .intro-text > h2[data-type="document-title"] {
+  string-set: module-number string(chapter-number); }
+  [data-type="chapter"] > [data-type="page"].introduction .intro-text > h2[data-type="document-title"] .os-text {
+    string-set: module-title "Introduction"; }
+
+[data-type="chapter"] > [data-type="page"]:not(.introduction) > h2[data-type="document-title"] .os-number {
+  string-set: module-number content(); }
+
+[data-type="chapter"] > [data-type="page"]:not(.introduction) > h2[data-type="document-title"] .os-text {
+  string-set: module-title content(); }
+
+.os-eoc > h2[data-type="document-title"] .os-text {
+  string-set: eoc-title content(); }
+
+.appendix > h1[data-type="document-title"] .os-number {
+  string-set: appendix-number content(); }
+
+.appendix > h1[data-type="document-title"] .os-text {
+  string-set: appendix-title content(); }
+
+div[data-type="composite-page"].os-eob > h1[data-type="document-title"] .os-text {
+  string-set: eob-title content(); }
+
+nav#toc {
+  page: table-of-contents; }
+
+div[data-type="page"].preface {
+  page: preface;
+  counter-reset: page 1; }
+
+.os-eoc {
+  page: eoc; }
+
+[data-type="chapter"] {
+  page: chapter;
+  prince-page-group: start; }
+
+div[data-type="page"].appendix {
+  page: appendix; }
+
+div[data-type="composite-page"].os-eob {
+  page: eob; }
+
+@page chapter:nth(1) {
+  @top-left-corner {
+    content: none; }
+  @top-right-corner {
+    content: none; }
+  @top-left {
+    content: none; }
+  @top-center {
+    content: none; }
+  @top-right {
+    content: none; } }
+
+@page table-of-contents {
+  @top-left-corner {
+    content: none; }
+  @top-left {
+    content: none; }
+  @top-right-corner {
+    content: none; }
+  @top-right {
+    content: none; } }
+
+@page :left {
+  @top-left {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: string(chapter-number) " • " string(chapter-title); }
+  @top-left-corner {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: counter(page);
+    margin-right: 40px; }
+  @bottom-left {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: "Access for free at openstax.org."; } }
+
+@page :right {
+  @top-right {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: string(module-number) " • " string(module-title); }
+  @top-right-corner {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: counter(page);
+    margin-left: 40px; } }
+
+@page preface:left {
+  @top-left {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: "Preface"; }
+  @top-left-corner {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: counter(page);
+    margin-right: 40px; }
+  @bottom-left {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: "Access for free at openstax.org."; } }
+
+@page preface:right {
+  @top-right {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: "Preface"; }
+  @top-right-corner {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: counter(page);
+    margin-left: 40px; } }
+
+@page eoc:left {
+  @top-left {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: counter(page) "     " string(chapter-number) " • " string(eoc-title); }
+  @bottom-left {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: "Access for free at openstax.org."; } }
+
+@page eoc:right {
+  @top-right {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: string(chapter-number) " • " string(eoc-title) "     " counter(page); } }
+
+@page appendix:left {
+  @top-left {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: counter(page) "     " string(appendix-number) " • " string(appendix-title); }
+  @bottom-left {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: "Access for free at openstax.org."; } }
+
+@page appendix:right {
+  @top-right {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: string(appendix-number) " • " string(appendix-title) "     " counter(page); } }
+
+@page eob:left {
+  @top-left {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: counter(page) "     " string(eob-title); }
+  @bottom-left {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: "Access for free at openstax.org."; } }
+
+@page eob:right {
+  @top-right {
+    font-size: 0.83333rem;
+    font-family: "Mulish", sans-serif;
+    color: #A5A5A5;
+    font-weight: 700;
+    content: string(eob-title) "     " counter(page); } }
+
+@page {
+  margin-left: 1in;
+  margin-right: 1in;
+  margin-bottom: 0.8in;
+  margin-top: 0.8in; }
+
+@page chapter:first {
+  margin-right: 2in; }
+
+@page chapter:nth(2) {
+  margin-right: 2in; }
+
+:root {
+  font-family: IBM Plex Serif, serif;
+  font-size: 12px;
+  line-height: 1.4rem;
+  color: #000000;
+  prince-image-resolution: auto, 200dpi;
+  prince-background-image-resolution: 200dpi; }
+
+nav#toc > .os-toc-title {
+  font-size: 4.29982rem;
+  line-height: 3rem;
+  color: #0074BC;
+  display: block;
+  font-family: IBM Plex Sans, sans-serif;
+  font-weight: lighter;
+  border-bottom: 0.5rem solid;
+  border-bottom-color: #0074BC;
+  margin-bottom: 2.8rem;
+  padding-bottom: 1.4rem; }
+
+nav#toc > ol {
+  list-style: none;
+  padding-left: 0;
+  margin-left: 0;
+  display: inline; }
+
+nav#toc > ol > .os-toc-preface {
+  display: block;
+  margin-bottom: 1.4rem; }
+
+nav#toc > ol > .os-toc-preface > a {
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #000000;
+  text-decoration: none; }
+
+nav#toc > ol > .os-toc-preface > a::after {
+  content: target-counter(attr(href), page);
+  display: inline-block;
+  margin-left: 3rem;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+nav#toc > ol > .os-toc-unit > a {
+  display: block;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 2.0736rem;
+  line-height: 1.5rem;
+  font-weight: bolder;
+  color: #0074BC;
+  border-bottom: 0.1rem solid black;
+  text-transform: uppercase;
+  letter-spacing: 0.1rem;
+  text-decoration: none;
+  padding-bottom: 0.7rem;
+  margin-bottom: 0.7rem; }
+
+nav#toc > ol > .os-toc-unit > ol {
+  list-style: none;
+  padding-left: 0;
+  margin-left: 0;
+  display: block; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter {
+  display: block;
+  margin-bottom: 1.4rem; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > a > .os-number {
+  display: block;
+  text-decoration: none;
+  color: #0074BC;
+  font-family: Mulish, sans-serif;
+  font-weight: bolder;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1rem; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > a {
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1.728rem;
+  line-height: 1.5rem;
+  font-weight: bolder;
+  color: #000000;
+  text-decoration: none; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > a::after {
+  content: target-counter(attr(href), page);
+  display: inline-block;
+  margin-left: 3rem;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: normal;
+  color: #000000; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > ol {
+  list-style: none;
+  padding-left: 0;
+  margin-left: 0;
+  display: block; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > ol > .os-toc-chapter-page {
+  display: block; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > ol > .os-toc-chapter-page > a {
+  font-family: IBM Plex Serif, serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #000000;
+  text-decoration: none; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > ol > .os-toc-chapter-page > a::after {
+  content: target-counter(attr(href), page);
+  display: inline-block;
+  margin-left: 3rem;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > ol > .os-toc-chapter-composite-page {
+  display: block; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > ol > .os-toc-chapter-composite-page > a {
+  font-family: IBM Plex Serif, serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #000000;
+  text-decoration: none; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > ol > .os-toc-chapter-composite-page > a::after {
+  content: target-counter(attr(href), page);
+  display: inline-block;
+  margin-left: 3rem;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > ol > .os-toc-composite-chapter > ol {
+  display: none; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > ol > .os-toc-composite-chapter > a {
+  font-family: IBM Plex Serif, serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #000000;
+  text-decoration: none; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > ol > .os-toc-composite-chapter > a::after {
+  content: target-counter(attr(href), page);
+  display: inline-block;
+  margin-left: 3rem;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+nav#toc > ol > .os-toc-composite-chapter {
+  display: block;
+  margin-bottom: 1.4rem; }
+
+nav#toc > ol > .os-toc-composite-chapter > ol {
+  display: none; }
+
+nav#toc > ol > .os-toc-composite-chapter > a {
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #000000;
+  text-decoration: none; }
+
+nav#toc > ol > .os-toc-composite-chapter > a::after {
+  content: target-counter(attr(href), page);
+  display: inline-block;
+  margin-left: 3rem;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+nav#toc > ol > .os-toc-appendix {
+  margin-bottom: 0.7rem; }
+
+nav#toc > ol > .os-toc-appendix > a > .os-number {
+  text-decoration: none;
+  font-family: Mulish, sans-serif;
+  font-weight: bolder; }
+
+nav#toc > ol > .os-toc-appendix > a {
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #000000;
+  text-decoration: none; }
+
+nav#toc > ol > .os-toc-appendix > a::after {
+  content: target-counter(attr(href), page);
+  display: inline-block;
+  margin-left: 3rem;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+nav#toc > ol > .os-toc-references {
+  display: block;
+  margin-bottom: 1.4rem; }
+
+nav#toc > ol > .os-toc-references > a {
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #000000;
+  text-decoration: none; }
+
+nav#toc > ol > .os-toc-references > a::after {
+  content: target-counter(attr(href), page);
+  display: inline-block;
+  margin-left: 3rem;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+nav#toc > ol > .os-toc-index {
+  display: block;
+  margin-bottom: 1.4rem; }
+
+nav#toc > ol > .os-toc-index > a {
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #000000;
+  text-decoration: none; }
+
+nav#toc > ol > .os-toc-index > a::after {
+  content: target-counter(attr(href), page);
+  display: inline-block;
+  margin-left: 3rem;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.preface {
+  column-count: 2;
+  column-gap: 2.4rem;
+  column-width: auto; }
+
+.preface > ul {
+  margin-left: 24px; }
+
+.preface > section > ul {
+  margin-left: 24px; }
+
+.preface > section > ol {
+  margin-left: 24px; }
+
+.preface > section > section > ul {
+  margin-left: 24px; }
+
+.preface > section > section > ul > li > ul {
+  margin-left: 16px; }
+
+.preface > section > section > div > ul {
+  margin-left: 24px; }
+
+.preface > section > section > section > ul {
+  margin-left: 24px; }
+
+.preface > section > section > section > ol {
+  margin-left: 24px; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] {
+  display: table; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] > .os-divider {
+  margin-right: 8px; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container img {
+  max-width: 100%; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container > ol > li > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container > div > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container > div > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container > div > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container.has-first-element {
+  display: table-cell;
+  vertical-align: bottom;
+  padding-top: 0.7rem;
+  width: 100%; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container.has-first-element > p {
+  margin-bottom: 0; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container.has-first-element img {
+  max-width: 100%; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container.has-first-element > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container.has-first-element > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container.has-first-element > ol > li > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container.has-first-element > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container.has-first-element > div > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container.has-first-element > div > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type='problem'] .os-problem-container.has-first-element > div > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+:not(.os-note-body) > [data-type="exercise"] [data-type="solution"] > .solution-title {
+  font-family: IBM Plex Sans, sans-serif;
+  font-weight: bold;
+  font-size: 1.2rem;
+  line-height: 1.5rem; }
+
+[data-type='chapter'] > .os-glossary-container {
+  margin-bottom: 1.4rem;
+  column-count: 2;
+  column-gap: 2.4rem;
+  column-width: auto; }
+
+[data-type='chapter'] > .os-glossary-container > dl {
+  text-indent: -16px;
+  padding-left: 16px; }
+
+[data-type='chapter'] > .os-glossary-container > dl > dt {
+  font-weight: bold;
+  padding-right: 8px;
+  display: inline; }
+
+[data-type='chapter'] > .os-glossary-container > dl > dd {
+  display: inline;
+  margin-left: 0px; }
+
+[data-type='chapter'] > .os-summary-container {
+  margin-bottom: 1.4rem;
+  column-count: 2;
+  column-gap: 2.4rem;
+  column-width: auto; }
+
+[data-type='chapter'] > .os-summary-container > section > ul {
+  margin-left: 24px; }
+
+[data-type='chapter'] > .os-summary-container > section > ul > li > ol {
+  margin-left: 16px; }
+
+[data-type='chapter'] > .os-summary-container > section > ol {
+  margin-left: 24px; }
+
+[data-type='chapter'] > .os-summary-container section > ul {
+  margin-left: 24px; }
+
+[data-type='chapter'] > .os-summary-container section > ul > li > ol {
+  margin-left: 16px; }
+
+[data-type='chapter'] > .os-summary-container section > ul {
+  margin-left: 24px; }
+
+[data-type='chapter'] > .os-summary-container section > ul > li > ul {
+  margin-left: 16px; }
+
+[data-type='chapter'] > .os-visual-exercise-container {
+  margin-bottom: 1.4rem;
+  column-count: 2;
+  column-gap: 2.4rem;
+  column-width: auto; }
+
+[data-type='chapter'] > .os-visual-exercise-container section {
+  margin-bottom: 0; }
+
+[data-type='chapter'] > .os-visual-exercise-container section > ul {
+  margin-left: 32px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container > div > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container > div > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container section > ol {
+  margin-left: 32px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] {
+  display: table; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] > .os-divider {
+  margin-right: 8px; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container img {
+  max-width: 100%; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container > ol > li > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container > div > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container > div > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container > div > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container.has-first-element {
+  display: table-cell;
+  vertical-align: bottom;
+  padding-top: 0.7rem;
+  width: 100%; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container.has-first-element > p {
+  margin-bottom: 0; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container.has-first-element img {
+  max-width: 100%; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container.has-first-element > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container.has-first-element > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container.has-first-element > ol > li > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container.has-first-element > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container.has-first-element > div > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container.has-first-element > div > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-problem-container.has-first-element > div > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-table > table {
+  max-width: 100%;
+  table-layout: fixed; }
+
+[data-type='chapter'] > .os-visual-exercise-container [data-type='problem'] .os-table > table > tbody > tr > td:not(:only-of-type) {
+  text-align: center;
+  padding-top: 0.7rem;
+  padding-bottom: 0.7rem;
+  padding-right: 4px;
+  padding-left: 4px; }
+
+[data-type='chapter'] > .os-multiple-choice-container {
+  margin-bottom: 1.4rem;
+  column-count: 2;
+  column-gap: 2.4rem;
+  column-width: auto; }
+
+[data-type='chapter'] > .os-multiple-choice-container section {
+  margin-bottom: 0; }
+
+[data-type='chapter'] > .os-multiple-choice-container section > ul {
+  margin-left: 32px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container > div > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container > div > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container section > ol {
+  margin-left: 32px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] {
+  display: table; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] > .os-divider {
+  margin-right: 8px; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container img {
+  max-width: 100%; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container > ol > li > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container > div > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container > div > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container > div > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container.has-first-element {
+  display: table-cell;
+  vertical-align: bottom;
+  padding-top: 0.7rem;
+  width: 100%; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container.has-first-element > p {
+  margin-bottom: 0; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container.has-first-element img {
+  max-width: 100%; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container.has-first-element > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container.has-first-element > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container.has-first-element > ol > li > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container.has-first-element > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container.has-first-element > div > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container.has-first-element > div > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-problem-container.has-first-element > div > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-table > table {
+  max-width: 100%;
+  table-layout: fixed; }
+
+[data-type='chapter'] > .os-multiple-choice-container [data-type='problem'] .os-table > table > tbody > tr > td:not(:only-of-type) {
+  text-align: center;
+  padding-top: 0.7rem;
+  padding-bottom: 0.7rem;
+  padding-right: 4px;
+  padding-left: 4px; }
+
+[data-type='chapter'] > .os-critical-thinking-container {
+  margin-bottom: 1.4rem;
+  column-count: 2;
+  column-gap: 2.4rem;
+  column-width: auto; }
+
+[data-type='chapter'] > .os-critical-thinking-container section {
+  margin-bottom: 0; }
+
+[data-type='chapter'] > .os-critical-thinking-container section > ul {
+  margin-left: 32px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container > div > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container > div > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container section > ol {
+  margin-left: 32px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] {
+  display: table; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] > .os-divider {
+  margin-right: 8px; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container img {
+  max-width: 100%; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container > ol > li > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container > div > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container > div > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container > div > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container.has-first-element {
+  display: table-cell;
+  vertical-align: bottom;
+  padding-top: 0.7rem;
+  width: 100%; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container.has-first-element > p {
+  margin-bottom: 0; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container.has-first-element img {
+  max-width: 100%; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container.has-first-element > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container.has-first-element > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container.has-first-element > ol > li > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container.has-first-element > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container.has-first-element > div > ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container.has-first-element > div > ol > li > ol {
+  margin-left: 16px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-problem-container.has-first-element > div > ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-table > table {
+  max-width: 100%;
+  table-layout: fixed; }
+
+[data-type='chapter'] > .os-critical-thinking-container [data-type='problem'] .os-table > table > tbody > tr > td:not(:only-of-type) {
+  text-align: center;
+  padding-top: 0.7rem;
+  padding-bottom: 0.7rem;
+  padding-right: 4px;
+  padding-left: 4px; }
+
+[data-type="page"] > [data-type="abstract"] > h3[data-type="title"] {
+  color: #0074BC;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-style: normal;
+  font-weight: bold; }
+
+[data-type="page"] > [data-type="abstract"] > p {
+  color: #0074BC;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-style: italic;
+  margin-bottom: 0; }
+
+[data-type="page"] > [data-type="abstract"] > ul {
+  margin-left: 24px; }
+
+[data-type="page"] > [data-type="abstract"] > ul > li {
+  font-family: Mulish, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+[data-type="page"] > [data-type="abstract"] > ul > li::marker {
+  color: #0074BC; }
+
+.os-index-container {
+  column-count: 3;
+  column-gap: 32px; }
+
+.os-index-container > .group-by {
+  color: #000000;
+  font-family: IBM Plex Serif, serif;
+  font-weight: normal;
+  padding-bottom: 1.4rem; }
+
+.os-index-container > .group-by > .group-label {
+  color: #000000;
+  font-family: Mulish, sans-serif;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.os-index-container > .group-by > .os-index-item {
+  color: #000000;
+  font-family: IBM Plex Serif, serif;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.os-index-container > .group-by > .os-index-item > .os-term {
+  color: #000000;
+  font-family: IBM Plex Serif, serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  padding-right: 8px; }
+
+.os-index-container > .group-by > .os-index-item > .os-term-section-link {
+  content: target-counter(attr(href, url), page); }
+
+.os-table.os-unstyled-container {
+  margin-bottom: 1.4rem; }
+
+.os-table.os-unstyled-container > table > thead > tr > th {
+  padding: 0.7rem; }
+
+.os-table.os-unstyled-container > table > tbody > tr > td:not(:only-of-type) {
+  padding-top: 0.7rem;
+  padding-bottom: 0.7rem;
+  padding-right: 0.7rem;
+  padding-left: 0.7rem; }
+
+a {
+  color: #027EB5; }
+
+[data-type="chapter"] > [data-type="page"]:not(.introduction) > ul {
+  margin-left: 24px; }
+
+[data-type="chapter"] > [data-type="page"]:not(.introduction) > ol {
+  margin-left: 24px; }
+
+[data-type="chapter"] > [data-type="page"]:not(.introduction) > section > ul {
+  margin-left: 24px; }
+
+[data-type="chapter"] > [data-type="page"]:not(.introduction) > section > ul > li > ul {
+  margin-left: 16px; }
+
+[data-type="chapter"] > [data-type="page"]:not(.introduction) > section > ul > li > ol {
+  margin-left: 16px; }
+
+[data-type="chapter"] > [data-type="page"]:not(.introduction) > section > section > ul {
+  margin-left: 24px; }
+
+[data-type="chapter"] > [data-type="page"]:not(.introduction) > section > section > ol {
+  margin-left: 24px; }
+
+.introduction > .os-figure.has-splash {
+  margin-bottom: 2rem; }
+
+.introduction > .os-figure.has-splash > figure.splash {
+  position: relative;
+  margin: 0; }
+
+.introduction > .os-figure.has-splash > figure.splash::before {
+  content: '';
+  background-color: #0074BC;
+  position: absolute;
+  height: 100%;
+  width: 8.65in;
+  margin-left: -1.15in;
+  z-index: -3;
+  box-sizing: border-box;
+  padding: inherit;
+  top: 0; }
+
+.introduction > .os-figure.has-splash > figure.splash > span[data-type="media"] {
+  line-height: 0;
+  height: 100%;
+  display: flex;
+  width: 7.65in;
+  justify-content: flex-end;
+  z-index: -2;
+  position: relative; }
+
+.introduction > .os-figure.has-splash > figure.splash > span[data-type="media"] > img {
+  width: 8.15in; }
+
+.introduction > .os-figure.has-splash .os-caption-container {
+  position: relative;
+  padding-top: 1rem;
+  padding-bottom: 2rem; }
+
+.introduction > .os-figure.has-splash .os-caption-container::before {
+  content: '';
+  background-color: #EEEAE0;
+  position: absolute;
+  height: 100%;
+  width: 8.8in;
+  margin-left: -1.15in;
+  z-index: -1;
+  box-sizing: border-box;
+  padding: inherit;
+  top: 0; }
+
+.introduction > .os-figure.has-splash .os-caption-container > .os-number {
+  font-family: Mulish, sans-serif;
+  font-weight: bold;
+  color: #C31427;
+  display: inline-block;
+  margin-right: 8px; }
+
+.introduction > .os-figure.has-splash .os-caption-container > .os-title-label {
+  font-family: Mulish, sans-serif;
+  font-weight: bold;
+  color: #C31427; }
+
+.introduction > .os-figure.has-splash .os-caption-container > .os-title {
+  font-family: Mulish, sans-serif;
+  font-weight: bold; }
+
+.introduction > .os-figure.has-splash .os-caption-container > .os-caption {
+  font-family: IBM Plex Sans, sans-serif; }
+
+.introduction > .intro-body {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: space-between;
+  position: relative;
+  right: -2in;
+  margin-left: -2in; }
+
+.introduction > .intro-body > .os-chapter-outline {
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5rem;
+  width: 2.15in;
+  background-color: #0074BC;
+  color: #FFFFFF;
+  margin: 0 -1.2rem 0 1.5rem;
+  padding: 1.5rem 0 1.5rem 1.5rem; }
+
+.introduction > .intro-body > .os-chapter-outline > .os-title {
+  overflow: visible;
+  border-bottom: 1px solid white;
+  padding: 0 3.9rem 0.5rem 0;
+  margin: .5rem 0 .5rem 0;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 500;
+  font-family: IBM Plex Sans, sans-serif; }
+
+.introduction > .intro-body > .os-chapter-outline > div.os-chapter-objective {
+  margin-bottom: 0.5rem;
+  padding-right: 3.9rem; }
+
+.introduction > .intro-body > .os-chapter-outline > div.os-chapter-objective > a.os-chapter-objective {
+  display: flex;
+  text-decoration: none;
+  color: white; }
+
+.introduction > .intro-body > .os-chapter-outline > div.os-chapter-objective > a.os-chapter-objective > .os-text {
+  margin-left: 0.5rem;
+  display: inline-block; }
+
+.introduction > .intro-body > .intro-text > h2[data-type="document-title"]:first-of-type {
+  float: left;
+  font-family: IBM Plex Serif, serif;
+  font-size: 1rem;
+  text-transform: uppercase;
+  margin: 0 .5rem 0 0;
+  font-weight: 700; }
+
+[data-type="unit"] > h1 {
+  display: none; }
+
+.os-table:not(.os-unstyled-container) {
+  margin-bottom: 1.4rem;
+  display: table;
+  margin-left: auto;
+  margin-right: auto; }
+
+.os-table:not(.os-unstyled-container) > table {
+  border-collapse: collapse; }
+
+.os-table:not(.os-unstyled-container) > table > thead > tr > th {
+  border-bottom: 0.1rem solid black;
+  font-family: Mulish, sans-serif;
+  font-weight: 700;
+  padding: 0.7rem; }
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td:not(:only-of-type) {
+  font-family: IBM Plex Serif, serif;
+  border-left: 0.025rem solid black;
+  padding-top: 0.7rem;
+  padding-bottom: 0.7rem;
+  padding-right: 0.7rem;
+  padding-left: 0.7rem; }
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td:not(:only-of-type) > ul {
+  margin-left: 0.7rem; }
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td:not(:only-of-type) > ul[data-bullet-style='none'] {
+  list-style-type: none; }
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td:first-of-type:not(:only-of-type) {
+  border-left: none;
+  border-right: 0.025rem solid black; }
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr > td {
+  border-bottom: 0.025rem solid black;
+  padding: 0.7rem; }
+
+.os-table:not(.os-unstyled-container) > table > tbody > tr:last-of-type > td:only-of-type {
+  border-right: none; }
+
+.os-table:not(.os-unstyled-container) .os-caption-container > .os-title-label {
+  font-weight: bold;
+  font-family: Mulish, sans-serif; }
+
+.os-table:not(.os-unstyled-container) .os-caption-container > .os-number {
+  font-weight: bold;
+  font-family: Mulish, sans-serif; }
+
+.os-table.os-top-titled-container {
+  margin-bottom: 1.4rem;
+  display: table;
+  margin-left: auto;
+  margin-right: auto; }
+
+.os-table.os-top-titled-container > .os-table-title {
+  color: #0074BC;
+  padding: 0.7rem 0.7rem;
+  text-align: center; }
+
+.os-table.os-top-titled-container > table {
+  border-collapse: collapse;
+  width: 100%; }
+
+.os-table.os-top-titled-container > table > thead > tr > th {
+  border-bottom: 0.1rem solid black;
+  border-top: 0.1rem solid black;
+  font-family: Mulish, sans-serif;
+  font-weight: 700;
+  padding: 0.7rem; }
+
+.os-table.os-top-titled-container > table > tbody > tr > td:not(:only-of-type) {
+  font-family: IBM Plex Serif, serif;
+  border-left: 0.025rem solid black;
+  border-bottom: 0.025rem solid black;
+  padding-top: 0.7rem;
+  padding-bottom: 0.7rem;
+  padding-right: 0.7rem;
+  padding-left: 0.7rem; }
+
+.os-table.os-top-titled-container > table > tbody > tr > td:first-of-type:not(:only-of-type) {
+  border-left: none;
+  border-right: 0.025rem solid black; }
+
+.os-table.os-top-titled-container > table > tbody > tr:last-of-type {
+  border-bottom: 0.1rem solid black; }
+
+.os-table.os-top-titled-container .os-caption-container {
+  display: table-caption;
+  caption-side: bottom;
+  prince-caption-page: all; }
+
+.os-table.os-top-titled-container .os-caption-container > .os-title-label {
+  font-weight: bold;
+  font-family: Mulish, sans-serif; }
+
+.os-table.os-top-titled-container .os-caption-container > .os-number {
+  font-weight: bold;
+  font-family: Mulish, sans-serif; }
+
+.os-figure:not(.has-splash) > figure {
+  display: table;
+  margin-left: auto;
+  margin-right: auto; }
+
+.os-figure:not(.has-splash) .os-caption-container {
+  display: table;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 0.7rem;
+  font-size: 0.83333rem;
+  line-height: 1.5rem; }
+
+.os-figure:not(.has-splash) .os-caption-container > .os-title-label {
+  font-family: Mulish, sans-serif;
+  font-weight: bold;
+  color: #C31427; }
+
+.os-figure:not(.has-splash) .os-caption-container > .os-number {
+  font-family: Mulish, sans-serif;
+  font-weight: bold;
+  color: #C31427;
+  display: inline-block;
+  margin-right: 8px; }
+
+.os-figure:not(.has-splash) .os-caption-container > .os-title {
+  font-family: Mulish, sans-serif;
+  font-weight: bold; }
+
+.os-figure:not(.has-splash) .os-caption-container > .os-caption {
+  font-family: IBM Plex Sans, sans-serif; }
+
+.os-figure:not(.has-splash) .os-caption-container > .os-divider {
+  margin: 0; }
+
+aside[role="doc-footnote"] {
+  float: footnote;
+  color: #000000;
+  line-height: 1.5rem;
+  font-family: IBM Plex Serif, serif;
+  font-size: 0.83333rem;
+  text-align: left;
+  font-weight: normal; }
+
+aside[role="doc-footnote"]::footnote-call {
+  content: none; }
+
+aside[role="doc-footnote"]::footnote-marker {
+  content: none; }
+
+aside[role="doc-footnote"] [data-type="footnote-number"] {
+  display: inline-block;
+  margin-right: 8px; }
+
+a[role="doc-noteref"] {
+  font-family: IBM Plex Serif, serif;
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+  top: -0.7em;
+  padding-right: 0.16rem; }
+
+[data-type="equation"].unnumbered {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 0.7rem; }
+
+iframe {
+  display: none; }
+
+.everyday {
+  border: solid;
+  border-color: #B10069;
+  box-decoration-break: slice;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-bottom: 0.7rem;
+  padding-top: 0.7rem;
+  margin-bottom: 1.4rem;
+  position: relative; }
+
+.everyday > .os-title {
+  color: #B10069;
+  font-family: Mulish, sans-serif;
+  font-weight: bold;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  margin-top: 0;
+  margin-bottom: 0.7rem;
+  box-decoration-break: slice; }
+
+.everyday > .os-note-body > .os-subtitle, h4[data-type=title] {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-family: IBM Plex Sans, sans-serif; }
+
+.everyday > .os-note-body ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.everyday > .os-note-body ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.career > .os-title {
+  font-family: Mulish, sans-serif;
+  font-weight: 900;
+  letter-spacing: 0.05rem;
+  text-transform: uppercase;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  border-bottom-color: #B05E36;
+  border-bottom-width: 0.2rem;
+  border-bottom-style: solid;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  margin-bottom: 0.7rem; }
+
+.career > .os-title::before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuMywgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAzNi42NiAzNC45NCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzYuNjYgMzQuOTQ7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7Y2xpcC1wYXRoOnVybCgjU1ZHSURfMl8pO2ZpbGw6I0ZGRkZGRjtzdHJva2U6I0IwNUUzMjtzdHJva2Utd2lkdGg6Mi4yNTt9Cgkuc3Qxe2ZpbGw6I0IxNUUzMjt9Cjwvc3R5bGU+CjxnPgoJPGRlZnM+CgkJPHJlY3QgaWQ9IlNWR0lEXzFfIiB4PSIyLjE0IiB5PSIwLjkiIHdpZHRoPSIzMyIgaGVpZ2h0PSIzMyIvPgoJPC9kZWZzPgoJPGNsaXBQYXRoIGlkPSJTVkdJRF8yXyI+CgkJPHVzZSB4bGluazpocmVmPSIjU1ZHSURfMV8iICBzdHlsZT0ib3ZlcmZsb3c6dmlzaWJsZTsiLz4KCTwvY2xpcFBhdGg+Cgk8Y2lyY2xlIGNsYXNzPSJzdDAiIGN4PSIxOC42NCIgY3k9IjE3LjQiIHI9IjE1LjM4Ii8+CjwvZz4KPHBhdGggY2xhc3M9InN0MSIgZD0iTTEzLjU2LDEwLjd2MTUuNWgtMy4xYy0xLjE0LDAtMi4wNy0wLjkzLTIuMDctMi4wN1YxMi43NmMwLTEuMTQsMC45My0yLjA3LDIuMDctMi4wN0gxMy41NnogTTI2Ljk5LDEwLjdoLTMuMQoJdjE1LjVoMy4xYzEuMTQsMCwyLjA3LTAuOTMsMi4wNy0yLjA3VjEyLjc2QzI5LjA2LDExLjYyLDI4LjEzLDEwLjcsMjYuOTksMTAuN3ogTTIyLjg2LDEwLjd2MTUuNWgtOC4yN1Y3LjYKCWMwLTAuNTcsMC40Ni0xLjAzLDEuMDMtMS4wM2g2LjJjMC41NywwLDEuMDMsMC40NiwxLjAzLDEuMDNWMTAuN3ogTTIwLjc5LDguNjNoLTQuMTN2Mi4wN2g0LjEzVjguNjN6Ii8+Cjwvc3ZnPgo=) no-repeat top left;
+  background-size: contain;
+  height: 2.8rem;
+  width: 2.8rem;
+  display: inline-block;
+  padding-right: 0.4rem;
+  position: relative;
+  bottom: -0.5rem;
+  content: ''; }
+
+.career > .os-title > .os-number {
+  display: inline-block;
+  word-wrap: normal;
+  margin-bottom: 0.2rem;
+  margin-left: 8px; }
+
+.career > .os-title > .os-title-label {
+  display: inline-block;
+  word-wrap: normal;
+  margin-bottom: 0.2rem; }
+
+.career {
+  margin-bottom: 1.4rem;
+  border-bottom-color: #B05E36;
+  border-bottom-width: 0.2rem;
+  border-bottom-style: solid;
+  box-decoration-break: slice; }
+
+.career ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.career ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.career > .os-note-body > .os-subtitle, h4[data-type=title] {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-family: IBM Plex Sans, sans-serif; }
+
+.career > .os-note-body div:not([class]) > [data-type='title'], div[data-type='title'] {
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.career > .os-note-body ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.career > .os-note-body ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.career p:first-of-type > [data-type='title'] {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.career p > [data-type='title'] {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.career > .body > [data-type='note'] > .os-title > .os-title-label {
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.evolution > .os-title {
+  font-family: Mulish, sans-serif;
+  font-weight: 900;
+  letter-spacing: 0.05rem;
+  text-transform: uppercase;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  border-bottom-color: #F37541;
+  border-bottom-width: 0.2rem;
+  border-bottom-style: solid;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  margin-bottom: 0.7rem; }
+
+.evolution > .os-title::before {
+  background: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzNC44NiIgaGVpZ2h0PSIzNC44NiIgdmlld0JveD0iMCAwIDM0Ljg2IDM0Ljg2Ij48dGl0bGU+Y2Fybml2YWwtZXZvbHV0aW9uPC90aXRsZT48Y2lyY2xlIGN4PSIxNy40MyIgY3k9IjE3LjQzIiByPSIxNi4zMSIgZmlsbD0iI2ZmZiIgc3Ryb2tlPSIjZjQ3NjQyIiBzdHJva2Utd2lkdGg9IjIuMjUiLz48cGF0aCBkPSJNMzAuNTcsMTQuODVjLTMsMC03LjMyLjI2LTkuNTEsMi40NWE1LjQyLDUuNDIsMCwwLDAtMS4zLDQuMjQuNTguNTgsMCwwLDAsLjM5LjUxLjU3LjU3LDAsMCwwLC42MS0uMTgsMTMuMywxMy4zLDAsMCwxLDQuNTEtMy40MS42NC42NCwwLDAsMSwuNDksMCwuNTUuNTUsMCwwLDEsMCwxbC0uMDYsMGgwYTEzLjY0LDEzLjY0LDAsMCwwLTcuNDksOS4zMmMtLjcxLTQuNjEtMi4yMS03LjMzLTMuNjMtOWExMC44NiwxMC44NiwwLDAsMC0yLjYxLTIuNDQsNC41Miw0LjUyLDAsMCwxLS41OC0uNDMuNTguNTgsMCwwLDEsMC0uODEuNTkuNTksMCwwLDEsLjg0LDAsMi4zNiwyLjM2LDAsMCwwLC4yOC4ybC4xLjA3YTEyLDEyLDAsMCwxLDMuNzIsMy44Ny41Ny41NywwLDAsMCwuNTkuMjcuNTguNTgsMCwwLDAsLjQ2LS40NUE2LDYsMCwwLDAsMTYuMTUsMTVDMTQsMTIuODYsOS42NywxMi42LDYuNjMsMTIuNmEuNTguNTgsMCwwLDAtLjU3LjU3YzAsMywuMjYsNy4zMiwyLjQ1LDkuNTJBNS4yNyw1LjI3LDAsMCwwLDEyLjIzLDI0YTYuNDQsNi40NCwwLDAsMCwzLjEyLS43OGMxLjE3LDIuNDIsMi4xLDYsMi4xLDExLjU4YS41OC41OCwwLDAsMCwuNTcuNTcuNTcuNTcsMCwwLDAsLjU3LS41N0ExOC4yOCwxOC4yOCwwLDAsMSwyMS4wOSwyNWE1LjU0LDUuNTQsMCwwLDAsMy42NSwxLjNIMjVhNS4yNSw1LjI1LDAsMCwwLDMuNzMtMS4zM2MyLjE5LTIuMTksMi40NC02LjQ4LDIuNDQtOS41MkEuNTcuNTcsMCwwLDAsMzAuNTcsMTQuODVaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMS4zMiAtMi40NSkiIGZpbGw9IiNmNDc2NDEiLz48L3N2Zz4=) no-repeat top left;
+  background-size: contain;
+  height: 2.8rem;
+  width: 2.8rem;
+  display: inline-block;
+  padding-right: 0.4rem;
+  position: relative;
+  bottom: -0.5rem;
+  content: ''; }
+
+.evolution > .os-title > .os-number {
+  display: inline-block;
+  word-wrap: normal;
+  margin-bottom: 0.2rem;
+  margin-left: 8px; }
+
+.evolution > .os-title > .os-title-label {
+  display: inline-block;
+  word-wrap: normal;
+  margin-bottom: 0.2rem; }
+
+.evolution {
+  margin-bottom: 1.4rem;
+  border-bottom-color: #F37541;
+  border-bottom-width: 0.2rem;
+  border-bottom-style: solid;
+  box-decoration-break: slice; }
+
+.evolution ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.evolution ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.evolution > .os-note-body > .os-subtitle, h4[data-type=title] {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-family: IBM Plex Sans, sans-serif; }
+
+.evolution > .os-note-body div:not([class]) > [data-type='title'], div[data-type='title'] {
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.evolution > .os-note-body ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.evolution > .os-note-body ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.evolution p:first-of-type > [data-type='title'] {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.evolution p > [data-type='title'] {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.evolution > .body > [data-type='note'] > .os-title > .os-title-label {
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.scientific > .os-title {
+  font-family: Mulish, sans-serif;
+  font-weight: 900;
+  letter-spacing: 0.05rem;
+  text-transform: uppercase;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  border-bottom-color: #0DC0DC;
+  border-bottom-width: 0.2rem;
+  border-bottom-style: solid;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  margin-bottom: 0.7rem; }
+
+.scientific > .os-title::before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuMywgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA0My43IDM5LjQ0IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA0My43IDM5LjQ0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0ZGRkZGRjtzdHJva2U6IzBEQzBEQztzdHJva2Utd2lkdGg6Mi4yNTt9Cgkuc3Qxe2ZpbGw6IzE1QzBEQzt9Cjwvc3R5bGU+CjxnPgoJPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMjIuMTMiIGN5PSIyMC4xNyIgcj0iMTUuMzgiLz4KPC9nPgo8cGF0aCBjbGFzcz0ic3QxIiBkPSJNMjkuOTMsMTAuMzZoLTUuNzFjLTAuNTItMS4xOC0xLjktMS43My0zLjA4LTEuMjFjLTAuNTQsMC4yNC0wLjk3LDAuNjctMS4yMSwxLjIxSDE0LjIKCWMtMC4zMiwwLTAuNTksMC4yNi0wLjU5LDAuNTl2MTguMWMwLDAuMzIsMC4yNiwwLjU5LDAuNTksMC41OWgxNS43MmMwLjMyLDAsMC41OS0wLjI2LDAuNTktMC41OXYtMTguMQoJQzMwLjUxLDEwLjYyLDMwLjI1LDEwLjM2LDI5LjkzLDEwLjM2eiBNMTguNDksMTEuNTNoMS44NWMwLjI4LTAuMDEsMC41MS0wLjIxLDAuNTgtMC40OGMwLjE1LTAuNjQsMC44LTEuMDMsMS40NC0wLjg4CgljMC4xNiwwLjA0LDAuMzEsMC4xMSwwLjQ0LDAuMmMwLjIyLDAuMTcsMC4zOCwwLjQyLDAuNDMsMC43YzAuMDYsMC4yNiwwLjMsMC40NSwwLjU3LDAuNDVoMS44NXYxLjA3YzAsMC41Mi0wLjQyLDAuOTQtMC45NCwwLjk0CgloLTUuMjdjLTAuNTIsMC0wLjk0LTAuNDItMC45NC0wLjk0TDE4LjQ5LDExLjUzeiBNMjAuMzUsMjUuMzRjMCwwLjMyLTAuMjYsMC41OS0wLjU5LDAuNTloLTIuNWMtMC4zMiwwLTAuNTktMC4yNi0wLjU5LTAuNTl2LTIuMjYKCWMwLTAuMzIsMC4yNi0wLjU5LDAuNTktMC41OWgyLjVjMC4zMiwwLDAuNTksMC4yNiwwLjU5LDAuNTlMMjAuMzUsMjUuMzR6IE0yMC4zNSwxOS43MmMwLDAuMzItMC4yNiwwLjU5LTAuNTksMC41OWgtMi41CgljLTAuMzIsMC0wLjU5LTAuMjYtMC41OS0wLjU5di0yLjI2YzAtMC4zMiwwLjI2LTAuNTksMC41OS0wLjU5aDIuNWMwLjMyLDAsMC41OSwwLjI2LDAuNTksMC41OUwyMC4zNSwxOS43MnogTTI3LjQ1LDI0LjhoLTUuMjIKCXYtMS4xN2g1LjIyVjI0Ljh6IE0yNy40NSwxOS4xOGgtNS4yMnYtMS4xN2g1LjIyVjE5LjE4eiIvPgo8L3N2Zz4K) no-repeat top left;
+  background-size: contain;
+  height: 2.8rem;
+  width: 2.8rem;
+  display: inline-block;
+  padding-right: 0.4rem;
+  position: relative;
+  bottom: -0.5rem;
+  content: ''; }
+
+.scientific > .os-title > .os-number {
+  display: inline-block;
+  word-wrap: normal;
+  margin-bottom: 0.2rem;
+  margin-left: 8px; }
+
+.scientific > .os-title > .os-title-label {
+  display: inline-block;
+  word-wrap: normal;
+  margin-bottom: 0.2rem; }
+
+.scientific {
+  margin-bottom: 1.4rem;
+  border-bottom-color: #0DC0DC;
+  border-bottom-width: 0.2rem;
+  border-bottom-style: solid;
+  box-decoration-break: slice; }
+
+.scientific ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.scientific ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.scientific > .os-note-body > .os-subtitle, h4[data-type=title] {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-family: IBM Plex Sans, sans-serif; }
+
+.scientific > .os-note-body div:not([class]) > [data-type='title'], div[data-type='title'] {
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.scientific > .os-note-body ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.scientific > .os-note-body ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.scientific p:first-of-type > [data-type='title'] {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.scientific p > [data-type='title'] {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.scientific > .body > [data-type='note'] > .os-title > .os-title-label {
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.visual-connection > .os-title {
+  font-family: Mulish, sans-serif;
+  font-weight: 900;
+  letter-spacing: 0.05rem;
+  text-transform: uppercase;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  border-bottom-color: #0074BC;
+  border-bottom-width: 0.2rem;
+  border-bottom-style: solid;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  margin-bottom: 0.7rem; }
+
+.visual-connection > .os-title::before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuMywgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAzOS41MyA0MC4xNyIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzkuNTMgNDAuMTc7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRkZGRkZGO3N0cm9rZTojMDA3NEJDO3N0cm9rZS13aWR0aDoyLjI1O30KCS5zdDF7ZmlsbDojMDM3NEJDO30KPC9zdHlsZT4KPGc+Cgk8Y2lyY2xlIGNsYXNzPSJzdDAiIGN4PSIxOS41NyIgY3k9IjIwLjM4IiByPSIxNy41Ii8+CjwvZz4KPHBhdGggY2xhc3M9InN0MSIgZD0iTTM0LjczLDIxLjAxYy0wLjI3LTAuMzMtNi43NS04LjA5LTE0Ljk1LTguMDlTNS4xMSwyMC42OCw0Ljg0LDIxLjAxYy0wLjMsMC4zNi0wLjI1LDAuOSwwLjEyLDEuMTkKCWMwLjM2LDAuMywwLjksMC4yNSwxLjE5LTAuMTJjMC4wMS0wLjAyLDAuMzYtMC40MywwLjk2LTEuMDRjMS41LDEuNjQsNi41Myw2LjU5LDEyLjY4LDYuNTlzMTEuMTctNC45NCwxMi42OC02LjU5CgljMC42LDAuNjIsMC45NSwxLjAyLDAuOTYsMS4wNGMwLjE3LDAuMiwwLjQxLDAuMzEsMC42NiwwLjMxYzAuMTksMCwwLjM4LTAuMDYsMC41NC0wLjE5QzM0Ljk4LDIxLjksMzUuMDMsMjEuMzcsMzQuNzMsMjEuMDF6CgkgTTI1LjQ1LDIwLjI3YzAsMy4xMi0yLjU0LDUuNjYtNS42Niw1LjY2Yy0zLjEyLDAtNS42Ni0yLjU0LTUuNjYtNS42NnMyLjU0LTUuNjYsNS42Ni01LjY2QzIyLjkxLDE0LjYxLDI1LjQ1LDE3LjE1LDI1LjQ1LDIwLjI3egoJIE04LjM0LDE5Ljg3YzEuMzItMS4xOSwzLjE3LTIuNjIsNS4zNC0zLjdjLTAuNzksMS4xNy0xLjI1LDIuNTgtMS4yNSw0LjFjMCwxLjM3LDAuMzgsMi42NSwxLjA0LDMuNzUKCUMxMC45OCwyMi41OCw5LjEsMjAuNjksOC4zNCwxOS44N3ogTTI2LjEsMjQuMDJjMC42Ni0xLjEsMS4wNC0yLjM4LDEuMDQtMy43NWMwLTEuNTItMC40Ni0yLjkzLTEuMjUtNC4xCgljMi4xNywxLjA3LDQuMDIsMi41MSw1LjM0LDMuN0MzMC40NywyMC42OSwyOC42LDIyLjU4LDI2LjEsMjQuMDJ6Ii8+CjxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0xOS43OSwyNC44MmMyLjUxLDAsNC41NS0yLjA0LDQuNTUtNC41NWMwLTAuNS0wLjA5LTAuOTktMC4yMy0xLjQ0Yy0wLjM1LDAuNzEtMS4wOCwxLjE5LTEuOTIsMS4xOQoJYy0xLjE5LDAtMi4xNS0wLjk3LTIuMTUtMi4xNWMwLTAuODQsMC40OS0xLjU2LDEuMTktMS45MmMtMC40NS0wLjE1LTAuOTMtMC4yMy0xLjQ0LTAuMjNjLTIuNTEsMC00LjU1LDIuMDQtNC41NSw0LjU1CglDMTUuMjQsMjIuNzksMTcuMjcsMjQuODIsMTkuNzksMjQuODJ6Ii8+Cjwvc3ZnPgo=) no-repeat top left;
+  background-size: contain;
+  height: 2.8rem;
+  width: 2.8rem;
+  display: inline-block;
+  padding-right: 0.4rem;
+  position: relative;
+  bottom: -0.5rem;
+  content: ''; }
+
+.visual-connection > .os-title > .os-number {
+  display: inline-block;
+  word-wrap: normal;
+  margin-bottom: 0.2rem;
+  margin-left: 8px; }
+
+.visual-connection > .os-title > .os-title-label {
+  display: inline-block;
+  word-wrap: normal;
+  margin-bottom: 0.2rem; }
+
+.visual-connection {
+  margin-bottom: 1.4rem;
+  border-bottom-color: #0074BC;
+  border-bottom-width: 0.2rem;
+  border-bottom-style: solid;
+  box-decoration-break: slice; }
+
+.visual-connection ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.visual-connection ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.visual-connection > .os-note-body > .os-subtitle, h4[data-type=title] {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-family: IBM Plex Sans, sans-serif; }
+
+.visual-connection > .os-note-body div:not([class]) > [data-type='title'], div[data-type='title'] {
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.visual-connection > .os-note-body ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.visual-connection > .os-note-body ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.visual-connection p:first-of-type > [data-type='title'] {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.visual-connection p > [data-type='title'] {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.visual-connection > .body > [data-type='note'] > .os-title > .os-title-label {
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.sciences-interconnect > .os-title {
+  font-family: Mulish, sans-serif;
+  font-weight: 900;
+  letter-spacing: 0.05rem;
+  text-transform: uppercase;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  border-bottom-color: #F37541;
+  border-bottom-width: 0.2rem;
+  border-bottom-style: solid;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  margin-bottom: 0.7rem; }
+
+.sciences-interconnect > .os-title::before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuMywgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAzNi44IDM1LjY0IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAzNi44IDM1LjY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2NsaXAtcGF0aDp1cmwoI1NWR0lEXzJfKTtmaWxsOiNGRkZGRkY7c3Ryb2tlOiNGNDc2NDI7c3Ryb2tlLXdpZHRoOjIuMjU7fQoJLnN0MXtmaWxsOiNGNDc2NDE7c3Ryb2tlOiNGNDc2NDE7c3Ryb2tlLXdpZHRoOjEuNTt9Cjwvc3R5bGU+CjxnPgoJPGRlZnM+CgkJPHJlY3QgaWQ9IlNWR0lEXzFfIiB4PSIxLjEyIiB5PSIwLjQxIiB3aWR0aD0iMzUiIGhlaWdodD0iMzUiLz4KCTwvZGVmcz4KCTxjbGlwUGF0aCBpZD0iU1ZHSURfMl8iPgoJCTx1c2UgeGxpbms6aHJlZj0iI1NWR0lEXzFfIiAgc3R5bGU9Im92ZXJmbG93OnZpc2libGU7Ii8+Cgk8L2NsaXBQYXRoPgoJPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMTguNjIiIGN5PSIxNy45MSIgcj0iMTYuMzEiLz4KPC9nPgo8cGF0aCBjbGFzcz0ic3QxIiBkPSJNMTguOTgsMjYuNzFjMS4yNSwwLDIuMjktMC45NCwyLjQ1LTIuMTRoNS42OGMwLjE4LDAsMC4zMy0wLjE1LDAuMzMtMC4zM1YxMS4yOGMwLTAuMTgtMC4xNS0wLjMzLTAuMzMtMC4zMwoJaC0zLjU0bDEuNDMtMS40M2MwLjEzLTAuMTMsMC4xMy0wLjMzLDAtMC40NWMtMC4xMy0wLjEzLTAuMzMtMC4xMy0wLjQ1LDBsLTEuOTYsMS45OGMtMC4wNSwwLjA1LTAuMDksMC4xNS0wLjA5LDAuMjIKCXMwLjA0LDAuMTYsMC4wOSwwLjIybDEuOTgsMS45OGMwLjA1LDAuMDUsMC4xNSwwLjA5LDAuMjIsMC4wOWMwLjA3LDAsMC4xNi0wLjA0LDAuMjItMC4wOWMwLjEzLTAuMTMsMC4xMy0wLjMzLDAtMC40NWwtMS40My0xLjQzCgloMy4yMVYyMy45aC01LjM3Yy0wLjE2LTEuMjItMS4yLTIuMTQtMi40NS0yLjE0Yy0xLjM2LDAtMi40NywxLjExLTIuNDcsMi40N1MxNy42MiwyNi43MSwxOC45OCwyNi43MXogTTE4Ljk4LDIyLjQxCgljMS4wMiwwLDEuODMsMC44MiwxLjgzLDEuODNzLTAuODQsMS44My0xLjgzLDEuODNjLTEsMC0xLjgzLTAuODItMS44My0xLjgzUzE3Ljk2LDIyLjQxLDE4Ljk4LDIyLjQxeiBNMTAuODUsMjQuNjRoMy41NGwtMS40MywxLjQzCgljLTAuMTMsMC4xMy0wLjEzLDAuMzMsMCwwLjQ1YzAuMDUsMC4wNSwwLjE1LDAuMDksMC4yMiwwLjA5czAuMTYtMC4wNCwwLjIyLTAuMDlsMS45OC0xLjk4YzAuMTMtMC4xMywwLjEzLTAuMzMsMC0wLjQ1bC0xLjk4LTEuOTgKCWMtMC4xMy0wLjEzLTAuMzMtMC4xMy0wLjQ1LDBjLTAuMTMsMC4xMy0wLjEzLDAuMzMsMCwwLjQ1TDE0LjM3LDI0aC0zLjE5VjExLjY4aDUuMzdjMC4xNiwxLjIyLDEuMiwyLjE0LDIuNDUsMi4xNAoJYzEuMzYsMCwyLjQ3LTEuMTEsMi40Ny0yLjQ3cy0xLjEzLTIuNDctMi40OS0yLjQ3Yy0xLjI1LDAtMi4yOSwwLjk0LTIuNDUsMi4xNGgtNS42OGMtMC4xOCwwLTAuMzMsMC4xNS0wLjMzLDAuMzN2MTIuOTYKCUMxMC41NCwyNC40OSwxMC42OCwyNC42NCwxMC44NSwyNC42NHogTTE4Ljk4LDkuNTJjMS4wMiwwLDEuODMsMC44MiwxLjgzLDEuODNzLTAuODQsMS44My0xLjgzLDEuODNjLTEsMC0xLjgzLTAuODItMS44My0xLjgzCglTMTcuOTYsOS41MiwxOC45OCw5LjUyeiIvPgo8L3N2Zz4K) no-repeat top left;
+  background-size: contain;
+  height: 2.8rem;
+  width: 2.8rem;
+  display: inline-block;
+  padding-right: 0.4rem;
+  position: relative;
+  bottom: -0.5rem;
+  content: ''; }
+
+.sciences-interconnect > .os-title > .os-number {
+  display: inline-block;
+  word-wrap: normal;
+  margin-bottom: 0.2rem;
+  margin-left: 8px; }
+
+.sciences-interconnect > .os-title > .os-title-label {
+  display: inline-block;
+  word-wrap: normal;
+  margin-bottom: 0.2rem; }
+
+.sciences-interconnect {
+  margin-bottom: 1.4rem;
+  border-bottom-color: #F37541;
+  border-bottom-width: 0.2rem;
+  border-bottom-style: solid;
+  box-decoration-break: slice; }
+
+.sciences-interconnect ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.sciences-interconnect ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.sciences-interconnect > .os-note-body > .os-subtitle, h4[data-type=title] {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-family: IBM Plex Sans, sans-serif; }
+
+.sciences-interconnect > .os-note-body div:not([class]) > [data-type='title'], div[data-type='title'] {
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.sciences-interconnect > .os-note-body ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.sciences-interconnect > .os-note-body ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.sciences-interconnect p:first-of-type > [data-type='title'] {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.sciences-interconnect p > [data-type='title'] {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.sciences-interconnect > .body > [data-type='note'] > .os-title > .os-title-label {
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.interactive:not(.non-majors) {
+  margin-bottom: 1.4rem;
+  box-decoration-break: slice; }
+
+.interactive:not(.non-majors) > .os-note-body {
+  border-bottom-style: solid;
+  border-bottom-width: 0.2rem;
+  border-bottom-color: #78B042;
+  box-decoration-break: slice; }
+
+.interactive:not(.non-majors) > .os-note-body > p {
+  margin-bottom: 0.7rem; }
+
+.interactive:not(.non-majors) > .os-note-body ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.interactive:not(.non-majors) > .os-note-body ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.interactive:not(.non-majors) > .os-title {
+  margin-bottom: 0.7rem;
+  font-weight: 900;
+  letter-spacing: 0.05rem;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-family: Mulish, sans-serif; }
+
+.interactive:not(.non-majors) > .os-title > .os-title-label {
+  display: inline-block;
+  word-wrap: normal;
+  text-transform: uppercase; }
+
+.interactive:not(.non-majors) > .os-title::before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuMywgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAyNyAyNyIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMjcgMjc7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRkZGRkZGO3N0cm9rZTojNzlCMTQyO3N0cm9rZS13aWR0aDoyLjI1O30KCS5zdDF7ZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7ZmlsbDojNzlCMTQyO30KPC9zdHlsZT4KPGcgaWQ9IlBhZ2UtMSI+Cgk8ZyBpZD0iSWNvbi1HdWlkZSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTExNS4wMDAwMDAsIC0xOC4wMDAwMDApIj4KCQk8ZyBpZD0iR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDExNi4wMDAwMDAsIDE5LjAwMDAwMCkiPgoJCQk8cGF0aCBpZD0iU3Ryb2tlLTMzIiBjbGFzcz0ic3QwIiBkPSJNMjQuMzMsMTIuMTJjMCw2LjYzLTUuMzcsMTItMTIsMTJzLTEyLTUuMzctMTItMTJzNS4zNy0xMiwxMi0xMgoJCQkJQzE4Ljk1LDAuMTIsMjQuMzMsNS41LDI0LjMzLDEyLjEyeiIvPgoJCQk8cGF0aCBpZD0iRmlsbC0xNSIgY2xhc3M9InN0MSIgZD0iTTEyLjEyLDUuMjJsLTIuMDYsMi4wOUM5LjksNy40OSw5LjczLDcuNjgsOS42LDcuODhDOS41Niw3LjkyLDkuNTQsNy45Nyw5LjUxLDguMDEKCQkJCWMwLjk5LTAuMjcsMi4wNS0wLjI2LDMuMDMsMC4wNWwwLjE3LTAuMTdsMS4xMy0xLjE1YzAuOTktMS4wMSwyLjYtMS4wMSwzLjU5LDBjMC45OSwxLjAxLDAuOTksMi42NCwwLDMuNjVsLTEuMjksMS4zMQoJCQkJbC0wLjI3LDAuMjdsLTAuMjYsMC4yNmwwLDBsLTAuNDMsMC40NGMtMC40NSwwLjQ1LTEuMDIsMC43LTEuNiwwLjc1bDAsMGwwLDBjLTAuMTIsMC4wMS0wLjIzLDAuMDEtMC4zMSwwLjAxCgkJCQljLTAuMDcsMC0wLjE3LTAuMDEtMC4xNy0wLjAxbC0wLjE1LTAuMDNsMCwwYy0wLjQ5LTAuMDktMC45Ny0wLjMzLTEuMzYtMC43MmMtMC4zNy0wLjM4LTAuNi0wLjg1LTAuNy0xLjMzCgkJCQljMC0wLjAxLDAtMC4wMy0wLjAxLTAuMDRjLTAuNDMsMC4wNC0wLjg2LDAuMjItMS4xOSwwLjU2bC0wLjY4LDAuNjljMC4yNCwwLjYsMC41OSwxLjE3LDEuMDcsMS42NnMxLjAzLDAuODUsMS42MywxLjA5CgkJCQljMC4xMSwwLjA0LDAuMjIsMC4wOCwwLjMzLDAuMTJjMC4wOSwwLjAzLDAuMTksMC4wNiwwLjI5LDAuMDhjMC4wMSwwLDAuMDEsMCwwLjAyLDBjMC4wMiwwLDAuMDMsMC4wMSwwLjA1LDAuMDEKCQkJCWMwLjk4LDAuMjMsMi4wMywwLjE0LDIuOTYtMC4yNmMwLjEyLTAuMDUsMC4yMy0wLjEsMC4zNC0wLjE2YzAuMDEsMCwwLjAxLTAuMDEsMC4wMi0wLjAxYzAuMDItMC4wMSwwLjA0LTAuMDIsMC4wNi0wLjAzCgkJCQljMC4wNS0wLjAzLDAuMS0wLjA1LDAuMTQtMC4wOGwwLDBjMC4zNC0wLjIxLDAuNjYtMC40NiwwLjk1LTAuNzVsMi4wNS0yLjA5YzEuODgtMS45MSwxLjg4LTUsMC02LjkKCQkJCUMxNy4wNCwzLjMyLDE0LDMuMzIsMTIuMTIsNS4yMiIvPgoJCQk8cGF0aCBpZD0iRmlsbC0xNyIgY2xhc3M9InN0MSIgZD0iTTEyLjI4LDE4Ljg2bDIuMDYtMi4wOWMwLjE4LTAuMTgsMC4zMy0wLjM3LDAuNDgtMC41N2MwLjAzLTAuMDQsMC4wNi0wLjA5LDAuMDktMC4xMwoJCQkJYy0wLjk5LDAuMjctMi4wNSwwLjI2LTMuMDMtMC4wNWwtMC4xNywwLjE4bC0xLjEzLDEuMTVjLTAuOTksMS4wMS0yLjYsMS4wMS0zLjU5LDBzLTAuOTktMi42NCwwLTMuNjVsMS4yOS0xLjMxbDAuMjctMC4yNwoJCQkJbDAuMjYtMC4yNmwwLDBsMC40My0wLjQ0YzAuNDUtMC40NiwxLjAyLTAuNywxLjYtMC43NWwwLDBsMCwwYzAuMTItMC4wMSwwLjIzLTAuMDEsMC4zMS0wLjAxYzAuMiwwLjAxLDAuMzEsMC4wNCwwLjMxLDAuMDRsMCwwCgkJCQlsMCwwYzAuNDksMC4wOSwwLjk3LDAuMzMsMS4zNSwwLjcyYzAuMzcsMC4zOCwwLjYsMC44NCwwLjcsMS4zM2MwLDAuMDEsMCwwLjAzLDAuMDEsMC4wNGMwLjQzLTAuMDQsMC44Ny0wLjIyLDEuMTktMC41NgoJCQkJbDAuNjgtMC43Yy0wLjI0LTAuNi0wLjU5LTEuMTctMS4wNy0xLjY2cy0xLjAzLTAuODUtMS42My0xLjA5Yy0wLjExLTAuMDQtMC4yMi0wLjA4LTAuMzMtMC4xMmMtMC4xLTAuMDMtMC4xOS0wLjA2LTAuMjktMC4wOAoJCQkJYy0wLjAxLDAtMC4wMSwwLTAuMDItMC4wMWMtMC4wMiwwLTAuMDMtMC4wMS0wLjA1LTAuMDFjLTAuOTgtMC4yMy0yLjAzLTAuMTQtMi45NiwwLjI2QzguOTUsOC44OSw4LjgzLDguOTQsOC43Miw5CgkJCQlDOC43MSw5LDguNzEsOS4wMSw4LjcsOS4wMUM4LjY4LDkuMDIsOC42Niw5LjAzLDguNjQsOS4wNEM4LjU5LDkuMDcsOC41NCw5LjA5LDguNSw5LjEybDAsMGMtMC4zNCwwLjItMC42NiwwLjQ1LTAuOTUsMC43NQoJCQkJbC0yLjA2LDIuMDljLTEuODgsMS45MS0xLjg4LDUsMCw2LjlDNy4zNywyMC43NywxMC40MSwyMC43NywxMi4yOCwxOC44NiIvPgoJCTwvZz4KCTwvZz4KPC9nPgo8L3N2Zz4K) no-repeat top left;
+  background-size: contain;
+  height: 1.4rem;
+  width: 1.4rem;
+  display: inline-block;
+  position: relative;
+  content: '';
+  padding-right: 8px; }
+
+.interactive.non-majors {
+  margin-bottom: 1.4rem;
+  box-decoration-break: slice; }
+
+.interactive.non-majors > .os-note-body {
+  border-bottom-style: solid;
+  border-bottom-width: 0.2rem;
+  border-bottom-color: #78B042;
+  box-decoration-break: slice; }
+
+.interactive.non-majors > .os-note-body > p {
+  margin-bottom: 0.7rem; }
+
+.interactive.non-majors > .os-note-body ul {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.interactive.non-majors > .os-note-body ol {
+  margin-left: 24px;
+  margin-bottom: 0.7rem; }
+
+.interactive.non-majors > .os-title {
+  margin-bottom: 0.7rem;
+  font-weight: 900;
+  letter-spacing: 0.05rem;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-family: Mulish, sans-serif; }
+
+.interactive.non-majors > .os-title > .os-title-label {
+  display: inline-block;
+  word-wrap: normal;
+  text-transform: uppercase; }
+
+.interactive.non-majors > .os-title::before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuMywgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAyNyAyNyIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMjcgMjc7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRkZGRkZGO3N0cm9rZTojNzlCMTQyO3N0cm9rZS13aWR0aDoyLjI1O30KCS5zdDF7ZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7ZmlsbDojNzlCMTQyO30KPC9zdHlsZT4KPGcgaWQ9IlBhZ2UtMSI+Cgk8ZyBpZD0iSWNvbi1HdWlkZSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTExNS4wMDAwMDAsIC0xOC4wMDAwMDApIj4KCQk8ZyBpZD0iR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDExNi4wMDAwMDAsIDE5LjAwMDAwMCkiPgoJCQk8cGF0aCBpZD0iU3Ryb2tlLTMzIiBjbGFzcz0ic3QwIiBkPSJNMjQuMzMsMTIuMTJjMCw2LjYzLTUuMzcsMTItMTIsMTJzLTEyLTUuMzctMTItMTJzNS4zNy0xMiwxMi0xMgoJCQkJQzE4Ljk1LDAuMTIsMjQuMzMsNS41LDI0LjMzLDEyLjEyeiIvPgoJCQk8cGF0aCBpZD0iRmlsbC0xNSIgY2xhc3M9InN0MSIgZD0iTTEyLjEyLDUuMjJsLTIuMDYsMi4wOUM5LjksNy40OSw5LjczLDcuNjgsOS42LDcuODhDOS41Niw3LjkyLDkuNTQsNy45Nyw5LjUxLDguMDEKCQkJCWMwLjk5LTAuMjcsMi4wNS0wLjI2LDMuMDMsMC4wNWwwLjE3LTAuMTdsMS4xMy0xLjE1YzAuOTktMS4wMSwyLjYtMS4wMSwzLjU5LDBjMC45OSwxLjAxLDAuOTksMi42NCwwLDMuNjVsLTEuMjksMS4zMQoJCQkJbC0wLjI3LDAuMjdsLTAuMjYsMC4yNmwwLDBsLTAuNDMsMC40NGMtMC40NSwwLjQ1LTEuMDIsMC43LTEuNiwwLjc1bDAsMGwwLDBjLTAuMTIsMC4wMS0wLjIzLDAuMDEtMC4zMSwwLjAxCgkJCQljLTAuMDcsMC0wLjE3LTAuMDEtMC4xNy0wLjAxbC0wLjE1LTAuMDNsMCwwYy0wLjQ5LTAuMDktMC45Ny0wLjMzLTEuMzYtMC43MmMtMC4zNy0wLjM4LTAuNi0wLjg1LTAuNy0xLjMzCgkJCQljMC0wLjAxLDAtMC4wMy0wLjAxLTAuMDRjLTAuNDMsMC4wNC0wLjg2LDAuMjItMS4xOSwwLjU2bC0wLjY4LDAuNjljMC4yNCwwLjYsMC41OSwxLjE3LDEuMDcsMS42NnMxLjAzLDAuODUsMS42MywxLjA5CgkJCQljMC4xMSwwLjA0LDAuMjIsMC4wOCwwLjMzLDAuMTJjMC4wOSwwLjAzLDAuMTksMC4wNiwwLjI5LDAuMDhjMC4wMSwwLDAuMDEsMCwwLjAyLDBjMC4wMiwwLDAuMDMsMC4wMSwwLjA1LDAuMDEKCQkJCWMwLjk4LDAuMjMsMi4wMywwLjE0LDIuOTYtMC4yNmMwLjEyLTAuMDUsMC4yMy0wLjEsMC4zNC0wLjE2YzAuMDEsMCwwLjAxLTAuMDEsMC4wMi0wLjAxYzAuMDItMC4wMSwwLjA0LTAuMDIsMC4wNi0wLjAzCgkJCQljMC4wNS0wLjAzLDAuMS0wLjA1LDAuMTQtMC4wOGwwLDBjMC4zNC0wLjIxLDAuNjYtMC40NiwwLjk1LTAuNzVsMi4wNS0yLjA5YzEuODgtMS45MSwxLjg4LTUsMC02LjkKCQkJCUMxNy4wNCwzLjMyLDE0LDMuMzIsMTIuMTIsNS4yMiIvPgoJCQk8cGF0aCBpZD0iRmlsbC0xNyIgY2xhc3M9InN0MSIgZD0iTTEyLjI4LDE4Ljg2bDIuMDYtMi4wOWMwLjE4LTAuMTgsMC4zMy0wLjM3LDAuNDgtMC41N2MwLjAzLTAuMDQsMC4wNi0wLjA5LDAuMDktMC4xMwoJCQkJYy0wLjk5LDAuMjctMi4wNSwwLjI2LTMuMDMtMC4wNWwtMC4xNywwLjE4bC0xLjEzLDEuMTVjLTAuOTksMS4wMS0yLjYsMS4wMS0zLjU5LDBzLTAuOTktMi42NCwwLTMuNjVsMS4yOS0xLjMxbDAuMjctMC4yNwoJCQkJbDAuMjYtMC4yNmwwLDBsMC40My0wLjQ0YzAuNDUtMC40NiwxLjAyLTAuNywxLjYtMC43NWwwLDBsMCwwYzAuMTItMC4wMSwwLjIzLTAuMDEsMC4zMS0wLjAxYzAuMiwwLjAxLDAuMzEsMC4wNCwwLjMxLDAuMDRsMCwwCgkJCQlsMCwwYzAuNDksMC4wOSwwLjk3LDAuMzMsMS4zNSwwLjcyYzAuMzcsMC4zOCwwLjYsMC44NCwwLjcsMS4zM2MwLDAuMDEsMCwwLjAzLDAuMDEsMC4wNGMwLjQzLTAuMDQsMC44Ny0wLjIyLDEuMTktMC41NgoJCQkJbDAuNjgtMC43Yy0wLjI0LTAuNi0wLjU5LTEuMTctMS4wNy0xLjY2cy0xLjAzLTAuODUtMS42My0xLjA5Yy0wLjExLTAuMDQtMC4yMi0wLjA4LTAuMzMtMC4xMmMtMC4xLTAuMDMtMC4xOS0wLjA2LTAuMjktMC4wOAoJCQkJYy0wLjAxLDAtMC4wMSwwLTAuMDItMC4wMWMtMC4wMiwwLTAuMDMtMC4wMS0wLjA1LTAuMDFjLTAuOTgtMC4yMy0yLjAzLTAuMTQtMi45NiwwLjI2QzguOTUsOC44OSw4LjgzLDguOTQsOC43Miw5CgkJCQlDOC43MSw5LDguNzEsOS4wMSw4LjcsOS4wMUM4LjY4LDkuMDIsOC42Niw5LjAzLDguNjQsOS4wNEM4LjU5LDkuMDcsOC41NCw5LjA5LDguNSw5LjEybDAsMGMtMC4zNCwwLjItMC42NiwwLjQ1LTAuOTUsMC43NQoJCQkJbC0yLjA2LDIuMDljLTEuODgsMS45MS0xLjg4LDUsMCw2LjlDNy4zNywyMC43NywxMC40MSwyMC43NywxMi4yOCwxOC44NiIvPgoJCTwvZz4KCTwvZz4KPC9nPgo8L3N2Zz4K) no-repeat top left;
+  background-size: contain;
+  height: 1.4rem;
+  width: 1.4rem;
+  display: inline-block;
+  position: relative;
+  content: '';
+  padding-right: 8px; }
+
+[data-type="chapter"] > h1 {
+  color: #0074BC;
+  font-family: Mulish, sans-serif;
+  font-size: 2.0736rem;
+  line-height: 1.5rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.1rem;
+  margin-bottom: 0.7rem; }
+
+[data-type="chapter"] > h1 > .os-text {
+  color: #000000;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 3.58318rem;
+  line-height: 3rem;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: normal;
+  display: block; }
+
+[data-type="page"]:not(.introduction).preface {
+  column-count: 2;
+  column-gap: 2.4rem;
+  column-width: auto; }
+
+[data-type="page"]:not(.introduction).preface > h1 {
+  color: #000000;
+  font-family: IBM Plex Sans, sans-serif;
+  font-weight: bold;
+  text-transform: uppercase;
+  column-span: all;
+  font-size: 3.58318rem;
+  line-height: 3rem;
+  padding-bottom: 0.7rem;
+  border-bottom-color: #000000;
+  border-bottom-width: 0.1rem;
+  border-bottom-style: solid;
+  margin-bottom: 1.4rem; }
+
+[data-type="page"]:not(.introduction) > h2 {
+  color: #0074BC;
+  font-family: Mulish, sans-serif;
+  font-size: 1.728rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: bold; }
+
+[data-type="page"]:not(.introduction) > section > h2 {
+  color: #0074BC;
+  font-family: Mulish, sans-serif;
+  font-size: 1.728rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: bold; }
+
+[data-type="page"]:not(.introduction) > section > h3 {
+  color: #0074BC;
+  font-family: Mulish, sans-serif;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: bold; }
+
+[data-type="page"]:not(.introduction) > section > section > h3 {
+  color: #0074BC;
+  font-family: Mulish, sans-serif;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: bold; }
+
+[data-type="page"]:not(.introduction) > section > section > h4 {
+  font-family: Mulish, sans-serif;
+  color: #0074BC;
+  font-weight: bold;
+  font-size: 1.2rem;
+  line-height: 1.5rem; }
+
+[data-type="page"]:not(.introduction) > section > section > section > h5 {
+  font-family: Mulish, sans-serif;
+  color: #0074BC;
+  font-weight: bold;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+[data-type="page"]:not(.introduction) span[data-type="title"] {
+  margin-right: 8px; }
+
+[data-type="page"]:not(.introduction) h4 + div.os-figure > figure {
+  padding-top: 0.7rem; }
+
+[data-type="page"]:not(.introduction).appendix > h1 {
+  color: #000000;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 3.58318rem;
+  line-height: 3rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  margin-bottom: 1.4rem; }
+
+[data-type="page"]:not(.introduction).appendix > h1 > .os-text {
+  color: #0074BC;
+  font-family: Mulish, sans-serif;
+  font-size: 2.48832rem;
+  line-height: 3rem;
+  padding-top: 0.7rem;
+  margin-top: 0.7rem;
+  font-weight: normal;
+  text-transform: none;
+  border-top-color: #000000;
+  border-top-style: solid;
+  border-top-width: 0.1rem;
+  display: block; }
+
+[data-type="chapter"] > .os-eoc[data-type="composite-page"] > h2 {
+  color: #0074BC;
+  font-family: Mulish, sans-serif;
+  font-size: 1.728rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: bold;
+  column-span: all;
+  text-transform: uppercase; }
+
+[data-type="chapter"] > .os-eoc[data-type="composite-page"] > section > a > h3 {
+  font-family: Mulish, sans-serif;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: bold; }
+
+[data-type="chapter"] > .os-eoc[data-type="composite-page"] [data-type="list"] > h3[data-type="title"] {
+  color: #000000;
+  font-family: IBM Plex Serif, serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+.os-eob > h1 {
+  color: #000000;
+  font-family: IBM Plex Sans, sans-serif;
+  font-weight: bold;
+  text-transform: uppercase;
+  column-span: all;
+  font-size: 3.58318rem;
+  line-height: 3rem;
+  padding-bottom: 0.7rem;
+  border-bottom-color: #000000;
+  border-bottom-width: 0.1rem;
+  border-bottom-style: solid;
+  margin-bottom: 1.4rem; }
+
+.os-eob > section > h2 {
+  color: #0074BC;
+  font-family: Mulish, sans-serif;
+  font-size: 1.728rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: bold; }
+
+.os-eob > div > h2 {
+  color: #0074BC;
+  font-family: Mulish, sans-serif;
+  font-size: 1.728rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: bold; }
+
+.os-eob > div > div > h3 {
+  color: #0074BC;
+  font-family: Mulish, sans-serif;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: bold; }
+
+[data-type="page"] > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="page"] > ol {
+  margin-left: 24px; }
+
+[data-type="page"] > [data-type="list"] > [data-type="title"] {
+  font-weight: bold; }
+
+[data-type="page"] > [data-type="list"] > ul[data-bullet-style='none'] {
+  list-style-type: none; }
+
+[data-type="page"] > section > ol {
+  margin-left: 24px; }
+
+[data-type="page"] > section > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="page"] > section > section > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="page"] > section > section > ol {
+  margin-left: 24px; }
+
+/*# sourceMappingURL=biology-pdf.css.map */

--- a/generic-styles/index.less
+++ b/generic-styles/index.less
@@ -149,3 +149,8 @@ body {
     font-weight: 700;
   }
 }
+
+#main-content.biology,
+#main-content.biology-2e {
+  @import "./biology.less";
+}

--- a/src/app/components/MainContent.tsx
+++ b/src/app/components/MainContent.tsx
@@ -6,6 +6,7 @@ import { Consumer } from '../context/SkipToContent';
 import { mergeRefs } from '../utils';
 
 interface Props {
+  bookSlug: string;
   className?: string;
   dangerouslySetInnerHTML?: { __html: string; };
 }
@@ -17,7 +18,7 @@ const HideOutline = styled.div`
 
 // tslint:disable-next-line:variable-name
 const MainContent = React.forwardRef<HTMLDivElement, React.PropsWithChildren<Props>>(
-  ({children, className, ...props}, ref) => <Consumer>
+  ({children, className, bookSlug, ...props}, ref) => <Consumer>
     {({registerMainContent}) => <div
       ref={mergeRefs(ref, registerMainContent)}
       className={className}
@@ -26,6 +27,7 @@ const MainContent = React.forwardRef<HTMLDivElement, React.PropsWithChildren<Pro
       <HideOutline
         id={MAIN_CONTENT_ID}
         tabIndex={-1}
+        className={bookSlug}
         {...props}
       >
         {children}

--- a/src/app/content/components/Page/PageComponent.tsx
+++ b/src/app/content/components/Page/PageComponent.tsx
@@ -136,6 +136,7 @@ export default class PageComponent extends Component<PagePropTypes> {
         key='main-content'
         ref={this.container}
         dangerouslySetInnerHTML={{ __html: html}}
+        bookSlug={(this.props.book as any).slug}
       />
       <PrevNextBar />
       <BuyBook />


### PR DESCRIPTION
for: https://github.com/openstax/unified/issues/1585

This version has our current styles + the styles from: https://raw.githubusercontent.com/openstax/cnx-recipes/master/styles/output/biology-pdf.css

There are fewer style issues than in the first version: https://github.com/openstax/rex-web/pull/1188
for example, key terms now look okay and nested figures are next to each other

Styles for biology are in a separate file and then we declare styles for each book slug (book slugs may change so maybe there is a better property that we could depend on)

Compare Biology 2e here:
http://rex-web-issue-1585-v2-fodh3szq.herokuapp.com/books/biology/pages/1-introduction
vs current version:
http://rex-web.herokuapp.com/books/biology/pages/1-introduction
