### PR TITLE
Added PingFang SC font to font-family

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@ body, #root, html {
 
 
 html {
-  font-family: "Neue Helvetica W01", Helvetica, Arial, sans-serif;
+  font-family: "Neue Helvetica W01", Helvetica, Arial, sans-serif, "PingFang SC";
   font-size: 62.5%; /* Now 10px = 1rem! */
   text-size-adjust: 100%; /* Prevent font scaling in landscape while allowing user zoom */
 }


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1652
This is the font that Chrome uses to render those circled answer choices. Apparently none of the fonts in our current font-family can render them.