### PR TITLE
update anthropology content version

### DIFF
--- a/src/config.books.json
+++ b/src/config.books.json
@@ -221,7 +221,7 @@
     "defaultVersion": "dc4550b"
   },
   "cf0085c6-528c-4101-ad26-19c612c5a2fa": {
-    "defaultVersion": "79fd480"
+    "defaultVersion": "190164e"
   },
   "4c29f9e5-a53d-42c0-bdb5-091990527d79": {
     "defaultVersion": "cc1b9af"


### PR DESCRIPTION
for: openstax/unified#1973

Chapter slug changes no longer throw an error due to recent updates to the redirect script.