### PR TITLE
Fixed transform-approved-books-data script

### DIFF
--- a/script/transform-approved-books-data.ts
+++ b/script/transform-approved-books-data.ts
@@ -270,7 +270,10 @@ const transformDataVer2 = (data: ApprovedBooksAndVersionsVer2) => {
         if (version.commit_sha.length > 7) {
           sha = version.commit_sha.substr(0, 7);
         }
-        if (!configuredBooks[book.uuid] || configuredBooks[book.uuid].defaultVersion !== sha) {
+        if (configuredBooks[book.uuid] && configuredBooks[book.uuid].defaultVersion === sha) {
+          // we are not interested in the currentVersion or any book versions older than that
+          delete results[book.uuid];
+        } else {
           results[book.uuid] = sha;
         }
       }


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1942
So it properly ignores books that are already on the latest version

Before the change, the output was:
```
{"175c88b6-f89b-4eba-9514-bc45e2139a1d":"a5b059c","da02605d-6d69-447c-a9b9-caf06dc4f413":"a5b059c","b647a9b9-7631-45a1-a8e7-5acc3a44fc01":"a5b059c","746f171e-0d6a-4ef2-b69d-367880872f4a":"6a2c2cd","afe4332a-c97f-4fc4-be27-4e4d384a32d8":"c28d7c7","06aba565-9432-40f6-97ee-b8a361f118a8":"96cb435","cce64fde-f448-43b8-ae88-27705cceb0da":"b682a4b","7fccc9cf-9b71-44f6-800b-f9457fd64335":"474e3ea","d9b85ee6-c57f-4861-8208-5ddf261e9c5f":"474e3ea","9ab4ba6d-1e48-486d-a2de-38ae1617ca84":"b9d5118","920d1c8a-606c-4888-bfd4-d1ee27ce1795":"b9d5118"}
```

After the change:
```
{"afe4332a-c97f-4fc4-be27-4e4d384a32d8":"c28d7c7"}
```