### PR TITLE
Improved UpdatesAvailable specs

### DIFF
--- a/src/app/notifications/components/UpdatesAvailable.spec.tsx
+++ b/src/app/notifications/components/UpdatesAvailable.spec.tsx
@@ -72,9 +72,8 @@ describe('UpdatesAvailable', () => {
     expect(component!.root.findAllByType('button').length).toBe(1);
   });
 
-  it(
-    'doesn\'t error or render if the serviceWorker or readyPromise change after render(), then the old readyPromise is resolved',
-    async() => {
+  it('doesn\'t render if the serviceWorker or readyPromise change after render(),\
+      then the old readyPromise is resolved', async() => {
       let component: ReactTestRenderer;
 
       // wait for useEffect()
@@ -87,7 +86,7 @@ describe('UpdatesAvailable', () => {
         // replace the readyPromise before useEffect()
         Object.defineProperty(window!.navigator, 'serviceWorker', {
           configurable: true, value: {
-            ready: Promise.resolve(sw)
+            ready: Promise.resolve(sw),
           },
         });
       });
@@ -107,9 +106,8 @@ describe('UpdatesAvailable', () => {
     }
   );
 
-  it(
-    'doesn\'t error or render if the serviceWorker or readyPromise change after useEffect(), then the old readyPromise is resolved',
-    async() => {
+  it('doesn\'t render if the serviceWorker or readyPromise change after useEffect(),\
+      then the old readyPromise is resolved', async() => {
       let component: ReactTestRenderer;
 
       // wait for useEffect()

--- a/src/app/notifications/components/UpdatesAvailable.spec.tsx
+++ b/src/app/notifications/components/UpdatesAvailable.spec.tsx
@@ -1,3 +1,4 @@
+import { ReactTestRenderer } from 'react-test-renderer';
 import { reactAndFriends, resetModules } from '../../../test/utils';
 
 describe('UpdatesAvailable', () => {
@@ -8,13 +9,14 @@ describe('UpdatesAvailable', () => {
   let TestContainer: ReturnType<typeof reactAndFriends>['TestContainer']; // tslint:disable-line:variable-name
   let UpdatesAvailable = require('./UpdatesAvailable').default; // tslint:disable-line:variable-name
   const sw = { update: () => Promise.resolve() };
+  let resolveReadyPromise: (sw: { update: () => Promise<void> }) => void;
 
   beforeEach(() => {
     Object.defineProperty(window, 'location', {
       configurable: true, value: { reload: jest.fn() },
     });
     Object.defineProperty(window!.navigator, 'serviceWorker', {
-      configurable: true, value: { ready: Promise.resolve(sw) },
+      configurable: true, value: { ready: new Promise((resolve) => resolveReadyPromise = resolve) },
     });
     resetModules();
     ({React, renderer, TestContainer} = reactAndFriends());
@@ -31,40 +33,62 @@ describe('UpdatesAvailable', () => {
   });
 
   it('reloads on click', async() => {
-    const component = renderer.create(<TestContainer><UpdatesAvailable /></TestContainer>);
+    let component: ReactTestRenderer;
     // wait for useEffect()
+    renderer.act(() => {
+      component = renderer.create(<TestContainer><UpdatesAvailable /></TestContainer>);
+    });
+    // resolve and wait for the readyPromise
+    renderer.act(() => resolveReadyPromise(sw));
+    await window!.navigator.serviceWorker.ready;
+    // wait for the component to re-render
     await new Promise((resolve) => setImmediate(resolve));
-    // wait for the ready Promise
-    await new Promise((resolve) => setImmediate(resolve));
-    component.root.findByType('button').props.onClick();
+    component!.root.findByType('button').props.onClick();
     expect(window!.location.reload).toHaveBeenCalled();
   });
 
-  it('doesn\'t render until reload is ready', () => {
-    const component = renderer.create(<TestContainer><UpdatesAvailable /></TestContainer>);
-    expect(component.root.findAllByType('button').length).toBe(0);
+  it('doesn\'t render until reload is ready', async() => {
+    let component: ReactTestRenderer;
+    // wait for useEffect()
+    renderer.act(() => {
+      component = renderer.create(<TestContainer><UpdatesAvailable /></TestContainer>);
+    });
+    // can't really wait for the readyPromise here since it's never resolved
+    // so we just wait for another resolved Promise instead
+    await Promise.resolve(sw);
+    // wait for the component to re-render
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(component!.root.findAllByType('button').length).toBe(0);
   });
 
   it(
     'doesn\'t cause an error if the serviceWorker and/or readyPromise change after rendering',
     async() => {
-      let component = renderer.create(<TestContainer><UpdatesAvailable /></TestContainer>);
-      Object.defineProperty(window!.navigator, 'serviceWorker', {
-        configurable: true, value: { ready: Promise.resolve(sw) },
-      });
-      // wait for useEffect()
-      await new Promise((resolve) => setImmediate(resolve));
-      // wait for the ready Promise
-      await new Promise((resolve) => setImmediate(resolve));
-      expect(component.root.findAllByType('button').length).toBe(0);
+      let component: ReactTestRenderer;
 
-      component = renderer.create(<TestContainer><UpdatesAvailable /></TestContainer>);
       // wait for useEffect()
+      renderer.act(() => {
+        component = renderer.create(<TestContainer><UpdatesAvailable /></TestContainer>);
+      });
+      // replace the readyPromise so the old one will never get resolved
+      Object.defineProperty(window!.navigator, 'serviceWorker', {
+        configurable: true, value: { ready: new Promise((resolve) => resolveReadyPromise = resolve) },
+      });
+      // resolve and wait for the readyPromise
+      renderer.act(() => resolveReadyPromise(sw));
+      await window!.navigator.serviceWorker.ready;
+      // wait for the component to re-render
       await new Promise((resolve) => setImmediate(resolve));
-      // wait for the ready Promise
+      expect(component!.root.findAllByType('button').length).toBe(0);
+
+      renderer.act(() => {
+        component = renderer.create(<TestContainer><UpdatesAvailable /></TestContainer>);
+      });
+      // wait for the readyPromise (already resolved)
+      await window!.navigator.serviceWorker.ready;
+      // wait for the component to render
       await new Promise((resolve) => setImmediate(resolve));
-      component.root.findByType('button').props.onClick();
-      expect(window!.location.reload).toHaveBeenCalled();
+      expect(component!.root.findAllByType('button').length).toBe(1);
     }
   );
 });


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1901

This just improves the UpdatesAvailable specs, hopefully making them less flaky:

- Make the mock readyPromise not be resolved instantly so we can control when it gets resolved
- Use `renderer.act()` instead of `await` to wait for `useEffect()`
- Add another `await` to wait for the component to render or re-render