### PR TITLE
Target all numbered .os-problem-container and .os-solution-container with display: inline

### DIFF
--- a/generic-styles/content-baked.less
+++ b/generic-styles/content-baked.less
@@ -273,27 +273,21 @@ h1.example-title .text {
   padding: 0;
 }
 
-.os-eoc, .os-eob, .section-exercises, [data-type="exercise-question"] {
-  .os-problem-container,
-  .os-solution-container {
+// We want to target all numbered exercises here
+// We do not want to target worked-examples, which are unnumbered
+.os-number ~ .os-problem-container, .os-number ~ .os-solution-container {
+  display: inline;
+  > :first-child:not(ul):not(ol):not([data-type="note"]):not(.os-figure) {
     display: inline;
-    > :first-child:not(ul):not(ol):not([data-type="note"]):not(.os-figure) {
-      display: inline;
-    }
-    > ul, > ol, [data-type="note"] {
-      margin-top: 0;
-    }
-    .os-figure {
-      margin: 3rem 0;
-    }
   }
-}
-
-.os-eob, .os-eos {
-  .os-solution-container, .os-problem-container {
-    img {
-      display: block;
-    }
+  > ul, > ol, [data-type="note"] {
+    margin-top: 0;
+  }
+  .os-figure {
+    margin: 3rem 0;
+  }
+  img {
+    display: block;
   }
 }
 
@@ -467,19 +461,6 @@ h1.example-title .text {
 
 .os-eoc,
 .os-eob {
-  .os-problem-container,
-  .os-solution-container {
-    display: inline;
-    > :first-child:not(ul):not(ol):not([data-type="note"]):not(.os-figure) {
-      display: inline;
-    }
-    > ul, > ol, [data-type="note"] {
-      margin-top: 0;
-    }
-    .os-figure {
-      margin: 3rem 0;
-    }
-  }
   h2[data-type="document-title"],
   h2.os-title {
     .content-font-size(2.1rem);

--- a/generic-styles/content-common.less
+++ b/generic-styles/content-common.less
@@ -290,8 +290,10 @@ blockquote {
 .mixin-exercise() {
   [data-type="problem"],
   [data-type="solution"],
+  [data-type="exercise-question"],
   .problem,
-  .solution {
+  .solution,
+  .exercise-question {
     padding: 0.5em 1em;
   }
 
@@ -362,9 +364,10 @@ blockquote {
 
 [data-type="example"],
 [data-type="exercise"],
+[data-type="injected-exercise"],
 .example,
-.exercise {
-
+.exercise,
+.injected-exercise {
   .mixin-exercise();
 }
 


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1952
Also made .mixin-exercise target both exercise types to fix the indentation and removed duplicate styles

<img width="1552" alt="Screen Shot 2022-06-28 at 2 02 08 PM" src="https://user-images.githubusercontent.com/1017808/176261968-0a7e3647-5708-481f-91a2-317dd056e86f.png">

<img width="1552" alt="Screen Shot 2022-06-28 at 1 10 55 PM" src="https://user-images.githubusercontent.com/1017808/176253204-c2121ddb-82ec-4abd-a251-9b63550667f0.png">
