### PR TITLE
Fix flaky pageview spec

### DIFF
--- a/src/app/content/content.prerenderspec.ts
+++ b/src/app/content/content.prerenderspec.ts
@@ -134,6 +134,7 @@ describe('content', () => {
     );
 
     await page.click('a[data-analytics-label="next"]');
+    await finishRender(page);
 
     const pendingEvents = await page.evaluate(() =>
       window!.__APP_ANALYTICS.googleAnalyticsClient.getPendingCommands()


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1926

The call to register a GA page view was moved into an async function so it seems the spec just needs to await `finishRender(page)`. At least it works locally.