### PR TITLE
Fix Intl

### DIFF
--- a/src/app/messages/SimpleMessageProvider.tsx
+++ b/src/app/messages/SimpleMessageProvider.tsx
@@ -9,9 +9,8 @@ const SimpleMessageProvider = (props: { children?: React.ReactNode }) => {
 
   useEffect(() => {
     const setUpIntl = async() => {
-      const languageWithCode = assertWindow().navigator.language || 'en-US';
-      const language = new (assertWindow()).Intl.Locale(languageWithCode).language;
-      const intlObject = await createIntl(language);
+      let language = assertWindow().navigator.language || 'en';
+      const intlObject = await createIntl(language.substring(0, 2));
       setIntl(intlObject);
     };
 

--- a/src/app/messages/SimpleMessageProvider.tsx
+++ b/src/app/messages/SimpleMessageProvider.tsx
@@ -9,7 +9,7 @@ const SimpleMessageProvider = (props: { children?: React.ReactNode }) => {
 
   useEffect(() => {
     const setUpIntl = async() => {
-      let language = assertWindow().navigator.language || 'en';
+      const language = assertWindow().navigator.language || 'en';
       const intlObject = await createIntl(language.substring(0, 2));
       setIntl(intlObject);
     };

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -56,11 +56,6 @@ declare global {
     ga: UniversalAnalytics.ga;
     dataLayer: object[];
     gtag: (eventKey?: string, eventVal?: string, eventObj?: object) => boolean | void;
-    Intl: {
-      Locale: {
-        new(locale: string): { language: string };
-      };
-    };
   }
 
   var fetch: (input: dom.RequestInfo, init?: dom.RequestInit) => Promise<Response>;


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1890
Safari versions < 14 do not support `Intl.Locale` so replace it with a simple substring to get the two letter language code if it's inside a tag like 'es-MX' or 'en-US'.