### PR TITLE
fix content update for versions ending in 0

### DIFF
--- a/script/update-content-versions-and-check-for-archived-slugs.ts
+++ b/script/update-content-versions-and-check-for-archived-slugs.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { argv } from 'yargs';
+import argv from 'yargs';
 import { makeUnifiedBookLoader } from '../src/app/content/utils';
 import { ARCHIVE_URL, REACT_APP_ARCHIVE_URL, REACT_APP_OS_WEB_API_URL } from '../src/config';
 import books from '../src/config.books';
@@ -8,7 +8,7 @@ import createArchiveLoader from '../src/gateways/createArchiveLoader';
 import createOSWebLoader from '../src/gateways/createOSWebLoader';
 import updateRedirectsData from './utils/update-redirects-data';
 
-const args = argv as any as {
+const args = argv.string('versionNumber').argv as any as {
   bookId: string
   versionNumber: string | number;
 };


### PR DESCRIPTION
for: openstax/unified#1656


[this](https://github.com/yargs/yargs/blob/master/docs/tricks.md#numbers) was messing us up
> Every argument that looks like a number (!isNaN(Number(arg))) is converted to one. This way you can just net.createConnection(argv.port) and you can add numbers out of argv with + without having that mean concatenation, which is super frustrating.