### PR TITLE
Remove map redundancies

### DIFF
--- a/src/app/content/utils/canonicalUrl.ts
+++ b/src/app/content/utils/canonicalUrl.ts
@@ -48,7 +48,7 @@ export async function getCanonicalUrlParams(
         break;
       }
 
-      // use map for canonical book if it exists
+      // use canonical book's map
       const newMap = getCanonicalMap(canonicalBook.id);
       done = !newMap.length || isEqual(canonicalMap, newMap);
       // throw if the new map has already been checked

--- a/src/app/content/utils/canonicalUrl.ts
+++ b/src/app/content/utils/canonicalUrl.ts
@@ -42,7 +42,13 @@ export async function getCanonicalUrlParams(
       canonicalPageId = CANONICAL_PAGES_MAP[canonicalPageId] || canonicalPageId;
       treeSection = findArchiveTreeNodeById(canonicalBook.tree, canonicalPageId);
 
-      // check canonical book for its own map
+      // end loop if page found and no page map exists for canonical book
+      if (treeSection && !CANONICAL_MAP[canonicalBook.id]) {
+        done = true;
+        break;
+      }
+
+      // use map for canonical book if it exists
       const newMap = getCanonicalMap(canonicalBook.id);
       done = !newMap.length || isEqual(canonicalMap, newMap);
       // throw if the new map has already been checked

--- a/src/canonicalBookMap.ts
+++ b/src/canonicalBookMap.ts
@@ -35,9 +35,6 @@ export const CANONICAL_MAP: CanonicalBookMap = {
   /* Algebra & Trigonometry */ '13ac107a-f15f-49d2-97e8-60ab2e3b519c' : [
     /* College Algebra 2e */ ['35d7cce2-48dd-4403-b6a5-e828cb5a17da', {}],
     /* Precalculus 2e */ ['f021395f-fd63-46cd-ab95-037c6f051730', {}],
-    /* College Algebra */ ['9b08c294-057f-4201-9f48-5d6ad992740d', {}],
-    /* Precalculus */ ['fd53eae1-fa23-47c7-bb1b-972349835c3c', {}],
-    /* Algebra & Trigonometry 2e */ ['eaefdaf1-bda0-4ada-a9fe-f1c065bfcc4e', {}],
   ],
   /* Anatomy & Physiology */ '14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22': [
     /* Anatomy & Physiology 2e */ ['4fd99458-6fdf-49bc-8688-a6dc17a1268d', {}],
@@ -59,8 +56,6 @@ export const CANONICAL_MAP: CanonicalBookMap = {
   ],
   /* College Algebra with Corequisite Support */ '507feb1e-cfff-4b54-bc07-d52636cecfe3': [
     /* College Algebra 2e */ ['35d7cce2-48dd-4403-b6a5-e828cb5a17da', {}],
-    /* College Algebra */ ['9b08c294-057f-4201-9f48-5d6ad992740d', {}],
-    /* College Algebra with Corequisite Support 2e */ ['59024a63-2b1a-4631-94c5-ae275a77b587', {}],
   ],
   /* Psychology */ '4abf04bf-93a0-45c3-9cbc-2cefd46e68cc' : [
     /* Psychology 2e */ ['06aba565-9432-40f6-97ee-b8a361f118a8', {
@@ -355,7 +350,6 @@ export const CANONICAL_MAP: CanonicalBookMap = {
   ],
   /* Precalculus */ 'fd53eae1-fa23-47c7-bb1b-972349835c3c' : [
     /* College Algebra 2e */ ['35d7cce2-48dd-4403-b6a5-e828cb5a17da', {}],
-    /* College Algebra */ ['9b08c294-057f-4201-9f48-5d6ad992740d', {}],
     /* Precalculus 2e */ ['f021395f-fd63-46cd-ab95-037c6f051730', {}],
   ],
 };


### PR DESCRIPTION
for: openstax/unified#1948

Fixes canonical URL error in Algebra & Trigonometry. I did two things here:
- per our [master list of canonical books](https://docs.google.com/spreadsheets/d/1Hj5vm2AbEiLgxgcbNRi550InzFTLvBOv16-Fw6P-c5E/edit#gid=0) I removed redundancies from math book mapping
- I terminated the loop for checking maps once a page is found in a canonical book that has no map of its own. The idea is that if Book A canonicals to Book B and Book C, we don't need to keep looking for pages once a match is found in Book B.