### PR TITLE
Save a screenshot on scroll test failure

### DIFF
--- a/src/app/content/components/Content.browserspec.tsx
+++ b/src/app/content/components/Content.browserspec.tsx
@@ -28,10 +28,10 @@ const testScroll = async(testCase: string, index: number) => {
 
   try {
     expect(scrollTop).toEqual(EXPECTED_SCROLL_TOPS[testCase][index]);
-  } catch(error) {
+  } catch (error) {
     try {
       mkdirSync('__diff_output__');
-    } catch(err) {
+    } catch (err) {
       if (err.code !== 'EEXIST') {
         throw err;
       }
@@ -42,7 +42,7 @@ const testScroll = async(testCase: string, index: number) => {
     );
     throw error;
   }
-}
+};
 
 describe('Content', () => {
   for (const testCase of Object.keys(TEST_CASES)) {


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1974
In case it happens again...
I put it in the diff_output dir so it gets uploaded as a GH action artifact.