### PR TITLE
ignore content updates where version is unchanged

### DIFF
--- a/concourse/update-content/script.bash
+++ b/concourse/update-content/script.bash
@@ -43,6 +43,12 @@ for book_and_version in $book_entries; do
   git checkout src/config.books.json
   (git checkout "$branch" && git merge "origin/$rex_default_branch" --no-edit -X theirs) || git checkout -b "$branch"
 
+  current_version=$(jq -r --arg bookId "$book_id" '.[$bookId].defaultVersion' < src/config.books.json)
+
+  if [[ "$current_version" -eq "$new_version" ]]; then
+    continue
+  fi
+
   node script/entry.js update-archive-version --contentVersion "$book_id@$new_version"
 
   if [[ -z $(git status --porcelain) ]]; then


### PR DESCRIPTION
for: openstax/unified#1830

if there is a pre-existing branch that is different from the default branch, the output of `transform-approved-books-data` might include an update from the default branch that is already on the update branch