### PR TITLE
Removed yarn install and yarn build to make the Docker image small once again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,11 +94,3 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 FROM utils AS release
-
-# Docker trickery so we can reuse the yarn install layer until package.json or yarn.lock change
-COPY package.json yarn.lock /code/
-WORKDIR /code
-RUN yarn install
-
-COPY . /code
-RUN yarn build:clean


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1815
Concourse does not behave well with the large image