### PR TITLE
Fixes for verify-production-urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,24 @@ FROM debian:buster as utils
 
 # general utils
 RUN apt-get update && apt-get install -y \
-  git \
-  procps \
   curl \
+  git \
   jq \
+  locales \
+  procps \
+  unzip \
   && rm -rf /var/lib/apt/lists/*
 
+# using an UTF-8 locale is required for the aws cli
+# to successfully list S3 objects with unicode characters
+# setup from https://stackoverflow.com/a/28406007
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 # AWS CLI
-RUN apt-get update && apt-get install -y \
-  unzip && \
-  rm -rf /var/lib/apt/lists/* && \
-  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
   unzip awscliv2.zip && \
   ./aws/install && \
   rm -rf awscliv2.zip aws

--- a/concourse/verify-production-urls/script.bash
+++ b/concourse/verify-production-urls/script.bash
@@ -5,7 +5,6 @@ production_url=https://openstax.org
 current_release_id=$(curl -s "${production_url}/rex/environment.json" | jq .release_id -r)
 
 get_bucket_release_files () {
-  AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
   aws s3api list-objects --bucket "$PROD_UNIFIED_S3_BUCKET" --prefix "rex/releases/$1/books/" \
   --output json | jq -r '.Contents[] | .Key' | sed -e "s/.*\/\(books\/.*\)/\1/"
 }

--- a/concourse/verify-production-urls/script.bash
+++ b/concourse/verify-production-urls/script.bash
@@ -10,7 +10,7 @@ get_bucket_release_files () {
   --output json | jq -r '.Contents[] | .Key' | sed -e "s/.*\/\(books\/.*\)/\1/"
 }
 
-count_files () { wc -l <<< "$1" | awk '{$1=$1};1'; }
+count_files () { grep -v '^$' <<< "$1" | wc -l <<< "$1" | awk '{$1=$1};1'; }
 
 # Bash array difference (with newline-separated inputs)
 # Returns files in $1 but not in $2

--- a/concourse/verify-production-urls/script.bash
+++ b/concourse/verify-production-urls/script.bash
@@ -10,7 +10,7 @@ get_bucket_release_files () {
   --output json | jq -r '.Contents[] | .Key' | sed -e "s/.*\/\(books\/.*\)/\1/"
 }
 
-count_files () { grep -v '^$' <<< "$1" | wc -l <<< "$1" | awk '{$1=$1};1'; }
+count_files () { grep -cv '^$' <<< "$1"; }
 
 # Bash array difference (with newline-separated inputs)
 # Returns files in $1 but not in $2


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1808
- Set Docker image locale to fix S3 listing of files with unicode characters
- Make count_files return 0 for empty lists of files

Locale fix seems to work in my Docker image.