### PR TITLE
fix highlight area of images which are not inside figure element

### DIFF
--- a/generic-styles/content-common.less
+++ b/generic-styles/content-common.less
@@ -32,8 +32,8 @@ a:not([role="button"]) {
 
 img {
   max-width: 100%;
-  padding-top: 1em;
-  padding-bottom: 1em;
+  margin-top: 1em;
+  margin-bottom: 1em;
 }
 
 pre {
@@ -74,7 +74,7 @@ figure {
   // do not wrap this in a .media so it applies to editing in Aloha
   img {
     max-width: 100%;
-    padding: 0; //overrides top&bott padding on img, all img EXCEPT those in figure tags should have 1em top&bott padding
+    margin: 0; //overrides top&bott margin on img, all img EXCEPT those in figure tags should have 1em top&bott margin
   }
 
   > [data-type="media"],


### PR DESCRIPTION
for: https://github.com/openstax/unified/issues/1312

I've changed the highlight area size of images which are not inside `<figure>` element to be the same as the the ones that are inside `<figure>`.

Image inside `<figure>` (highlighted):
![obraz](https://user-images.githubusercontent.com/36712200/123642243-5d8e6480-d823-11eb-8014-ebfccb4af745.png)

Image **not** inside `<figure>` (highlighted) **BROKEN**:
![obraz](https://user-images.githubusercontent.com/36712200/123643377-9844cc80-d824-11eb-9abf-3962c43112be.png)

Image **not** inside `<figure>` (highlighted) **FIXED**:
![obraz](https://user-images.githubusercontent.com/36712200/123642688-de4d6080-d823-11eb-9df2-ff3a38f8d633.png)