### PR TITLE
update markers

### DIFF
--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -43,7 +43,7 @@ test-rail-sauce: venv
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
 		--capability screenResolution 1600x1200 \
-		--marker=$(highlighting") \
+		-m "highlighting" \
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \
 		pytest-selenium/tests

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -51,7 +51,7 @@ test-rail-sauce: venv
 sauce: venv
 	marker="$(MARKER)" && . .venv/bin/activate && pytest \
 		$${marker:+-m "$$marker"} \
-		--marker=$(highlighting) \
+		--marker="highlighting" \
 		--base-url=$(BASE_URL) \
 		--driver SauceLabs \
 		--capability avoidProxy True \

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -51,7 +51,7 @@ test-rail-sauce: venv
 sauce: venv
 	marker="$(MARKER)" && . .venv/bin/activate && pytest \
 		$${marker:+-m "$$marker"} \
-		--marker=$(highlighting") \
+		--marker=$(highlighting) \
 		--base-url=$(BASE_URL) \
 		--driver SauceLabs \
 		--capability avoidProxy True \

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -50,7 +50,7 @@ test-rail-sauce: venv
 sauce: venv
 	marker="$(MARKER)" && . .venv/bin/activate && pytest \
 		$${marker:+-m "$$marker"} \
-		-m "highlighting" \
+		-m "--highlighting" \
 		--base-url=$(BASE_URL) \
 		--driver SauceLabs \
 		--capability avoidProxy True \

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -56,7 +56,7 @@ sauce: venv
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
 		--capability screenResolution 1600x1200 \
-		$highlighting
+		--$highlighting
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \
 		pytest-selenium/tests

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -51,7 +51,7 @@ test-rail-sauce: venv
 sauce: venv
 	marker="$(MARKER)" && . .venv/bin/activate && pytest \
 		$${marker:+-m "$$marker"} \
-		-m "highlighting" \
+		+-m "highlighting" \
 		--base-url=$(BASE_URL) \
 		--driver SauceLabs \
 		--capability avoidProxy True \

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -43,6 +43,7 @@ test-rail-sauce: venv
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
 		--capability screenResolution 1600x1200 \
+		--highlighting
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \
 		pytest-selenium/tests
@@ -55,6 +56,7 @@ sauce: venv
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
 		--capability screenResolution 1600x1200 \
+		--highlighting
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \
 		pytest-selenium/tests

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -43,7 +43,7 @@ test-rail-sauce: venv
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
 		--capability screenResolution 1600x1200 \
-		--highlighting
+		--marker=$(highlighting") \
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \
 		pytest-selenium/tests
@@ -51,12 +51,12 @@ test-rail-sauce: venv
 sauce: venv
 	marker="$(MARKER)" && . .venv/bin/activate && pytest \
 		$${marker:+-m "$$marker"} \
+		--marker=$(highlighting") \
 		--base-url=$(BASE_URL) \
 		--driver SauceLabs \
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
 		--capability screenResolution 1600x1200 \
-		--$highlighting
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \
 		pytest-selenium/tests

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -43,7 +43,6 @@ test-rail-sauce: venv
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
 		--capability screenResolution 1600x1200 \
-		-m "highlighting" \
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \
 		pytest-selenium/tests
@@ -51,7 +50,7 @@ test-rail-sauce: venv
 sauce: venv
 	marker="$(MARKER)" && . .venv/bin/activate && pytest \
 		$${marker:+-m "$$marker"} \
-		+-m "highlighting" \
+		-m "highlighting" \
 		--base-url=$(BASE_URL) \
 		--driver SauceLabs \
 		--capability avoidProxy True \

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -38,6 +38,7 @@ test-rail-sauce: venv
 		--tr-password=$(TR_PASSWORD) \
 		--tr-run-id=$(TR_RUN_ID) \
 		--tr-skip-missing \
+		--highlighting \
 		--base-url=$(BASE_URL) \
 		--driver SauceLabs \
 		--capability avoidProxy True \
@@ -50,7 +51,7 @@ test-rail-sauce: venv
 sauce: venv
 	marker="$(MARKER)" && . .venv/bin/activate && pytest \
 		$${marker:+-m "$$marker"} \
-		-m "--highlighting" \
+		--highlighting \
 		--base-url=$(BASE_URL) \
 		--driver SauceLabs \
 		--capability avoidProxy True \

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -56,7 +56,7 @@ sauce: venv
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
 		--capability screenResolution 1600x1200 \
-		--highlighting
+		$highlighting
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \
 		pytest-selenium/tests

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -51,7 +51,7 @@ test-rail-sauce: venv
 sauce: venv
 	marker="$(MARKER)" && . .venv/bin/activate && pytest \
 		$${marker:+-m "$$marker"} \
-		--marker="highlighting" \
+		-m "highlighting" \
 		--base-url=$(BASE_URL) \
 		--driver SauceLabs \
 		--capability avoidProxy True \

--- a/pytest-selenium/pages/base.py
+++ b/pytest-selenium/pages/base.py
@@ -81,9 +81,9 @@ class Page(pypom.Page):
         key. Returns after loading the last element (title) of the page).
 
         """
-        title_before_click = self.driver.title
+        title_before_click = self.page_title
         element.send_keys(Keys.ENTER)
-        self.wait.until(lambda _: title_before_click != (self.driver.title))
+        self.wait.until(lambda _: title_before_click != (self.page_title))
 
     def element_is_not_interactable(self, element):
         try:

--- a/pytest-selenium/pages/base.py
+++ b/pytest-selenium/pages/base.py
@@ -81,9 +81,9 @@ class Page(pypom.Page):
         key. Returns after loading the last element (title) of the page).
 
         """
-        title_before_click = self.page_title
+        title_before_click = self.driver.title
         element.send_keys(Keys.ENTER)
-        self.wait.until(lambda _: title_before_click != (self.page_title))
+        self.wait.until(lambda _: title_before_click != (self.driver.title))
 
     def element_is_not_interactable(self, element):
         try:

--- a/pytest-selenium/tests/conftest.py
+++ b/pytest-selenium/tests/conftest.py
@@ -87,8 +87,8 @@ def pytest_collection_modifyitems(config, items):
             deselected.append(item)
         elif heroku_app and "non_heroku" in keywords:
             deselected.append(item)
-        # elif not highlighting and "highlighting" in keywords:
-        #     remaining.append(item)
+        elif not highlighting and "highlighting" in keywords:
+            deselected.append(item)
         else:
             remaining.append(item)
 

--- a/pytest-selenium/tests/conftest.py
+++ b/pytest-selenium/tests/conftest.py
@@ -87,8 +87,8 @@ def pytest_collection_modifyitems(config, items):
             deselected.append(item)
         elif heroku_app and "non_heroku" in keywords:
             deselected.append(item)
-        elif not highlighting and "highlighting" in keywords:
-            remaining.append(item)
+        # elif not highlighting and "highlighting" in keywords:
+        #     remaining.append(item)
         else:
             remaining.append(item)
 

--- a/pytest-selenium/tests/conftest.py
+++ b/pytest-selenium/tests/conftest.py
@@ -72,14 +72,8 @@ def pytest_addoption(parser):
 
 def pytest_collection_modifyitems(config, items):
     """Runtime test options."""
-    server = (
-        config.getoption("--base-url") or
-        config.getini("base_url")
-    )
-    dev_system = (
-        "//staging.openstax." not in server and
-        "//openstax." not in server
-    )
+    server = config.getoption("--base-url") or config.getini("base_url")
+    dev_system = "//staging.openstax." not in server and "//openstax." not in server
     heroku_app = "herokuapp" in server
     highlighting = config.getoption("--highlighting")
     if dev_system and not heroku_app and highlighting:
@@ -94,7 +88,7 @@ def pytest_collection_modifyitems(config, items):
         elif heroku_app and "non_heroku" in keywords:
             deselected.append(item)
         elif not highlighting and "highlighting" in keywords:
-            deselected.append(item)
+            remaining.append(item)
         else:
             remaining.append(item)
 
@@ -129,10 +123,7 @@ def chrome_options(chrome_options, pytestconfig, language):
 
     # Set the browser language
     chrome_options.add_argument("--lang={lang}".format(lang=language))
-    chrome_options.add_experimental_option(
-        "prefs",
-        {"intl.accept_languages": language}
-    )
+    chrome_options.add_experimental_option("prefs", {"intl.accept_languages": language})
 
     return chrome_options
 

--- a/pytest-selenium/tests/test_ga_events.py
+++ b/pytest-selenium/tests/test_ga_events.py
@@ -17,10 +17,7 @@ ACTION_SCRIPT = (
     "return __APP_ANALYTICS.googleAnalyticsClient.getPendingCommands()"
     ".map(x => x.command.payload);"
 )
-VIEW_ANALYTICS_QUEUE = {
-    "name": "ANALYTICS_OPT_OUT",
-    "value": "1",
-}
+VIEW_ANALYTICS_QUEUE = {"name": "ANALYTICS_OPT_OUT", "value": "1"}
 
 
 # --------------------- #
@@ -30,8 +27,7 @@ VIEW_ANALYTICS_QUEUE = {
 
 @markers.test_case("C591502")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_the_user_clicks_a_toc_link_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_the_user_clicks_a_toc_link_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when a TOC link is clicked."""
     # SETUP:
     event_action = None
@@ -39,8 +35,7 @@ def test_the_user_clicks_a_toc_link_ga_event(
     event_label = f"/books/{book_slug}/pages/{page_slug}"
 
     # GIVEN: a user viewing a book page
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -56,20 +51,19 @@ def test_the_user_clicks_a_toc_link_ga_event(
     #          eventCategory: "REX Link (toc)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     toc_link_event = Utilities.get_analytics_queue(selenium, -2)
-    assert(
-        "eventAction" in toc_link_event and
-        "eventCategory" in toc_link_event and
-        "eventLabel" in toc_link_event
+    assert (
+        "eventAction" in toc_link_event
+        and "eventCategory" in toc_link_event
+        and "eventLabel" in toc_link_event
     ), "Not viewing the correct GA event"
-    assert(toc_link_event["eventAction"] == event_action)
-    assert(toc_link_event["eventCategory"] == event_category)
-    assert(toc_link_event["eventLabel"] == event_label)
+    assert toc_link_event["eventAction"] == event_action
+    assert toc_link_event["eventCategory"] == event_category
+    assert toc_link_event["eventLabel"] == event_label
 
 
 @markers.test_case("C591503")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_user_clicks_the_order_a_print_copy_link_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_user_clicks_the_order_a_print_copy_link_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when a print link is clicked."""
     # SETUP:
     event_action = "buy-book"
@@ -77,8 +71,7 @@ def test_user_clicks_the_order_a_print_copy_link_ga_event(
     event_label = f"/books/{book_slug}/pages/{page_slug}"
 
     # GIVEN: a user viewing a book page
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -91,29 +84,23 @@ def test_user_clicks_the_order_a_print_copy_link_ga_event(
     #          eventCategory: "REX Link (toolbar)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_action)
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert last_event["eventAction"] == event_action
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621361", "C621362")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-2-the-scientific-methods")]
-)
+@markers.parametrize("book_slug, page_slug", [("physics", "1-2-the-scientific-methods")])
 def test_user_clicks_the_previous_and_next_page_links_ga_events(
-        selenium, base_url, book_slug, page_slug):
+    selenium, base_url, book_slug, page_slug
+):
     """The page submits the correct GA event when the page link is clicked."""
     # SETUP:
     label = "[data-analytics-label={label}]"
-    load_script = (
-        'return document.querySelector("[data-analytics-label={label}]");'
-    )
+    load_script = 'return document.querySelector("[data-analytics-label={label}]");'
     next_event_action = "next"
     next_event_category = "REX Link (prev-next)"
     next_event_label = None  # Not yet known
@@ -122,8 +109,7 @@ def test_user_clicks_the_previous_and_next_page_links_ga_events(
     previous_event_label = f"/books/{book_slug}/pages/{page_slug}"
 
     # GIVEN: a user viewing a book that is not the first book page
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -131,13 +117,11 @@ def test_user_clicks_the_previous_and_next_page_links_ga_events(
     # WHEN:  they click the 'Previous' link
     #        (use a script because we need the events before the page changes)
     events = selenium.execute_script(
-        ACTION_SCRIPT.format(
-            selector=label.format(label=previous_event_action)
-        )
+        ACTION_SCRIPT.format(selector=label.format(label=previous_event_action))
     )
-    book.wait.until(lambda _: book.driver.execute_script(
-        load_script.format(label=next_event_action)
-    ))
+    book.wait.until(
+        lambda _: book.driver.execute_script(load_script.format(label=next_event_action))
+    )
 
     # THEN:  the correct Google Analytics event is queued
     #        { eventAction: "prev",
@@ -145,21 +129,19 @@ def test_user_clicks_the_previous_and_next_page_links_ga_events(
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     next_event_label = "/".join([""] + selenium.current_url.split("/")[3:])
     transition_event = events[-2]
-    assert(
-        "eventAction" in transition_event and
-        "eventCategory" in transition_event and
-        "eventLabel" in transition_event
+    assert (
+        "eventAction" in transition_event
+        and "eventCategory" in transition_event
+        and "eventLabel" in transition_event
     ), "Not viewing the correct GA event"
-    assert(transition_event["eventAction"] == previous_event_action)
-    assert(transition_event["eventCategory"] == previous_event_category)
-    assert(transition_event["eventLabel"] == previous_event_label)
+    assert transition_event["eventAction"] == previous_event_action
+    assert transition_event["eventCategory"] == previous_event_category
+    assert transition_event["eventLabel"] == previous_event_label
 
     # WHEN:  they click the 'Next' link
     #        (use a script because we need the events before the page changes)
     events = selenium.execute_script(
-        ACTION_SCRIPT.format(
-            selector=label.format(label=next_event_action)
-        )
+        ACTION_SCRIPT.format(selector=label.format(label=next_event_action))
     )
 
     # THEN:  the correct Google Analytics event is queued
@@ -167,20 +149,19 @@ def test_user_clicks_the_previous_and_next_page_links_ga_events(
     #          eventCategory: "REX Link (prev-next)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     transition_event = events[-2]
-    assert(
-        "eventAction" in transition_event and
-        "eventCategory" in transition_event and
-        "eventLabel" in transition_event
+    assert (
+        "eventAction" in transition_event
+        and "eventCategory" in transition_event
+        and "eventLabel" in transition_event
     ), "Not viewing the correct GA event"
-    assert(transition_event["eventAction"] == next_event_action)
-    assert(transition_event["eventCategory"] == next_event_category)
-    assert(transition_event["eventLabel"] == next_event_label)
+    assert transition_event["eventAction"] == next_event_action
+    assert transition_event["eventCategory"] == next_event_category
+    assert transition_event["eventLabel"] == next_event_label
 
 
 @markers.test_case("C621363")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_user_logout_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_user_logout_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when a user logs out."""
     # SETUP:
     event_action = f"/accounts/logout?r=/books/{book_slug}/pages/{page_slug}"
@@ -202,20 +183,19 @@ def test_user_logout_ga_event(
     #          eventCategory: "REX Link (openstax-navbar)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     log_out_event = events[-2]
-    assert(
-        "eventAction" in log_out_event and
-        "eventCategory" in log_out_event and
-        "eventLabel" in log_out_event
+    assert (
+        "eventAction" in log_out_event
+        and "eventCategory" in log_out_event
+        and "eventLabel" in log_out_event
     ), "Not viewing the correct GA event"
-    assert(log_out_event["eventAction"] == event_action)
-    assert(log_out_event["eventCategory"] == event_category)
-    assert(log_out_event["eventLabel"] == event_label)
+    assert log_out_event["eventAction"] == event_action
+    assert log_out_event["eventCategory"] == event_category
+    assert log_out_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621364", "C621366")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_open_and_close_the_table_of_contents_ga_events(
-        selenium, base_url, book_slug, page_slug):
+def test_open_and_close_the_table_of_contents_ga_events(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when the ToC is opened."""
     # SETUP:
     close_event_action = "Click to close the Table of Contents"
@@ -226,8 +206,7 @@ def test_open_and_close_the_table_of_contents_ga_events(
     open_event_label = close_event_label
 
     # GIVEN: a user viewing a book page and the ToC is open
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -242,14 +221,12 @@ def test_open_and_close_the_table_of_contents_ga_events(
     #          eventCategory: "REX Button (toc)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == close_event_action)
-    assert(last_event["eventCategory"] == close_event_category)
-    assert(last_event["eventLabel"] == close_event_label)
+    assert last_event["eventAction"] == close_event_action
+    assert last_event["eventCategory"] == close_event_category
+    assert last_event["eventLabel"] == close_event_label
 
     # WHEN:  they open the table of contents
     book.toolbar.click_toc_toggle_button()
@@ -259,23 +236,19 @@ def test_open_and_close_the_table_of_contents_ga_events(
     #          eventCategory: "REX Button (toolbar)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == open_event_action)
-    assert(last_event["eventCategory"] == open_event_category)
-    assert(last_event["eventLabel"] == open_event_label)
+    assert last_event["eventAction"] == open_event_action
+    assert last_event["eventCategory"] == open_event_category
+    assert last_event["eventLabel"] == open_event_label
 
 
 @markers.test_case("C621365")
 @markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-1-physics-definitions-and-applications")]
+    "book_slug, page_slug", [("physics", "1-1-physics-definitions-and-applications")]
 )
-def test_click_a_figure_link_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_click_a_figure_link_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when a figure link is clicked."""
     # SETUP:
     event_action = None  # Not yet known, uses the anchor reference
@@ -283,8 +256,7 @@ def test_click_a_figure_link_ga_event(
     event_label = f"/books/{book_slug}/pages/{page_slug}"
 
     # GIVEN: a user viewing a book page with a figure link
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -299,20 +271,19 @@ def test_click_a_figure_link_ga_event(
     #          eventCategory: "REX Link",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     link_click_event = Utilities.get_analytics_queue(selenium, -2)
-    assert(
-        "eventAction" in link_click_event and
-        "eventCategory" in link_click_event and
-        "eventLabel" in link_click_event
+    assert (
+        "eventAction" in link_click_event
+        and "eventCategory" in link_click_event
+        and "eventLabel" in link_click_event
     ), "Not viewing the correct GA event"
-    assert(link_click_event["eventAction"] == event_action)
-    assert(link_click_event["eventCategory"] == event_category)
-    assert(link_click_event["eventLabel"] == event_label)
+    assert link_click_event["eventAction"] == event_action
+    assert link_click_event["eventCategory"] == event_category
+    assert link_click_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621367")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_account_profile_menu_bar_click_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_account_profile_menu_bar_click_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when account profile clicked."""
     # SETUP:
     event_action = "/accounts/profile"
@@ -334,20 +305,17 @@ def test_account_profile_menu_bar_click_ga_event(
     #          eventCategory: "REX Link (openstax-navbar)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = events[-1]
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_action)
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert last_event["eventAction"] == event_action
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C545852", "C621368")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_clicking_a_search_excerpt_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_clicking_a_search_excerpt_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when ."""
     # SETUP:
     excerpt_event_action = None  # Not yet known, uses the search result link
@@ -360,8 +328,7 @@ def test_clicking_a_search_excerpt_ga_event(
 
     # GIVEN: a user viewing a book page
     # AND:   searched the book for a term
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -375,14 +342,14 @@ def test_clicking_a_search_excerpt_ga_event(
     #          eventCategory: "REX Link",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     search_event = Utilities.get_analytics_queue(selenium, -2)
-    assert(
-        "eventAction" in search_event and
-        "eventCategory" in search_event and
-        "eventLabel" in search_event
+    assert (
+        "eventAction" in search_event
+        and "eventCategory" in search_event
+        and "eventLabel" in search_event
     ), "Not viewing the correct GA event"
-    assert(search_event["eventAction"] == search_event_action)
-    assert(search_event["eventCategory"] == search_event_category)
-    assert(search_event["eventLabel"] == search_event_label)
+    assert search_event["eventAction"] == search_event_action
+    assert search_event["eventCategory"] == search_event_category
+    assert search_event["eventLabel"] == search_event_label
 
     # WHEN:  they click on a search excerpt
     link = random.choice(search_results)
@@ -394,20 +361,19 @@ def test_clicking_a_search_excerpt_ga_event(
     #          eventCategory: "REX Link",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     link_click_event = Utilities.get_analytics_queue(selenium, -2)
-    assert(
-        "eventAction" in link_click_event and
-        "eventCategory" in link_click_event and
-        "eventLabel" in link_click_event
+    assert (
+        "eventAction" in link_click_event
+        and "eventCategory" in link_click_event
+        and "eventLabel" in link_click_event
     ), "Not viewing the correct GA event"
-    assert(link_click_event["eventAction"] == excerpt_event_action)
-    assert(link_click_event["eventCategory"] == excerpt_event_category)
-    assert(link_click_event["eventLabel"] == excerpt_event_label)
+    assert link_click_event["eventAction"] == excerpt_event_action
+    assert link_click_event["eventCategory"] == excerpt_event_category
+    assert link_click_event["eventLabel"] == excerpt_event_label
 
 
 @markers.test_case("C621369")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_banner_book_title_click_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_banner_book_title_click_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when the book title is clicked."""
     # SETUP:
     event_action = f"/details/books/{book_slug}"
@@ -416,8 +382,7 @@ def test_banner_book_title_click_ga_event(
     selector = "a[data-testid=details-link-collapsed]"
 
     # GIVEN: a non-logged in user viewing a book page that is scrolled down
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -430,22 +395,21 @@ def test_banner_book_title_click_ga_event(
     #          eventCategory: "REX Link (book-banner-collapsed)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     link_click_event = events[-2]
-    assert(
-        "eventAction" in link_click_event and
-        "eventCategory" in link_click_event and
-        "eventLabel" in link_click_event
+    assert (
+        "eventAction" in link_click_event
+        and "eventCategory" in link_click_event
+        and "eventLabel" in link_click_event
     ), "Not viewing the correct GA event"
-    assert(link_click_event["eventAction"] == event_action)
-    assert(link_click_event["eventCategory"] == event_category)
-    assert(link_click_event["eventLabel"] == event_label)
+    assert link_click_event["eventAction"] == event_action
+    assert link_click_event["eventCategory"] == event_category
+    assert link_click_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621370")
 @markers.skip_test(reason="difficulty getting GA data from OSWeb")
 @markers.dev_only
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_view_book_online_link_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_view_book_online_link_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when a user clicks View online."""
     # SETUP:
     event_action = "open"
@@ -461,20 +425,17 @@ def test_view_book_online_link_ga_event(
     #          eventCategory: "Webview {book_slug} REX",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_action)
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert last_event["eventAction"] == event_action
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621371")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_openstax_logo_click_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_openstax_logo_click_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when a user clicks the logo."""
     # SETUP:
     event_action = "/"
@@ -483,8 +444,7 @@ def test_openstax_logo_click_ga_event(
     selector = "a[href='/']"
 
     # GIVEN: a user viewing a book page
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -497,20 +457,19 @@ def test_openstax_logo_click_ga_event(
     #          eventCategory: "REX Link (openstax-navbar)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     logo_click_event = events[-2]
-    assert(
-        "eventAction" in logo_click_event and
-        "eventCategory" in logo_click_event and
-        "eventLabel" in logo_click_event
+    assert (
+        "eventAction" in logo_click_event
+        and "eventCategory" in logo_click_event
+        and "eventLabel" in logo_click_event
     ), "Not viewing the correct GA event"
-    assert(logo_click_event["eventAction"] == event_action)
-    assert(logo_click_event["eventCategory"] == event_category)
-    assert(logo_click_event["eventLabel"] == event_label)
+    assert logo_click_event["eventAction"] == event_action
+    assert logo_click_event["eventCategory"] == event_category
+    assert logo_click_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621372")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_log_in_click_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_log_in_click_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when ."""
     # SETUP:
     event_action = "login"
@@ -519,8 +478,7 @@ def test_log_in_click_ga_event(
     selector = "a[href*=login]"
 
     # GIVEN: a non-logged in user viewing a book page that is scrolled down
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -533,24 +491,20 @@ def test_log_in_click_ga_event(
     #          eventCategory: "REX Link (openstax-navbar)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     log_in_event = events[-2]
-    assert(
-        "eventAction" in log_in_event and
-        "eventCategory" in log_in_event and
-        "eventLabel" in log_in_event
+    assert (
+        "eventAction" in log_in_event
+        and "eventCategory" in log_in_event
+        and "eventLabel" in log_in_event
     ), "Not viewing the correct GA event"
-    assert(log_in_event["eventAction"] == event_action)
-    assert(log_in_event["eventCategory"] == event_category)
-    assert(log_in_event["eventLabel"] == event_label)
+    assert log_in_event["eventAction"] == event_action
+    assert log_in_event["eventCategory"] == event_category
+    assert log_in_event["eventLabel"] == event_label
 
 
 @markers.test_case("C597377")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
-def test_new_highlight_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
+def test_new_highlight_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when content is selected."""
     # SETUP:
     color = Highlight.random_color()
@@ -565,9 +519,7 @@ def test_new_highlight_ga_event(
     while not book.content.highlight_count:
         try:
             book.content.highlight(
-                target=random.choice(book.content.paragraphs),
-                offset=Highlight.ENTIRE,
-                color=color
+                target=random.choice(book.content.paragraphs), offset=Highlight.ENTIRE, color=color
             )
         except NoSuchElementException:
             pass
@@ -577,24 +529,20 @@ def test_new_highlight_ga_event(
     #          eventCategory: "REX highlighting (inline create)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_action)
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert last_event["eventAction"] == event_action
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621346")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
 def test_remove_highlight_by_using_same_color_button_ga_event(
-        selenium, base_url, book_slug, page_slug):
+    selenium, base_url, book_slug, page_slug
+):
     """The page submits the correct GA event when the same color is clicked."""
     # SETUP:
     color = Highlight.random_color()
@@ -613,7 +561,7 @@ def test_remove_highlight_by_using_same_color_button_ga_event(
                 target=random.choice(book.content.paragraphs),
                 offset=Highlight.ENTIRE,
                 color=color,
-                close_box=False
+                close_box=False,
             )
         except NoSuchElementException:
             pass
@@ -625,24 +573,20 @@ def test_remove_highlight_by_using_same_color_button_ga_event(
     #          eventCategory: "REX highlighting (delete-inline-highlight)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_action)
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert last_event["eventAction"] == event_action
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621347")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
 def test_cancel_log_in_from_highlight_creation_nudge_ga_event(
-        selenium, base_url, book_slug, page_slug):
+    selenium, base_url, book_slug, page_slug
+):
     """The page submits the correct GA event when login nudge is cancelled."""
     # SETUP:
     event_action = "cancel"
@@ -650,8 +594,7 @@ def test_cancel_log_in_from_highlight_creation_nudge_ga_event(
     event_label = f"/books/{book_slug}/pages/{page_slug}"
 
     # GIVEN: a non-logged in user viewing a book page
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -663,7 +606,7 @@ def test_cancel_log_in_from_highlight_creation_nudge_ga_event(
             target=random.choice(book.content.paragraphs),
             offset=Highlight.ENTIRE,
             color=None,
-            close_box=False
+            close_box=False,
         )
 
     book.content.highlight_box.cancel()
@@ -673,24 +616,18 @@ def test_cancel_log_in_from_highlight_creation_nudge_ga_event(
     #          eventCategory: "REX Button (highlighting-login)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_action)
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert last_event["eventAction"] == event_action
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621348")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
-def test_log_in_nudge_login_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
+def test_log_in_nudge_login_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when using the inline 'Log in'."""
     # SETUP:
     event_action = "login"
@@ -701,8 +638,7 @@ def test_log_in_nudge_login_ga_event(
     selector = "[data-testid=confirm]"
 
     # GIVEN: a non-logged in user viewing a book page
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -714,7 +650,7 @@ def test_log_in_nudge_login_ga_event(
             target=random.choice(book.content.paragraphs),
             offset=Highlight.ENTIRE,
             color=None,
-            close_box=False
+            close_box=False,
         )
 
     # use a script because we need the events before the page changes
@@ -728,33 +664,29 @@ def test_log_in_nudge_login_ga_event(
     #        { eventAction: "/books/{book_slug}/pages/{page_slug}",
     #          eventCategory: "REX unload" }
     second_to_last_event = events[-2]
-    assert(
-        "eventAction" in second_to_last_event and
-        "eventCategory" in second_to_last_event and
-        "eventLabel" in second_to_last_event
+    assert (
+        "eventAction" in second_to_last_event
+        and "eventCategory" in second_to_last_event
+        and "eventLabel" in second_to_last_event
     ), "Not viewing the correct GA event"
-    assert(second_to_last_event["eventAction"] == event_action)
-    assert(second_to_last_event["eventCategory"] == event_category)
-    assert(second_to_last_event["eventLabel"] == event_label)
+    assert second_to_last_event["eventAction"] == event_action
+    assert second_to_last_event["eventCategory"] == event_category
+    assert second_to_last_event["eventLabel"] == event_label
 
     last_event = events[-1]
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" not in last_event
+    assert (
+        "eventAction" in last_event
+        and "eventCategory" in last_event
+        and "eventLabel" not in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_unload_action)
-    assert(last_event["eventCategory"] == event_unload_category)
+    assert last_event["eventAction"] == event_unload_action
+    assert last_event["eventCategory"] == event_unload_category
 
 
 @markers.test_case("C621349")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
-def test_cancel_highlight_delete_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
+def test_cancel_highlight_delete_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when hl deletion is cancelled."""
     # SETUP:
     event_action = "cancel"
@@ -774,7 +706,7 @@ def test_cancel_highlight_delete_ga_event(
                 target=random.choice(book.content.paragraphs),
                 offset=Highlight.ENTIRE,
                 note=note,
-                close_box=False
+                close_box=False,
             )
         except NoSuchElementException:
             pass
@@ -788,24 +720,18 @@ def test_cancel_highlight_delete_ga_event(
     #          eventCategory: "REX Button (confirm-delete-inline-highlight)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_action)
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert last_event["eventAction"] == event_action
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621350")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
-def test_highlight_delete_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
+def test_highlight_delete_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when a highlight is deleted."""
     # SETUP:
     event_action = "cancel"
@@ -825,7 +751,7 @@ def test_highlight_delete_ga_event(
                 target=random.choice(book.content.paragraphs),
                 offset=Highlight.ENTIRE,
                 note=note,
-                close_box=False
+                close_box=False,
             )
         except NoSuchElementException:
             pass
@@ -839,24 +765,18 @@ def test_highlight_delete_ga_event(
     #          eventCategory: "REX Button (confirm-delete-inline-highlight)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_action)
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert last_event["eventAction"] == event_action
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621351", "C621352")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
-def test_edit_existing_note_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
+def test_edit_existing_note_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when existing note is edited."""
     # SETUP:
     color = Highlight.random_color()
@@ -882,7 +802,7 @@ def test_edit_existing_note_ga_event(
                 offset=Highlight.ENTIRE,
                 color=color,
                 note=note_one,
-                close_box=False
+                close_box=False,
             )
         except NoSuchElementException:
             pass
@@ -902,34 +822,28 @@ def test_edit_existing_note_ga_event(
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     events = Utilities.get_analytics_queue(selenium)
     second_to_last_event = events[-2]
-    assert(
-        "eventAction" in second_to_last_event and
-        "eventCategory" in second_to_last_event and
-        "eventLabel" in second_to_last_event
+    assert (
+        "eventAction" in second_to_last_event
+        and "eventCategory" in second_to_last_event
+        and "eventLabel" in second_to_last_event
     ), "Not viewing the correct GA event"
-    assert(second_to_last_event["eventAction"] == first_event_action)
-    assert(second_to_last_event["eventCategory"] == first_event_category)
-    assert(second_to_last_event["eventLabel"] == first_event_label)
+    assert second_to_last_event["eventAction"] == first_event_action
+    assert second_to_last_event["eventCategory"] == first_event_category
+    assert second_to_last_event["eventLabel"] == first_event_label
 
     last_event = events[-1]
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == second_event_action)
-    assert(last_event["eventCategory"] == second_event_category)
-    assert(last_event["eventLabel"] == second_event_label)
+    assert last_event["eventAction"] == second_event_action
+    assert last_event["eventCategory"] == second_event_category
+    assert last_event["eventLabel"] == second_event_label
 
 
 @markers.test_case("C621353", "C621354")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
-def test_add_note_to_highlight_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
+def test_add_note_to_highlight_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when note added to a highlight."""
     # SETUP:
     color = Highlight.random_color()
@@ -953,7 +867,7 @@ def test_add_note_to_highlight_ga_event(
                 offset=Highlight.ENTIRE,
                 color=color,
                 note=None,
-                close_box=False
+                close_box=False,
             )
         except NoSuchElementException:
             pass
@@ -971,34 +885,28 @@ def test_add_note_to_highlight_ga_event(
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     events = Utilities.get_analytics_queue(selenium)
     second_to_last_event = events[-2]
-    assert(
-        "eventAction" in second_to_last_event and
-        "eventCategory" in second_to_last_event and
-        "eventLabel" in second_to_last_event
+    assert (
+        "eventAction" in second_to_last_event
+        and "eventCategory" in second_to_last_event
+        and "eventLabel" in second_to_last_event
     ), "Not viewing the correct GA event"
-    assert(second_to_last_event["eventAction"] == first_event_action)
-    assert(second_to_last_event["eventCategory"] == first_event_category)
-    assert(second_to_last_event["eventLabel"] == first_event_label)
+    assert second_to_last_event["eventAction"] == first_event_action
+    assert second_to_last_event["eventCategory"] == first_event_category
+    assert second_to_last_event["eventLabel"] == first_event_label
 
     last_event = events[-1]
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == second_event_action)
-    assert(last_event["eventCategory"] == second_event_category)
-    assert(last_event["eventLabel"] == second_event_label)
+    assert last_event["eventAction"] == second_event_action
+    assert last_event["eventCategory"] == second_event_category
+    assert last_event["eventLabel"] == second_event_label
 
 
 @markers.test_case("C621355")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
-def test_change_highlight_color_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
+def test_change_highlight_color_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when a hl color is changed."""
     # SETUP:
     changed_color = Color.PURPLE
@@ -1018,7 +926,7 @@ def test_change_highlight_color_ga_event(
                 target=random.choice(book.content.paragraphs),
                 offset=Highlight.ENTIRE,
                 color=initial_color,
-                close_box=False
+                close_box=False,
             )
         except NoSuchElementException:
             pass
@@ -1030,24 +938,18 @@ def test_change_highlight_color_ga_event(
     #          eventCategory: "REX highlighting (inline edit)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_action)
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert last_event["eventAction"] == event_action
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C597671")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
-def test_select_text_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
+def test_select_text_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when content is selected."""
     # SETUP:
     event_action = "show create"
@@ -1063,7 +965,7 @@ def test_select_text_ga_event(
             target=random.choice(book.content.paragraphs),
             offset=Highlight.ENTIRE,
             color=None,
-            close_box=False
+            close_box=False,
         )
 
     # THEN:  the create highlight box is opened
@@ -1071,27 +973,21 @@ def test_select_text_ga_event(
     #        { eventAction: "show create",
     #          eventCategory: "REX highlighting - show create",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
-    assert(book.content.highlight_boxes), 'No highlight box found'
+    assert book.content.highlight_boxes, "No highlight box found"
 
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_action)
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert last_event["eventAction"] == event_action
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C597672")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
-def test_inline_highlighting_login_nudge_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
+def test_inline_highlighting_login_nudge_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when the log in nudge is shown."""
     # SETUP:
     event_action = "show login"
@@ -1099,8 +995,7 @@ def test_inline_highlighting_login_nudge_ga_event(
     event_label = f"/books/{book_slug}/pages/{page_slug}"
 
     # GIVEN: a non-logged in user viewing a book page
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1111,7 +1006,7 @@ def test_inline_highlighting_login_nudge_ga_event(
             target=random.choice(book.content.paragraphs),
             offset=Highlight.ENTIRE,
             color=None,
-            close_box=False
+            close_box=False,
         )
 
     # THEN:  the inline log in nudge is opened
@@ -1119,28 +1014,22 @@ def test_inline_highlighting_login_nudge_ga_event(
     #        { eventAction: "show login",
     #          eventCategory: "REX highlighting - show login",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
-    assert(book.content.highlight_box.login_overlay_present), "Log in not seen"
+    assert book.content.highlight_box.login_overlay_present, "Log in not seen"
 
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(last_event["eventAction"] == event_action)
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert last_event["eventAction"] == event_action
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C615600")
 @markers.desktop_only
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-introduction")]
-)
-def test_go_to_highlight_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
+def test_go_to_highlight_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event for the 'Go to highlight' button.
 
     This is the final event before switching the browser to a new tab/window.
@@ -1160,8 +1049,7 @@ def test_go_to_highlight_ga_event(
     while not book.content.highlight_count:
         try:
             book.content.highlight(
-                target=random.choice(book.content.paragraphs),
-                offset=Highlight.ENTIRE
+                target=random.choice(book.content.paragraphs), offset=Highlight.ENTIRE
             )
         except NoSuchElementException:
             pass
@@ -1180,14 +1068,12 @@ def test_go_to_highlight_ga_event(
     #          eventCategory: "REX Link (MH gotohighlight)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 # ----------------- #
@@ -1201,61 +1087,36 @@ def test_title_and_meta_page_tags_for_seo(selenium, base_url, book_slug):
     """Test the title and meta title property book header tags."""
     # SETUP:
     action_script = "return document.querySelector('[href=\"{}\"]');"
-    chapters = [
-        "Ch. 1",
-        "1.1",
-        "Ch. 1",
-        "B"
-    ]
-    pages = [
-        "1-introduction",
-        "1-1-chemistry-in-context",
-        "1-key-terms",
-        "b-essential-mathematics"
-    ]
+    chapters = ["Ch. 1", "1.1", "Ch. 1", "B"]
+    pages = ["1-introduction", "1-1-chemistry-in-context", "1-key-terms", "b-essential-mathematics"]
     starting_page = "preface"
     title = "{chapter} {title} - Chemistry 2e | OpenStax"
-    titles = [
-        "Introduction",
-        "Chemistry in Context",
-        "Key Terms",
-        "Essential Mathematics"
-    ]
+    titles = ["Introduction", "Chemistry in Context", "Key Terms", "Essential Mathematics"]
 
     # GIVEN: a user
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=starting_page).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=starting_page).open()
 
     for section in range(4):
         # WHEN:  they open a book page
-        new_page = book.driver.execute_script(
-            action_script.format(pages[section])
-        )
+        new_page = book.driver.execute_script(action_script.format(pages[section]))
         Utilities.click_option(book.driver, element=new_page)
         book.wait_for_page_to_load()
         page_title, page_meta_title, page_meta_url = book.titles
-        expected_title = title.format(
-            chapter=chapters[section],
-            title=titles[section]
-        )
+        expected_title = title.format(chapter=chapters[section], title=titles[section])
 
         # THEN:  the page title is formatted correctly
-        assert(page_title == expected_title), "Incorrect title found"
+        assert page_title == expected_title, "Incorrect title found"
 
         # AND:   the page meta title tag content is formatted correctly
-        assert(page_meta_title == expected_title), "Incorrect title found"
+        assert page_meta_title == expected_title, "Incorrect title found"
 
         # AND:   the page meta URL tag content is the current page URL
-        assert(page_meta_url == selenium.current_url), "Incorrect page URL"
+        assert page_meta_url == selenium.current_url, "Incorrect page URL"
 
 
 @markers.test_case("C605728")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("american-government-2e", "1-introduction")]
-)
-def test_study_guide_chapter_tag_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("american-government-2e", "1-introduction")])
+def test_study_guide_chapter_tag_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when a SG chapter tag opened."""
     # SETUP:
     event_action = "Filter study guides by Chapter"
@@ -1263,8 +1124,7 @@ def test_study_guide_chapter_tag_ga_event(
     event_label = f"/books/{book_slug}/pages/{page_slug}"
 
     # GIVEN: a user viewing a book study guide
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1278,23 +1138,17 @@ def test_study_guide_chapter_tag_ga_event(
     #          eventCategory: "REX Button (SG popup)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C607438")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("principles-economics-2e", "1-introduction")]
-)
-def test_study_guide_cta_sign_up_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("principles-economics-2e", "1-introduction")])
+def test_study_guide_cta_sign_up_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when sign up link is clicked."""
     # SETUP:
     event_action = "signup"
@@ -1303,8 +1157,7 @@ def test_study_guide_cta_sign_up_ga_event(
     selector = "[data-analytics-label=signup]"
 
     # GIVEN: a non-logged in user viewing a book page
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1320,23 +1173,19 @@ def test_study_guide_cta_sign_up_ga_event(
     #          eventCategory: "REX Link (SG popup)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     sign_up_link_event = events[-2]
-    assert(
-        "eventAction" in sign_up_link_event and
-        "eventCategory" in sign_up_link_event and
-        "eventLabel" in sign_up_link_event
+    assert (
+        "eventAction" in sign_up_link_event
+        and "eventCategory" in sign_up_link_event
+        and "eventLabel" in sign_up_link_event
     ), "Not viewing the correct GA event"
-    assert(event_action in sign_up_link_event["eventAction"])
-    assert(sign_up_link_event["eventCategory"] == event_category)
-    assert(sign_up_link_event["eventLabel"] == event_label)
+    assert event_action in sign_up_link_event["eventAction"]
+    assert sign_up_link_event["eventCategory"] == event_category
+    assert sign_up_link_event["eventLabel"] == event_label
 
 
 @markers.test_case("C605716", "C621330")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("principles-economics-2e", "1-introduction")]
-)
-def test_open_study_guide_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("principles-economics-2e", "1-introduction")])
+def test_open_study_guide_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when the study guide is opened."""
     # SETUP:
     button_event_action = "button"
@@ -1347,8 +1196,7 @@ def test_open_study_guide_ga_event(
     open_event_label = button_event_label
 
     # GIVEN: a user viewing a book page with a study guide
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1366,33 +1214,29 @@ def test_open_study_guide_ga_event(
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     events = Utilities.get_analytics_queue(selenium)
     open_study_guide_event = events[-3]
-    assert(
-        "eventAction" in open_study_guide_event and
-        "eventCategory" in open_study_guide_event and
-        "eventLabel" in open_study_guide_event
+    assert (
+        "eventAction" in open_study_guide_event
+        and "eventCategory" in open_study_guide_event
+        and "eventLabel" in open_study_guide_event
     ), "Not viewing the correct GA event"
-    assert(open_event_action in open_study_guide_event["eventAction"])
-    assert(open_study_guide_event["eventCategory"] == open_event_category)
-    assert(open_study_guide_event["eventLabel"] == open_event_label)
+    assert open_event_action in open_study_guide_event["eventAction"]
+    assert open_study_guide_event["eventCategory"] == open_event_category
+    assert open_study_guide_event["eventLabel"] == open_event_label
 
     button_event = events[-1]
-    assert(
-        "eventAction" in button_event and
-        "eventCategory" in button_event and
-        "eventLabel" in button_event
+    assert (
+        "eventAction" in button_event
+        and "eventCategory" in button_event
+        and "eventLabel" in button_event
     ), "Not viewing the correct GA event"
-    assert(button_event_action in button_event["eventAction"])
-    assert(button_event["eventCategory"] == button_event_category)
-    assert(button_event["eventLabel"] == button_event_label)
+    assert button_event_action in button_event["eventAction"]
+    assert button_event["eventCategory"] == button_event_category
+    assert button_event["eventLabel"] == button_event_label
 
 
 @markers.test_case("C621326")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("principles-economics-2e", "1-introduction")]
-)
-def test_sg_close_using_overlay_click_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("principles-economics-2e", "1-introduction")])
+def test_sg_close_using_overlay_click_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when SG close by overlay click."""
     # SETUP:
     event_action = "overlay"
@@ -1400,8 +1244,7 @@ def test_sg_close_using_overlay_click_ga_event(
     event_label = f"/books/{book_slug}/pages/{page_slug}"
 
     # GIVEN: a user viewing a book page with a study guide
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1410,33 +1253,24 @@ def test_sg_close_using_overlay_click_ga_event(
     # AND:   click on the content overlay
     guide = book.toolbar.study_guides()
 
-    (ActionChains(selenium)
-     .move_to_element_with_offset(guide.overlay, 5, 5)
-     .click()
-     .perform())
+    (ActionChains(selenium).move_to_element_with_offset(guide.overlay, 5, 5).click().perform())
 
     # THEN:  the correct Google Analytics event is queued
     #        { eventAction: "overlay",
     #          eventCategory: "REX Study guides (close SG popup)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -2)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621327")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("principles-economics-2e", "1-introduction")]
-)
-def test_sg_close_using_esc_key_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("principles-economics-2e", "1-introduction")])
+def test_sg_close_using_esc_key_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when close SG by escape key."""
     # SETUP:
     event_action = "esc"
@@ -1444,8 +1278,7 @@ def test_sg_close_using_esc_key_ga_event(
     event_label = f"/books/{book_slug}/pages/{page_slug}"
 
     # GIVEN: a user viewing a book page with a study guide
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1454,32 +1287,26 @@ def test_sg_close_using_esc_key_ga_event(
     # AND:   hit the escape key
     book.toolbar.study_guides()
 
-    (ActionChains(selenium)
-     .send_keys(Keys.ESCAPE)
-     .perform())
+    (ActionChains(selenium).send_keys(Keys.ESCAPE).perform())
 
     # THEN:  the correct Google Analytics event is queued
     #        { eventAction: "esc",
     #          eventCategory: "REX Study guides (close SG popup)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     esc_key_event = Utilities.get_analytics_queue(selenium, -2)
-    assert(
-        "eventAction" in esc_key_event and
-        "eventCategory" in esc_key_event and
-        "eventLabel" in esc_key_event
+    assert (
+        "eventAction" in esc_key_event
+        and "eventCategory" in esc_key_event
+        and "eventLabel" in esc_key_event
     ), "Not viewing the correct GA event"
-    assert(event_action in esc_key_event["eventAction"])
-    assert(esc_key_event["eventCategory"] == event_category)
-    assert(esc_key_event["eventLabel"] == event_label)
+    assert event_action in esc_key_event["eventAction"]
+    assert esc_key_event["eventCategory"] == event_category
+    assert esc_key_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621328", "C621329")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("principles-economics-2e", "1-introduction")]
-)
-def test_sg_close_using_x_close_button_ga_events(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("principles-economics-2e", "1-introduction")])
+def test_sg_close_using_x_close_button_ga_events(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when SG close 'x' is clicked."""
     # SETUP:
     button_event_action = "button"
@@ -1490,8 +1317,7 @@ def test_sg_close_using_x_close_button_ga_events(
     close_event_label = button_event_label
 
     # GIVEN: a user viewing a book page with a study guide
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1512,33 +1338,29 @@ def test_sg_close_using_x_close_button_ga_events(
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     events = Utilities.get_analytics_queue(selenium)
     close_event = events[-3]
-    assert(
-        "eventAction" in close_event and
-        "eventCategory" in close_event and
-        "eventLabel" in close_event
+    assert (
+        "eventAction" in close_event
+        and "eventCategory" in close_event
+        and "eventLabel" in close_event
     ), "Not viewing the correct GA event"
-    assert(close_event_action in close_event["eventAction"])
-    assert(close_event["eventCategory"] == close_event_category)
-    assert(close_event["eventLabel"] == close_event_label)
+    assert close_event_action in close_event["eventAction"]
+    assert close_event["eventCategory"] == close_event_category
+    assert close_event["eventLabel"] == close_event_label
 
     button_event = events[-2]
-    assert(
-        "eventAction" in button_event and
-        "eventCategory" in button_event and
-        "eventLabel" in button_event
+    assert (
+        "eventAction" in button_event
+        and "eventCategory" in button_event
+        and "eventLabel" in button_event
     ), "Not viewing the correct GA event"
-    assert(button_event_action in button_event["eventAction"])
-    assert(button_event["eventCategory"] == button_event_category)
-    assert(button_event["eventLabel"] == button_event_label)
+    assert button_event_action in button_event["eventAction"]
+    assert button_event["eventCategory"] == button_event_category
+    assert button_event["eventLabel"] == button_event_label
 
 
 @markers.test_case("C621331")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("principles-economics-2e", "1-introduction")]
-)
-def test_study_guide_log_in_link_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("principles-economics-2e", "1-introduction")])
+def test_study_guide_log_in_link_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when SG log in link is clicked."""
     # SETUP:
     event_action = "login"
@@ -1547,8 +1369,7 @@ def test_study_guide_log_in_link_ga_event(
     selector = "[class*=StudyGuides] [data-analytics-label=login]"
 
     # GIVEN: a user viewing a book page with a study guide
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1564,23 +1385,19 @@ def test_study_guide_log_in_link_ga_event(
     #          eventCategory: "REX Link (SG popup)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     log_in_link_event = events[-2]
-    assert(
-        "eventAction" in log_in_link_event and
-        "eventCategory" in log_in_link_event and
-        "eventLabel" in log_in_link_event
+    assert (
+        "eventAction" in log_in_link_event
+        and "eventCategory" in log_in_link_event
+        and "eventLabel" in log_in_link_event
     ), "Not viewing the correct GA event"
-    assert(event_action in log_in_link_event["eventAction"])
-    assert(log_in_link_event["eventCategory"] == event_category)
-    assert(log_in_link_event["eventLabel"] == event_label)
+    assert event_action in log_in_link_event["eventAction"]
+    assert log_in_link_event["eventCategory"] == event_category
+    assert log_in_link_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621333")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("principles-economics-2e", "1-introduction")]
-)
-def test_study_guide_remove_chapter_filter_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("principles-economics-2e", "1-introduction")])
+def test_study_guide_remove_chapter_filter_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when SA chapter filter removed."""
     # SETUP:
     event_action = "Remove breadcrumb for chapter {number} {name}"
@@ -1595,10 +1412,7 @@ def test_study_guide_remove_chapter_filter_ga_event(
     guide = book.toolbar.study_guides()
 
     chapter = guide.toolbar.active_filters[0]
-    event_action = event_action.format(
-        number=chapter.number,
-        name=chapter.name
-    )
+    event_action = event_action.format(number=chapter.number, name=chapter.name)
     chapter.remove_filter()
 
     # THEN:  the correct Google Analytics event is queued
@@ -1606,23 +1420,17 @@ def test_study_guide_remove_chapter_filter_ga_event(
     #          eventCategory: "REX Button (SG popup)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action.lower() in last_event["eventAction"].lower())
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action.lower() in last_event["eventAction"].lower()
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C609711")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("american-government-2e", "1-introduction")]
-)
-def test_using_this_guide_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("american-government-2e", "1-introduction")])
+def test_using_this_guide_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when 'Using this guide' in SG."""
     # SETUP:
     event_action = "button"
@@ -1646,30 +1454,26 @@ def test_using_this_guide_ga_event(
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     events = Utilities.get_analytics_queue(selenium)
     last_event = events[-1]
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
     # WHEN:  they close the 'Using this guide' banner
     using_this_guide.close()
 
     # THEN:  no new Google Analytics event is created
     ga_queue = Utilities.get_analytics_queue(selenium)
-    assert(len(ga_queue) == len(events)), "new GA event(s) created"
+    assert len(ga_queue) == len(events), "new GA event(s) created"
 
 
 @markers.test_case("C620209")
 @markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-1-physics-definitions-and-applications")]
+    "book_slug, page_slug", [("physics", "1-1-physics-definitions-and-applications")]
 )
-def test_practice_opened_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_practice_opened_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when Practice is opened."""
     # SETUP:
     button_event_action = "button"
@@ -1680,8 +1484,7 @@ def test_practice_opened_ga_event(
     link_event_label = button_event_label
 
     # GIVEN: a user viewing a book page with practice questions
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1699,30 +1502,27 @@ def test_practice_opened_ga_event(
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     events = Utilities.get_analytics_queue(selenium)
     link_event = events[-3]
-    assert(
-        "eventAction" in link_event and
-        "eventCategory" in link_event and
-        "eventLabel" in link_event
+    assert (
+        "eventAction" in link_event and "eventCategory" in link_event and "eventLabel" in link_event
     ), "Not viewing the correct GA event"
-    assert(link_event_action in link_event["eventAction"])
-    assert(link_event["eventCategory"] == link_event_category)
-    assert(link_event["eventLabel"] == link_event_label)
+    assert link_event_action in link_event["eventAction"]
+    assert link_event["eventCategory"] == link_event_category
+    assert link_event["eventLabel"] == link_event_label
 
     button_event = events[-2]
-    assert(
-        "eventAction" in button_event and
-        "eventCategory" in button_event and
-        "eventLabel" in button_event
+    assert (
+        "eventAction" in button_event
+        and "eventCategory" in button_event
+        and "eventLabel" in button_event
     ), "Not viewing the correct GA event"
-    assert(button_event_action in button_event["eventAction"])
-    assert(button_event["eventCategory"] == button_event_category)
-    assert(button_event["eventLabel"] == button_event_label)
+    assert button_event_action in button_event["eventAction"]
+    assert button_event["eventCategory"] == button_event_category
+    assert button_event["eventLabel"] == button_event_label
 
 
 @markers.test_case("C621317")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_continue_to_questions_button_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_continue_to_questions_button_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when Continue button clicked."""
     # SETUP:
     event_action = "Continue (Empty Screen)"
@@ -1731,8 +1531,7 @@ def test_continue_to_questions_button_ga_event(
     re_title = re.compile(r"(?:Ch\.\ \d{1,2})?(\ ?.*)(?:\ \-\ .*){1}")
 
     # GIVEN: a user viewing the practice modal for a page without questions
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1747,23 +1546,19 @@ def test_continue_to_questions_button_ga_event(
     #          eventCategory: "REX Button (PQ popup)",
     #          eventLabel: "{page_title}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621318")
 @markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-1-physics-definitions-and-applications")]
+    "book_slug, page_slug", [("physics", "1-1-physics-definitions-and-applications")]
 )
-def test_submit_practice_question_answer_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_submit_practice_question_answer_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when submiting a PQ answer."""
     # SETUP:
     event_action = "Submit"
@@ -1771,8 +1566,7 @@ def test_submit_practice_question_answer_ga_event(
     event_label = None
 
     # GIVEN: a student viewing a practice question
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1792,23 +1586,17 @@ def test_submit_practice_question_answer_ga_event(
     #          eventCategory: "REX Button (PQ popup)",
     #          eventLabel: "{section page title}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621319")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "2-4-velocity-vs-time-graphs")]
-)
-def test_practice_question_finish_section_button_ga_event(
-        selenium, base_url, book_slug, page_slug):
+@markers.parametrize("book_slug, page_slug", [("physics", "2-4-velocity-vs-time-graphs")])
+def test_practice_question_finish_section_button_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when 'Finish' button clicked."""
     # SETUP:
     event_action = "Finish"
@@ -1816,8 +1604,7 @@ def test_practice_question_finish_section_button_ga_event(
     event_label = None
 
     # GIVEN: a student viewing a practice question
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1843,23 +1630,20 @@ def test_practice_question_finish_section_button_ga_event(
     #          eventCategory: "REX Button (PQ popup)",
     #          eventLabel: "{section page title}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621320")
+@markers.smoke_test
 @markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-1-physics-definitions-and-applications")]
+    "book_slug, page_slug", [("physics", "1-1-physics-definitions-and-applications")]
 )
-def test_practice_show_answer_button_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_practice_show_answer_button_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when show answer clicked."""
     # SETUP:
     event_action = "Show answer"
@@ -1867,8 +1651,7 @@ def test_practice_show_answer_button_ga_event(
     event_label = None
 
     # GIVEN: a student viewing a practice question
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1893,23 +1676,19 @@ def test_practice_show_answer_button_ga_event(
     #          eventCategory: "REX Button (PQ popup)",
     #          eventLabel: "{section page title}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621321")
 @markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-1-physics-definitions-and-applications")]
+    "book_slug, page_slug", [("physics", "1-1-physics-definitions-and-applications")]
 )
-def test_skip_practice_question_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_skip_practice_question_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when skip link is clicked."""
     # SETUP:
     event_action = "Skip"
@@ -1917,8 +1696,7 @@ def test_skip_practice_question_ga_event(
     event_label = None
 
     # GIVEN: a student viewing a practice question
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -1934,20 +1712,17 @@ def test_skip_practice_question_ga_event(
     #          eventCategory: "REX Button (PQ popup)",
     #          eventLabel: "{section page title}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621322")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_close_practice_by_clicking_the_overlay_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_close_practice_by_clicking_the_overlay_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when the overlay is clicked."""
     # SETUP:
     event_action = "overlay"
@@ -1955,38 +1730,31 @@ def test_close_practice_by_clicking_the_overlay_ga_event(
     event_label = f"/books/{book_slug}/pages/{page_slug}"
 
     # GIVEN: a student viewing the practice question modal
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
     practice = book.toolbar.practice()
 
     # WHEN:  they click the overlay outside the modal
-    (ActionChains(selenium)
-     .move_to_element_with_offset(practice.overlay, 5, 5)
-     .click()
-     .perform())
+    (ActionChains(selenium).move_to_element_with_offset(practice.overlay, 5, 5).click().perform())
 
     # THEN:  the correct Google Analytics event is queued
     #        { eventAction: "overlay",
     #          eventCategory: "REX Practice questions (close PQ popup)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621323")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_close_practice_by_using_esc_key_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_close_practice_by_using_esc_key_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when ESC key hit."""
     # SETUP:
     event_action = "esc"
@@ -1994,37 +1762,34 @@ def test_close_practice_by_using_esc_key_ga_event(
     event_label = f"/books/{book_slug}/pages/{page_slug}"
 
     # GIVEN: a student viewing the practice question modal
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
     book.toolbar.practice()
 
     # WHEN:  they hit the escape key
-    (ActionChains(selenium)
-     .send_keys(Keys.ESCAPE)
-     .perform())
+    (ActionChains(selenium).send_keys(Keys.ESCAPE).perform())
 
     # THEN:  the correct Google Analytics event is queued
     #        { eventAction: "esc",
     #          eventCategory: "REX Practice questions (close PQ popup)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C621324")
+@markers.smoke_test
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
 def test_practice_closed_when_x_close_button_clicked_ga_events(
-        selenium, base_url, book_slug, page_slug):
+    selenium, base_url, book_slug, page_slug
+):
     """The page submits the correct GA events when 'x' close button clicked."""
     # SETUP:
     button_event_action = "button"
@@ -2035,8 +1800,7 @@ def test_practice_closed_when_x_close_button_clicked_ga_events(
     close_event_label = button_event_label
 
     # GIVEN: a student viewing the practice question modal
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -2055,30 +1819,29 @@ def test_practice_closed_when_x_close_button_clicked_ga_events(
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     events = Utilities.get_analytics_queue(selenium)
     close_event = events[-3]
-    assert(
-        "eventAction" in close_event and
-        "eventCategory" in close_event and
-        "eventLabel" in close_event
+    assert (
+        "eventAction" in close_event
+        and "eventCategory" in close_event
+        and "eventLabel" in close_event
     ), "Not viewing the correct GA event"
-    assert(close_event_action in close_event["eventAction"])
-    assert(close_event["eventCategory"] == close_event_category)
-    assert(close_event["eventLabel"] == close_event_label)
+    assert close_event_action in close_event["eventAction"]
+    assert close_event["eventCategory"] == close_event_category
+    assert close_event["eventLabel"] == close_event_label
 
     button_event = events[-1]
-    assert(
-        "eventAction" in button_event and
-        "eventCategory" in button_event and
-        "eventLabel" in button_event
+    assert (
+        "eventAction" in button_event
+        and "eventCategory" in button_event
+        and "eventLabel" in button_event
     ), "Not viewing the correct GA event"
-    assert(button_event_action in button_event["eventAction"])
-    assert(button_event["eventCategory"] == button_event_category)
-    assert(button_event["eventLabel"] == button_event_label)
+    assert button_event_action in button_event["eventAction"]
+    assert button_event["eventCategory"] == button_event_category
+    assert button_event["eventLabel"] == button_event_label
 
 
 @markers.test_case("C621325")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_practice_read_link_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_practice_read_link_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when read link is clicked."""
     # SETUP:
     event_action = "Go to link"
@@ -2087,8 +1850,7 @@ def test_practice_read_link_ga_event(
     selector = "[data-analytics-label='Go to link']"
 
     # GIVEN: a student viewing the practice question modal
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -2103,23 +1865,20 @@ def test_practice_read_link_ga_event(
     #          eventCategory: "REX Link (PQ popup)",
     #          eventLabel: "/books/{book_slug}/pages/{page_slug}" }
     last_event = events[-1]
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] in event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] in event_label
 
 
 @markers.test_case("C622245")
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "2-4-velocity-vs-time-graphs")]
-)
+@markers.smoke_test
+@markers.parametrize("book_slug, page_slug", [("physics", "2-4-velocity-vs-time-graphs")])
 def test_pq_continue_to_next_section_button_click_ga_event(
-        selenium, base_url, book_slug, page_slug):
+    selenium, base_url, book_slug, page_slug
+):
     """The page submits the correct GA event when continuing to next pq set."""
     # SETUP:
     event_action = "Continue (Final Screen)"
@@ -2127,8 +1886,7 @@ def test_pq_continue_to_next_section_button_click_ga_event(
     event_label = None
 
     # GIVEN: a student viewing the practice question modal
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
@@ -2154,20 +1912,17 @@ def test_pq_continue_to_next_section_button_click_ga_event(
     #          eventCategory: "REX Button (PQ popup)",
     #          eventLabel: "{section page title}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 @markers.test_case("C622246")
 @markers.parametrize("book_slug, page_slug", [("physics", "1-introduction")])
-def test_practice_filter_ga_events(
-        selenium, base_url, book_slug, page_slug):
+def test_practice_filter_ga_events(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA events when a PQ filter selected."""
     # SETUP:
     filter_menu_event_action = "Filter PQ by Chapter & Section"
@@ -2178,24 +1933,19 @@ def test_practice_filter_ga_events(
     filter_section_event_label = None
 
     # GIVEN: a student viewing the practice question modal
-    book = Content(selenium, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()
     practice = book.toolbar.practice()
-    filter_menu_event_label = (
-        f"{practice.content.number} {practice.content.title}"
-    )
+    filter_menu_event_label = f"{practice.content.number} {practice.content.title}"
     filter_section_event_label = filter_menu_event_label
 
     # WHEN:  they select a different section filter
     filters = practice.filters.toggle()
     filters.chapters[0].toggle()
     section = filters.chapters[0].sections[0]
-    filter_section_event_action = (
-        f"Filter PQ by {section.number} {section.title}"
-    )
+    filter_section_event_action = f"Filter PQ by {section.number} {section.title}"
     section.select()
 
     # THEN:  the correct Google Analytics filter menu event is queued
@@ -2208,33 +1958,29 @@ def test_practice_filter_ga_events(
     #          eventLabel: "{section page title}" }
     events = Utilities.get_analytics_queue(selenium)
     menu_event = events[-2]
-    assert(
-        "eventAction" in menu_event and
-        "eventCategory" in menu_event and
-        "eventLabel" in menu_event
+    assert (
+        "eventAction" in menu_event and "eventCategory" in menu_event and "eventLabel" in menu_event
     ), "Not viewing the correct GA event"
-    assert(filter_menu_event_action in menu_event["eventAction"])
-    assert(menu_event["eventCategory"] == filter_menu_event_category)
-    assert(menu_event["eventLabel"] == filter_menu_event_label)
+    assert filter_menu_event_action in menu_event["eventAction"]
+    assert menu_event["eventCategory"] == filter_menu_event_category
+    assert menu_event["eventLabel"] == filter_menu_event_label
 
     selection_event = events[-1]
-    assert(
-        "eventAction" in selection_event and
-        "eventCategory" in selection_event and
-        "eventLabel" in selection_event
+    assert (
+        "eventAction" in selection_event
+        and "eventCategory" in selection_event
+        and "eventLabel" in selection_event
     ), "Not viewing the correct GA event"
-    assert(filter_section_event_action in selection_event["eventAction"])
-    assert(selection_event["eventCategory"] == filter_section_event_category)
-    assert(selection_event["eventLabel"] == filter_section_event_label)
+    assert filter_section_event_action in selection_event["eventAction"]
+    assert selection_event["eventCategory"] == filter_section_event_category
+    assert selection_event["eventLabel"] == filter_section_event_label
 
 
 @markers.test_case("C620825")
 @markers.parametrize(
-    "book_slug, page_slug",
-    [("physics", "1-1-physics-definitions-and-applications")]
+    "book_slug, page_slug", [("physics", "1-1-physics-definitions-and-applications")]
 )
-def test_start_practice_ga_event(
-        selenium, base_url, book_slug, page_slug):
+def test_start_practice_ga_event(selenium, base_url, book_slug, page_slug):
     """The page submits the correct GA event when starting a practice."""
     # SETUP:
     event_action = "Start now"
@@ -2257,20 +2003,17 @@ def test_start_practice_ga_event(
     #          eventCategory: "REX Button (PQ popup)",
     #          eventLabel: "{page title}" }
     last_event = Utilities.get_analytics_queue(selenium, -1)
-    assert(
-        "eventAction" in last_event and
-        "eventCategory" in last_event and
-        "eventLabel" in last_event
+    assert (
+        "eventAction" in last_event and "eventCategory" in last_event and "eventLabel" in last_event
     ), "Not viewing the correct GA event"
-    assert(event_action in last_event["eventAction"])
-    assert(last_event["eventCategory"] == event_category)
-    assert(last_event["eventLabel"] == event_label)
+    assert event_action in last_event["eventAction"]
+    assert last_event["eventCategory"] == event_category
+    assert last_event["eventLabel"] == event_label
 
 
 def user_setup(driver, base_url, book_slug, page_slug):
     """Setup a new user for use in Goggle Analytics event tests."""
-    book = Content(driver, base_url,
-                   book_slug=book_slug, page_slug=page_slug).open()
+    book = Content(driver, base_url, book_slug=book_slug, page_slug=page_slug).open()
     book.driver.add_cookie(VIEW_ANALYTICS_QUEUE)
     while book.notification_present:
         book.notification.got_it()

--- a/pytest-selenium/tests/test_highlighting_42.py
+++ b/pytest-selenium/tests/test_highlighting_42.py
@@ -17,11 +17,8 @@ from utils.utility import Highlight, Utilities
 
 @markers.test_case("C592636")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("chemistry-2e", "1-introduction")]
-)
-@markers.smoke_test
+@markers.parametrize("book_slug, page_slug", [("chemistry-2e", "1-introduction")])
+# @markers.smoke_test
 def test_my_highlights_summary_shows_highlights_and_notes_on_current_page(
     selenium, base_url, book_slug, page_slug
 ):
@@ -164,10 +161,7 @@ def test_my_highlights_summary_shows_highlights_and_notes_on_current_page(
 
 @markers.test_case("C592637")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("chemistry-2e", "1-4-measurements")]
-)
+@markers.parametrize("book_slug, page_slug", [("chemistry-2e", "1-4-measurements")])
 def test_my_highlights_summary_shows_all_types_of_content(selenium, base_url, book_slug, page_slug):
     """My Highlights and Notes summary shows all types of page content."""
     # GIVEN: the Chemistry 2e book section 1.4 is displayed
@@ -200,63 +194,72 @@ def test_my_highlights_summary_shows_all_types_of_content(selenium, base_url, bo
         group=book.content.paragraphs,
         offset=Highlight.ENTIRE,
         color=Highlight.random_color(),
-        name="Paragraph")
+        name="Paragraph",
+    )
     Highlight.force_highlight(
         book=book,
         by=random.choice,
         group=book.content.images,
         offset=Highlight.ENTIRE,
         color=Highlight.random_color(),
-        name="Image")
+        name="Image",
+    )
     Highlight.force_highlight(
         book=book,
         by=random.choice,
         group=book.content.figures,
         offset=Highlight.ENTIRE,
         color=Highlight.random_color(),
-        name="Figure")
+        name="Figure",
+    )
     Highlight.force_highlight(
         book=book,
         by=random.choice,
         group=book.content.captions,
         offset=Highlight.ENTIRE,
         color=Highlight.random_color(),
-        name="Caption")
+        name="Caption",
+    )
     Highlight.force_highlight(
         book=book,
         by=random.choice,
         group=book.content.lists,
         offset=Highlight.ENTIRE,
         color=Highlight.random_color(),
-        name="List")
+        name="List",
+    )
     Highlight.force_highlight(
         book=book,
         by=random.choice,
         group=book.content.tables,
         offset=Highlight.ENTIRE,
         color=Highlight.random_color(),
-        name="Table")
+        name="Table",
+    )
     Highlight.force_highlight(
         book=book,
         by=random.choice,
         group=book.content.footnotes,
         offset=Highlight.ENTIRE,
         color=Highlight.random_color(),
-        name="Footnote")
+        name="Footnote",
+    )
     Highlight.force_highlight(
         book=book,
         by=random.choice,
         group=book.content.links,
         offset=Highlight.ENTIRE,
         color=Highlight.random_color(),
-        name="Link")
+        name="Link",
+    )
     Highlight.force_highlight(
         book=book,
         by=random.choice,
         group=book.content.math,
         offset=Highlight.ENTIRE,
         color=Highlight.random_color(),
-        name="Math")
+        name="Math",
+    )
     highlight_ids = set(book.content.highlight_ids)
 
     if width != DESKTOP[0]:
@@ -281,10 +284,7 @@ def test_my_highlights_summary_shows_all_types_of_content(selenium, base_url, bo
 @markers.test_case("C592640")
 @markers.desktop_only
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("chemistry-2e", "1-introduction")]
-)
+@markers.parametrize("book_slug, page_slug", [("chemistry-2e", "1-introduction")])
 def test_able_to_close_my_highlights_with_keyboard_navigation(
     selenium, base_url, book_slug, page_slug
 ):
@@ -316,10 +316,7 @@ def test_able_to_close_my_highlights_with_keyboard_navigation(
 
 @markers.test_case("C592641")
 @markers.highlighting
-@markers.parametrize(
-    "book_slug, page_slug",
-    [("chemistry-2e", "1-1-chemistry-in-context")]
-)
+@markers.parametrize("book_slug, page_slug", [("chemistry-2e", "1-1-chemistry-in-context")])
 def test_lengthy_highlights_summary_page_has_a_floating_back_to_top_link(
     selenium, base_url, book_slug, page_slug
 ):
@@ -352,7 +349,7 @@ def test_lengthy_highlights_summary_page_has_a_floating_back_to_top_link(
             by=random.choice,
             group=book.content.paragraphs,
             offset=Highlight.ENTIRE,
-            color=Highlight.random_color()
+            color=Highlight.random_color(),
         )
 
     if width != DESKTOP[0]:


### PR DESCRIPTION
1. Update smoke test markers to include new practice/SG tests and remove from existing tests as needed
2. Update `highlighting` marker so that the highlighting tests run in CI checks. There is one outstanding bug which makes one of the smoke test to fail but the bug card is being fixed. If the tests continue to be flaky we can revisit