### PR TITLE
FE selenium: update to make testrail tests publish results

### DIFF
--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -37,7 +37,6 @@ test-rail-sauce: venv
 		--tr-email=$(TR_USERNAME) \
 		--tr-password=$(TR_PASSWORD) \
 		--tr-run-id=$(TR_RUN_ID) \
-		--tr-skip-missing \
 		--highlighting \
 		--base-url=$(BASE_URL) \
 		--driver SauceLabs \


### PR DESCRIPTION
for: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/1729

Testrail results are not published after sandbox deployments for quite some time. Investigating locally, removing the `--tr-skip-missing` command published the results. So trying this out.