### PR TITLE
Fix localhost/heroku search by pointing it to prod search

### DIFF
--- a/src/config.development.js
+++ b/src/config.development.js
@@ -29,7 +29,7 @@ module.exports = {
   ACCOUNTS_URL: process.env.ACCOUNTS_URL || 'https://dev.openstax.org',
   OS_WEB_URL: process.env.OS_WEB_URL || 'https://dev.openstax.org',
   HIGHLIGHTS_URL: process.env.HIGHLIGHTS_URL || 'https://highlights-hl-40b2567.sandbox.openstax.org',
-  SEARCH_URL: process.env.SEARCH_URL || 'https://search-os-a6c9b00.sandbox.openstax.org',
+  SEARCH_URL: process.env.SEARCH_URL || 'https://openstax.org',
 
   SKIP_OS_WEB_PROXY: process.env.SKIP_OS_WEB_PROXY !== undefined,
   FIXTURES: false,


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2007
It's not clear why search is broken but highlights is not. I'm guessing highlights might break soon too and the same fix won't work there because of login issues.