### PR TITLE
assignable reading page

### DIFF
--- a/src/app/content/__snapshots__/routes.spec.tsx.snap
+++ b/src/app/content/__snapshots__/routes.spec.tsx.snap
@@ -53,4 +53,6 @@ Array [
 ]
 `;
 
+exports[`assigned route route renders renders loading state (for loadable component) 1`] = `null`;
+
 exports[`content route route renders renders a component 1`] = `null`;

--- a/src/app/content/__snapshots__/routes.spec.tsx.snap
+++ b/src/app/content/__snapshots__/routes.spec.tsx.snap
@@ -1,3 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`assigned route route renders renders a component 1`] = `
+Array [
+  <a
+    className="HiddenLink-wwwegq-0 bkbyvj"
+    href="#main-content"
+    onClick={[Function]}
+  >
+    Skip to Content
+  </a>,
+  <a
+    className="HiddenLink-wwwegq-0 bkbyvj"
+    href={
+      Array [
+        "https://openstax.org/accessibility-statement",
+      ]
+    }
+  >
+    Go to accessibility page
+  </a>,
+  <a
+    className="HiddenLink-wwwegq-0 bkbyvj"
+    href="#"
+    onClick={[Function]}
+  >
+    Keyboard shortcuts menu
+  </a>,
+  <div
+    className="MinPageHeight-sc-1i28xs0-0 hxgCaZ"
+  >
+    <div
+      className="RedoPadding-sc-1rj2rww-0 gaOlpC"
+    >
+      <div
+        className="page-content PageContent-ny9bj0-0 cXwdbF"
+        tabIndex={0}
+      >
+        <div
+          className="MainContent__ContentStyles-sc-6yy1if-0 evJIOJ sc-bxivhb exnGOr"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<div xmlns:m=\\"http://www.w3.org/1998/Math/MathML\\" xmlns:ns2=\\"urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0\\" class=\\"introduction\\" data-cnxml-to-html-ver=\\"1.3.2\\" data-type=\\"page\\" id=\\"1d1fd537-77fb-4eac-8a8a-60bbaa747b6d\\"><p id=\\"p1\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi ex erat, lacinia vitae mattis id, commodo vitae est. Nam quis arcu quis enim congue aliquet. Vivamus dictum rhoncus tortor, malesuada placerat tortor imperdiet ac. Fusce ac viverra nisi. Aliquam ut tempor diam. Cras rhoncus sodales massa vitae porttitor. Integer pharetra lorem a ante sollicitudin condimentum. Aliquam imperdiet erat et tellus mattis finibus. Sed nisl lectus, ultricies et ante ut, porttitor varius sem. Interdum et malesuada fames ac ante ipsum primis in faucibus. Fusce tempus interdum ante, nec placerat felis facilisis quis. Nunc nec malesuada nisi. Cras eu iaculis felis. Sed id maximus enim, sit amet sodales sapien. Proin pulvinar sem risus, nec ultricies odio viverra a. Aliquam feugiat euismod dapibus.</p><section id=\\"section1\\"><h3 data-type=\\"document-title\\" id=\\"100_copy_1\\"><span class=\\"os-number\\">1.1</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">A Section, Probably</span></h3><p id=\\"p2\\">Morbi lobortis mattis velit, <math display=\\"inline\\"><semantics><mrow><mrow><mrow><mrow><mrow><mrow><mi>W</mi><mo stretchy=\\"false\\">=</mo><mrow><msub><mtext>KE</mtext><mrow><mn>f</mn></mrow></msub><mo stretchy=\\"false\\">+</mo><msub><mtext>PE</mtext><mrow><mn>g</mn></mrow></msub></mrow></mrow><mo stretchy=\\"false\\">=</mo><mfrac><mrow><mn>1</mn></mrow><mrow><mn>2</mn></mrow></mfrac><msup><msub><mi fontstyle=\\"italic\\">mv</mi><mn>f</mn></msub><mn>2</mn></msup><mo stretchy=\\"false\\">+</mo><mrow><mtext fontstyle=\\"italic\\">mgh</mtext></mrow></mrow></mrow></mrow><mrow></mrow></mrow></mrow><annotation-xml encoding=\\"MathML-Content\\"><semantics><mrow><mrow><mrow><mrow><mrow><mi>W</mi><mo stretchy=\\"false\\">=</mo><mrow><msub><mtext>KE</mtext><mrow><mn>f</mn></mrow></msub><mo stretchy=\\"false\\">+</mo><msub><mtext>PE</mtext><mrow><mn>g</mn></mrow></msub></mrow></mrow><mo stretchy=\\"false\\">=</mo><mfrac><mrow><mn>1</mn></mrow><mrow><mn>2</mn></mrow></mfrac><msup><msub><mi fontstyle=\\"italic\\">mv</mi><mn>f</mn></msub><mn>2</mn></msup><mo stretchy=\\"false\\">+</mo><mrow><mtext fontstyle=\\"italic\\">mgh</mtext></mrow></mrow></mrow></mrow><mrow></mrow></mrow><annotation encoding=\\"StarMath 5.0\\"> size 12{W=\\"KE\\" rSub { size 8{f} } +\\"PE\\" rSub { size 8{g} } = {  { size 8{1} }  over  { size 8{2} } }  ital \\"mv\\" rSub { size 8{f}   rSup { size 8{2} } } + ital \\"mgh\\"} {}</annotation></semantics></annotation-xml></semantics></math> dapibus convallis est mollis sed. Sed ullamcorper est tortor, at ultricies felis tincidunt ut. Mauris interdum nunc et convallis pharetra. Nulla ac erat nulla. Vivamus a ornare leo. Quisque luctus dui eget auctor tristique. Sed vel est eget lorem volutpat mattis non et nisi. Aliquam ultricies ultrices velit, id fringilla ex suscipit in. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris consequat blandit felis, non finibus neque dignissim sit amet. Integer laoreet dapibus quam eget pulvinar. Aenean lobortis, arcu dignissim euismod ornare, eros est tincidunt urna, nec auctor odio quam eget tortor. Praesent sit amet metus a metus varius tincidunt. Pellentesque convallis sit amet erat eget malesuada. Proin pretium est euismod risus facilisis dignissim. Interdum et malesuada fames ac ante ipsum primis in faucibus.</p><p id=\\"p3\\">Integer maximus augue vitae orci vehicula tincidunt. Integer auctor ante odio, nec porta nisi pellentesque id. Donec porttitor velit vel turpis sagittis molestie. Sed eu rhoncus orci. Donec feugiat tristique posuere. Fusce consequat, nisi vitae porttitor ornare, augue velit sodales augue, ac facilisis turpis orci vitae lectus. Mauris mauris urna, dictum a dui et, imperdiet commodo justo. Pellentesque scelerisque dui sed libero porta, sit amet rhoncus ex dictum. Interdum et malesuada fames ac ante ipsum primis in faucibus.</p><div data-type=\\"equation\\" id=\\"fs-id2746082\\"><math display=\\"block\\"><semantics><mrow><mrow><mrow><mrow><mi>P</mi><mo stretchy=\\"false\\">=</mo><mfrac><mi>W</mi><mi>t</mi></mfrac></mrow></mrow><mrow></mrow></mrow></mrow><annotation-xml encoding=\\"MathML-Content\\"><semantics><mrow><mrow><mrow><mi>P</mi><mo stretchy=\\"false\\">=</mo><mfrac><mi>W</mi><mi>t</mi></mfrac></mrow></mrow><mrow></mrow></mrow><annotation encoding=\\"StarMath 5.0\\"> size 12{P= {  {W}  over  {t} } } {}</annotation></semantics></annotation-xml></semantics></math><div class=\\"os-equation-number\\"><span class=\\"os-number\\">1.01</span></div></div><p id=\\"p4\\">Donec congue tortor sed magna ullamcorper mollis. Suspendisse eu tincidunt augue, et pulvinar purus. Fusce gravida quam lorem, sed pharetra libero bibendum et. Etiam facilisis ex vel nisi egestas, non consequat mi malesuada. Donec scelerisque magna sem, ut ornare massa rhoncus sed. In ultricies tellus porttitor enim elementum, ut mollis nisl euismod. Pellentesque eu lobortis neque. Phasellus eget luctus velit, in eleifend lectus. Pellentesque leo odio, cursus eget feugiat eu, finibus in nibh. In nec urna justo. Donec ut nisi eleifend, auctor lacus quis, hendrerit sem. Pellentesque sagittis nunc a molestie finibus. Donec pulvinar nibh elit, nec ornare nibh egestas quis. Curabitur luctus euismod lobortis.</p><div class=\\"os-figure\\" id=\\"figureid\\"><figure data-id=\\"figureid\\"><div data-alt=\\"\\" data-type=\\"media\\" id=\\"Phet_module_25.2\\"> <iframe title=\\"interactive simulation\\" height=\\"371.4\\" src=\\"/specials/version/radio-waves/#sim-radio-waves\\" width=\\"660\\"></iframe></div></figure><div class=\\"os-caption-container\\"><span class=\\"os-title-label\\">Figure </span><span class=\\"os-number\\">1.0</span><span class=\\"os-divider\\"> </span></div></div>  <p id=\\"p5\\">Maecenas vehicula nec quam vitae sodales. Vestibulum bibendum accumsan mauris. Nunc rhoncus libero odio, in ullamcorper massa ornare convallis. Nullam metus tortor, aliquam a ultrices et, rhoncus in risus. Nunc vel turpis erat. Cras semper sagittis odio, eu mattis nulla faucibus quis. Aliquam egestas nunc elit, eget condimentum lectus congue et. Curabitur non gravida lorem. Integer mi nunc, commodo vitae augue vel, bibendum pretium magna. Sed ut nibh venenatis ipsum tempus mollis pretium eget est. Aliquam commodo quam ipsum, at fermentum enim tristique eget. Mauris imperdiet dapibus maximus. Donec tristique varius lacinia. Pellentesque pharetra nunc eu nisi ullamcorper placerat. Suspendisse potenti.</p><p id=\\"p6\\">Integer fringilla blandit dolor ut mattis. Nam commodo ex at blandit sodales. Nullam suscipit, nunc eu mollis sagittis, purus arcu tincidunt ligula, vitae pharetra metus tortor id ex. Donec malesuada aliquet ligula id mollis. Maecenas scelerisque maximus sollicitudin. Quisque sagittis dolor at ligula congue, quis rhoncus mi porttitor. Quisque lobortis ut ante sed convallis. Integer luctus cursus molestie.</p><p id=\\"p7\\">Morbi a purus a elit dapibus fermentum. Sed varius ex quis tortor tincidunt posuere. Mauris luctus risus id aliquet mollis. Phasellus ornare leo a arcu imperdiet dictum. Praesent accumsan venenatis urna, sed egestas sem pharetra a. Sed vulputate sit amet nisl a aliquet. Interdum et malesuada fames ac ante ipsum primis in faucibus. Mauris facilisis augue vitae est maximus pharetra in ac elit. Pellentesque viverra purus non ligula tempor convallis.</p><p id=\\"p8\\">Pellentesque lectus ante, malesuada ut ornare vitae, euismod non urna. Morbi varius eros eget felis accumsan vehicula. In diam ex, finibus rhoncus dapibus non, lacinia in lacus. Nullam pretium mollis laoreet. Ut interdum dui sit amet elementum dignissim. Etiam in nibh vitae ligula fringilla aliquet quis vel ex. Nullam quis elit libero. In aliquet laoreet arcu at posuere. Duis consectetur et dolor non accumsan. Fusce enim est, dignissim sed mauris at, ornare cursus ligula. Nullam tincidunt eu purus vel lacinia. Praesent varius, arcu sed facilisis elementum, orci metus vestibulum nisl, sed sodales urna eros ullamcorper turpis. Donec mollis ac massa ac elementum. Nulla maximus purus sed orci efficitur, ut porta mauris elementum.</p><p id=\\"p9\\">Vestibulum blandit enim quis sapien ultrices pretium. Cras dapibus ornare fringilla. Duis ut laoreet dolor. Proin ullamcorper molestie dui eu vestibulum. Nullam convallis mollis mauris nec accumsan. Proin egestas enim non nisl suscipit, ut feugiat felis pharetra. In faucibus fringilla ipsum vel sollicitudin. Maecenas blandit augue odio, ac mattis justo feugiat sit amet. Etiam nec molestie eros. Sed gravida velit libero, at pretium diam venenatis sit amet. Donec tellus leo, faucibus eu sapien nec, mollis efficitur lorem. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p></section><dl id=\\"test-pair-page1\\"><dt>test term</dt><dd>test definition with <math>math element</math></dd></dl></div>",
+            }
+          }
+          data-dynamic-style={false}
+          id="main-content"
+          tabIndex={-1}
+        />
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`content route route renders renders a component 1`] = `null`;

--- a/src/app/content/components/Assigned.spec.tsx
+++ b/src/app/content/components/Assigned.spec.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import { RawIntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import renderer from 'react-test-renderer';
+import createTestServices from '../../../test/createTestServices';
+import createTestStore from '../../../test/createTestStore';
+import { book, page, shortPage } from '../../../test/mocks/archiveLoader';
+import { mockCmsBook } from '../../../test/mocks/osWebLoader';
+import * as Services from '../../context/Services';
+import createIntl from '../../messages/createIntl';
+import * as selectNavigation from '../../navigation/selectors';
+import { MiddlewareAPI, Store } from '../../types';
+import { setTextSize } from '../actions';
+import * as selectContent from '../selectors';
+import { formatBookData } from '../utils';
+import Assigned from './Assigned';
+
+describe('Assigned', () => {
+  let store: Store;
+  let services: ReturnType<typeof createTestServices> & MiddlewareAPI;
+
+  beforeEach(() => {
+    store = createTestStore();
+    services = {
+      ...createTestServices(),
+      dispatch: store.dispatch,
+      getState: store.getState,
+    };
+
+    store.dispatch(setTextSize(0));
+  });
+
+  it('renders loading state without book', async() => {
+    jest.spyOn(selectNavigation, 'query').mockReturnValue({
+      section: [page.id, shortPage.id],
+    });
+
+    const intl = await createIntl(book.language);
+
+    const tree = renderer.create(
+      <Provider store={store}>
+        <RawIntlProvider value={intl}>
+          <Services.Provider value={services}>
+            <Assigned />
+          </Services.Provider>
+        </RawIntlProvider>
+      </Provider>
+    );
+
+    expect(() =>
+      tree.root.findByProps({
+        'data-testid': 'loader',
+      })
+    ).not.toThrow();
+
+    tree.unmount();
+  });
+
+  it('renders loading state without page', async() => {
+    jest.spyOn(selectNavigation, 'query').mockReturnValue({
+      section: [page.id, shortPage.id],
+    });
+    jest
+      .spyOn(selectContent, 'book')
+      .mockReturnValue(formatBookData(book, mockCmsBook));
+
+    const intl = await createIntl(book.language);
+
+    const tree = renderer.create(
+      <Provider store={store}>
+        <RawIntlProvider value={intl}>
+          <Services.Provider value={services}>
+            <Assigned />
+          </Services.Provider>
+        </RawIntlProvider>
+      </Provider>
+    );
+
+    expect(() =>
+      tree.root.findByProps({
+        'data-testid': 'loader',
+      })
+    ).not.toThrow();
+
+    tree.unmount();
+  });
+
+  it('renders with next link', async() => {
+    jest.spyOn(selectNavigation, 'query').mockReturnValue({
+      section: [page.id, shortPage.id],
+    });
+    jest
+      .spyOn(selectContent, 'book')
+      .mockReturnValue(formatBookData(book, mockCmsBook));
+
+    const intl = await createIntl(book.language);
+
+    const tree = renderer.create(
+      <Provider store={store}>
+        <RawIntlProvider value={intl}>
+          <Services.Provider value={services}>
+            <Assigned />
+          </Services.Provider>
+        </RawIntlProvider>
+      </Provider>
+    );
+
+    await renderer.act(async() => {
+      await services.promiseCollector.calm();
+    });
+
+    expect(() =>
+      tree.root.findByProps({
+        'aria-label': 'Next Page',
+        'href': 'books/book-slug-1/pages/3-test-page-4',
+      })
+    ).not.toThrow();
+
+    tree.unmount();
+  });
+
+  it('goes to next', async() => {
+    jest.spyOn(selectNavigation, 'query').mockReturnValue({
+      redirect: '/cool/redirect',
+      section: [page.id, shortPage.id],
+    });
+    jest.spyOn(selectContent, 'book')
+      .mockReturnValue(formatBookData(book, mockCmsBook));
+
+    const intl = await createIntl(book.language);
+
+    const tree = renderer.create(
+      <Provider store={store}>
+        <RawIntlProvider value={intl}>
+          <Services.Provider value={services}>
+            <Assigned />
+          </Services.Provider>
+        </RawIntlProvider>
+      </Provider>
+    );
+
+    await renderer.act(async() => {
+      await services.promiseCollector.calm();
+    });
+
+    const initialPageContent = tree.root.findByProps({ id: 'main-content' })
+      .props.dangerouslySetInnerHTML.__html;
+
+    expect(() => tree.root.findByProps({href: '/cool/redirect'})).toThrow();
+
+    await renderer.act(async() => {
+      tree.root
+        .findByProps({
+          'aria-label': 'Next Page',
+          'href': 'books/book-slug-1/pages/3-test-page-4',
+        })
+        .props.onClick({ preventDefault: jest.fn() });
+
+      await services.promiseCollector.calm();
+    });
+
+    expect(
+      tree.root.findByProps({ id: 'main-content' }).props.dangerouslySetInnerHTML.__html
+    ).not.toBe(initialPageContent);
+
+    expect(() => tree.root.findByProps({
+      'aria-label': 'Next Page',
+      'href': 'books/book-slug-1/pages/3-test-page-4',
+    })).toThrow();
+
+    expect(() => tree.root.findByProps({
+      'aria-label': 'Previous Page',
+      'href': 'books/book-slug-1/pages/test-page-1',
+    })).not.toThrow();
+
+    expect(() => tree.root.findByProps({
+      href: '/cool/redirect',
+    })).not.toThrow();
+
+    tree.unmount();
+  });
+
+  it('goes to previous', async() => {
+    jest.spyOn(selectNavigation, 'query').mockReturnValue({
+      section: [page.id, shortPage.id],
+    });
+    jest.spyOn(selectContent, 'book')
+      .mockReturnValue(formatBookData(book, mockCmsBook));
+
+    const intl = await createIntl(book.language);
+
+    const tree = renderer.create(
+      <Provider store={store}>
+        <RawIntlProvider value={intl}>
+          <Services.Provider value={services}>
+            <Assigned />
+          </Services.Provider>
+        </RawIntlProvider>
+      </Provider>
+    );
+
+    await renderer.act(async() => {
+      await services.promiseCollector.calm();
+    });
+
+    await renderer.act(async() => {
+      tree.root
+        .findByProps({
+          'aria-label': 'Next Page',
+          'href': 'books/book-slug-1/pages/3-test-page-4',
+        })
+        .props.onClick({ preventDefault: jest.fn() });
+
+      await services.promiseCollector.calm();
+    });
+
+    const initialPageContent = tree.root.findByProps({ id: 'main-content' })
+      .props.dangerouslySetInnerHTML.__html;
+
+    await renderer.act(async() => {
+      tree.root
+        .findByProps({
+          'aria-label': 'Previous Page',
+          'href': 'books/book-slug-1/pages/test-page-1',
+        })
+        .props.onClick({ preventDefault: jest.fn() });
+
+      await services.promiseCollector.calm();
+    });
+
+    expect(
+      tree.root.findByProps({ id: 'main-content' }).props.dangerouslySetInnerHTML.__html
+    ).not.toBe(initialPageContent);
+
+    expect(() => tree.root.findByProps({
+      'aria-label': 'Next Page',
+      'href': 'books/book-slug-1/pages/3-test-page-4',
+    })).not.toThrow();
+
+    expect(() => tree.root.findByProps({
+      'aria-label': 'Previous Page',
+      'href': 'books/book-slug-1/pages/test-page-1',
+    })).toThrow();
+
+    tree.unmount();
+  });
+});

--- a/src/app/content/components/Assigned.tsx
+++ b/src/app/content/components/Assigned.tsx
@@ -81,8 +81,8 @@ export default () => {
           ? <PrevNextBar
             book={book}
             prevNext={prevNext}
-            onPrevious={() => setCurrentSectionIndex(Math.max(0, currentSectionIndex - 1))}
-            onNext={() => setCurrentSectionIndex(Math.min(sections.length - 1, currentSectionIndex + 1))}
+            handlePrevious={() => setCurrentSectionIndex(Math.max(0, currentSectionIndex - 1))}
+            handleNext={() => setCurrentSectionIndex(Math.min(sections.length - 1, currentSectionIndex + 1))}
           />
           : null
         }

--- a/src/app/content/components/Assigned.tsx
+++ b/src/app/content/components/Assigned.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import AccessibilityButtonsWrapper from '../../components/AccessibilityButtonsWrapper';
+import Button from '../../components/Button';
+import { useServices } from '../../context/Services';
+import ErrorBoundary from '../../errors/components/ErrorBoundary';
+import ErrorModal from '../../errors/components/ErrorModal';
+import { or } from '../../fpUtils';
+import * as selectNavigation from '../../navigation/selectors';
+import { assertString } from '../../utils/assertions';
+import { loadPage } from '../hooks/locationChange/resolveContent';
+import * as selectContent from '../selectors';
+import { ArchiveTreeSection, LinkedArchiveTreeSection } from '../types';
+import { findTreePages, getPrevNext, nodeMatcher } from '../utils/archiveTreeUtils';
+import { stripIdVersion } from '../utils/idUtils';
+import Page from './Page';
+import { PrevNextBar } from './PrevNextBar';
+
+const useLoadSection = (currentSection: ArchiveTreeSection | undefined) => {
+  const services = useServices();
+  const book = useSelector(selectContent.book);
+
+  React.useEffect(() => {
+    if (!book || !currentSection) {
+      return;
+    }
+    const uuid = stripIdVersion(currentSection.id);
+    loadPage(services, {uuid}, book, services.archiveLoader.forBook(book), uuid);
+  }, [services, currentSection, book]);
+};
+
+const useAssignedSections = () => {
+  const book = useSelector(selectContent.book);
+  const query = useSelector(selectNavigation.query);
+  const sections = React.useMemo(() => query.section instanceof Array
+    ? query.section
+    : [assertString(query.section, 'at least one section must be assigned')]
+  , [query]);
+
+  return React.useMemo(() => {
+    if (!book) {
+      return [];
+    }
+    const allPages = findTreePages(book.tree);
+
+    return allPages.filter(or(...sections.map(nodeMatcher)));
+  }, [book, sections]);
+};
+
+const usePrevNext = (sections: LinkedArchiveTreeSection[]) => {
+  const page = useSelector(selectContent.page);
+
+  return React.useMemo(() => {
+    if (!page) {
+      return;
+    }
+    const prevNext = getPrevNext(sections, page.id);
+
+    if (!prevNext.prev && !prevNext.next) {
+      return undefined;
+    }
+
+    return prevNext;
+  }, [sections, page]);
+};
+
+export default () => {
+  const book = useSelector(selectContent.book);
+  const {redirect} = useSelector(selectNavigation.query);
+  const sections = useAssignedSections();
+  const [currentSectionIndex, setCurrentSectionIndex] = React.useState(0);
+  const prevNext = usePrevNext(sections);
+
+  useLoadSection(sections[currentSectionIndex]);
+
+  return <AccessibilityButtonsWrapper>
+    <ErrorModal />
+    <ErrorBoundary>
+      <Page>
+        {prevNext
+          ? <PrevNextBar
+            book={book}
+            prevNext={prevNext}
+            onPrevious={() => setCurrentSectionIndex(Math.max(0, currentSectionIndex - 1))}
+            onNext={() => setCurrentSectionIndex(Math.min(sections.length - 1, currentSectionIndex + 1))}
+          />
+          : null
+        }
+        {!prevNext?.next && typeof redirect === 'string'
+            ? <Button component={<a href={redirect}>finished reading</a>} variant='primary' size='large' />
+            : null
+        }
+      </Page>
+    </ErrorBoundary>
+  </AccessibilityButtonsWrapper>;
+};

--- a/src/app/content/components/ContentLink.spec.tsx
+++ b/src/app/content/components/ContentLink.spec.tsx
@@ -162,11 +162,7 @@ describe('ContentLink', () => {
 
       const event = await click(component);
 
-      expect(dispatch).toHaveBeenCalledWith(push({
-        params: {book: {slug: BOOK_SLUG}, page: {slug: PAGE_SLUG}},
-        route: content,
-        state: { },
-      }));
+      expect(dispatch).not.toHaveBeenCalled();
       expect(event.preventDefault).toHaveBeenCalled();
       expect(clickSpy).toHaveBeenCalled();
     });

--- a/src/app/content/components/ContentLink.spec.tsx
+++ b/src/app/content/components/ContentLink.spec.tsx
@@ -162,7 +162,11 @@ describe('ContentLink', () => {
 
       const event = await click(component);
 
-      expect(dispatch).not.toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith(push({
+        params: {book: {slug: BOOK_SLUG}, page: {slug: PAGE_SLUG}},
+        route: content,
+        state: { },
+      }));
       expect(event.preventDefault).toHaveBeenCalled();
       expect(clickSpy).toHaveBeenCalled();
     });

--- a/src/app/content/components/ContentLink.tsx
+++ b/src/app/content/components/ContentLink.tsx
@@ -89,9 +89,9 @@ export const ContentLink = (props: React.PropsWithChildren<Props>) => {
 
       if (onClick) {
         onClick();
+      } else {
+        navigate(navigationMatch, options);
       }
-
-      navigate(navigationMatch, options);
     }}
     href={URL}
     {...anchorProps}

--- a/src/app/content/components/ContentLink.tsx
+++ b/src/app/content/components/ContentLink.tsx
@@ -27,7 +27,8 @@ interface Props {
     title: string;
   };
   currentBook: Book | undefined;
-  onClick?: () => void;
+  onClick?: () => void; // this one gets called before navigation
+  handleClick?: () => void; // this one gets called instead of navigation
   navigate: typeof push;
   currentPath: string;
   hasUnsavedHighlight: boolean;
@@ -52,6 +53,7 @@ export const ContentLink = (props: React.PropsWithChildren<Props>) => {
     scrollTarget,
     navigate,
     onClick,
+    handleClick,
     children,
     myForwardedRef,
     hasUnsavedHighlight,
@@ -89,6 +91,10 @@ export const ContentLink = (props: React.PropsWithChildren<Props>) => {
 
       if (onClick) {
         onClick();
+      }
+
+      if (handleClick) {
+        handleClick();
       } else {
         navigate(navigationMatch, options);
       }

--- a/src/app/content/components/PrevNextBar.tsx
+++ b/src/app/content/components/PrevNextBar.tsx
@@ -81,6 +81,8 @@ interface PropTypes {
   book?: Book;
   onPrevious?: () => void;
   onNext?: () => void;
+  handlePrevious?: () => void;
+  handleNext?: () => void;
   prevNext: null | {
     prev?: ArchiveTreeSection;
     next?: ArchiveTreeSection;
@@ -88,7 +90,7 @@ interface PropTypes {
 }
 
 // tslint:disable-next-line:variable-name
-export const PrevNextBar = ({book, prevNext, onPrevious, onNext}: PropTypes) => {
+export const PrevNextBar = ({book, prevNext, ...props}: PropTypes) => {
   const { formatMessage } = useIntl();
 
   if (!prevNext) {
@@ -99,7 +101,8 @@ export const PrevNextBar = ({book, prevNext, onPrevious, onNext}: PropTypes) => 
     <HidingContentLink side='left'
       book={book}
       page={prevNext.prev}
-      onClick={onPrevious}
+      onClick={props.onPrevious}
+      handleClick={props.handlePrevious}
       aria-label={formatMessage({id: 'i18n:prevnext:prev:aria-label'})}
       data-analytics-label='prev'
     >
@@ -112,7 +115,8 @@ export const PrevNextBar = ({book, prevNext, onPrevious, onNext}: PropTypes) => 
     <HidingContentLink side='right'
       book={book}
       page={prevNext.next}
-      onClick={onNext}
+      onClick={props.onNext}
+      handleClick={props.handleNext}
       aria-label={formatMessage({id: 'i18n:prevnext:next:aria-label'})}
       data-analytics-label='next'
     >

--- a/src/app/content/components/PrevNextBar.tsx
+++ b/src/app/content/components/PrevNextBar.tsx
@@ -79,6 +79,8 @@ const BarWrapper = styled.div`
 
 interface PropTypes {
   book?: Book;
+  onPrevious?: () => void;
+  onNext?: () => void;
   prevNext: null | {
     prev?: ArchiveTreeSection;
     next?: ArchiveTreeSection;
@@ -86,7 +88,7 @@ interface PropTypes {
 }
 
 // tslint:disable-next-line:variable-name
-export const PrevNextBar = ({book, prevNext}: PropTypes) => {
+export const PrevNextBar = ({book, prevNext, onPrevious, onNext}: PropTypes) => {
   const { formatMessage } = useIntl();
 
   if (!prevNext) {
@@ -97,6 +99,7 @@ export const PrevNextBar = ({book, prevNext}: PropTypes) => {
     <HidingContentLink side='left'
       book={book}
       page={prevNext.prev}
+      onClick={onPrevious}
       aria-label={formatMessage({id: 'i18n:prevnext:prev:aria-label'})}
       data-analytics-label='prev'
     >
@@ -109,6 +112,7 @@ export const PrevNextBar = ({book, prevNext}: PropTypes) => {
     <HidingContentLink side='right'
       book={book}
       page={prevNext.next}
+      onClick={onNext}
       aria-label={formatMessage({id: 'i18n:prevnext:next:aria-label'})}
       data-analytics-label='next'
     >

--- a/src/app/content/highlights/hooks/index.ts
+++ b/src/app/content/highlights/hooks/index.ts
@@ -3,6 +3,7 @@ import { receiveUser } from '../../../auth/actions';
 import { closeModal } from '../../../navigation/hooks/closeModalHook';
 import { openModal } from '../../../navigation/hooks/openModalHook';
 import { actionHook } from '../../../utils';
+import { receivePage } from '../../actions';
 import { closeMyHighlights, openMyHighlights } from '../actions';
 import { modalUrlName } from '../constants';
 import createHighlight from './createHighlight';
@@ -32,4 +33,5 @@ export default [
   actionHook(openMyHighlights, openModal(modalUrlName)),
   actionHook(receiveUser, loadHighlights),
   actionHook(receivePageFocus, loadHighlights),
+  actionHook(receivePage, loadHighlights),
 ];

--- a/src/app/content/hooks/index.ts
+++ b/src/app/content/hooks/index.ts
@@ -10,7 +10,7 @@ import * as routes from '../routes';
 import searchHooks from '../search/hooks';
 import studyGuidesHooks from '../studyGuides/hooks';
 import kineticEnabled from './kineticEnabled';
-import locationChangeBody from './locationChange';
+import { assignedRouteHookBody, contentRouteHookBody } from './locationChange';
 import receiveContentBody from './receiveContent';
 import receivePageNotFoundId from './receivePageNotFoundId';
 import storeTextSize, { loadStoredTextSize } from './storeTextSize';
@@ -25,7 +25,8 @@ export default [
   /*
    * clears meta on locationChange, in case the new route doesn't call setHead
    * */
-  routeHook(routes.content, locationChangeBody),
+  routeHook(routes.content, contentRouteHookBody),
+  routeHook(routes.assigned, assignedRouteHookBody),
   /*
    * sets metadata based on the loaded content
    */

--- a/src/app/content/hooks/locationChange.spec.ts
+++ b/src/app/content/hooks/locationChange.spec.ts
@@ -15,12 +15,12 @@ import { formatBookData } from '../utils';
 
 const mockBook = {...book, id: '13ac107a-f15f-49d2-97e8-60ab2e3b519c', version: '29.7'};
 
-describe('locationChange', () => {
+describe('contentRouteHookBody', () => {
   let store: Store;
   let dispatch: jest.SpyInstance;
   let helpers: ReturnType<typeof createTestServices> & MiddlewareAPI;
   let payload: {location: Location, match: Match<typeof routes.content>};
-  let hook = require('./locationChange').default;
+  let hook = require('./locationChange').contentRouteHookBody;
   let contentHook: typeof import ('./locationChange/resolveContent');
   let intlHook: typeof import ('./intlHook');
   let mockBookConfig: {[key: string]: {defaultVersion: string}};
@@ -62,7 +62,7 @@ describe('locationChange', () => {
       },
     };
 
-    hook = (require('./locationChange').default)(helpers);
+    hook = (require('./locationChange').contentRouteHookBody)(helpers);
     contentHook = require('./locationChange/resolveContent');
     intlHook = require('./intlHook');
   });

--- a/src/app/content/hooks/locationChange.spec.ts
+++ b/src/app/content/hooks/locationChange.spec.ts
@@ -14,36 +14,39 @@ import { SlugParams } from '../types';
 import { formatBookData } from '../utils';
 
 const mockBook = {...book, id: '13ac107a-f15f-49d2-97e8-60ab2e3b519c', version: '29.7'};
+let store: Store;
+let dispatch: jest.SpyInstance;
+let helpers: ReturnType<typeof createTestServices> & MiddlewareAPI;
+let intlHook: typeof import ('./intlHook');
+let mockBookConfig: {[key: string]: {defaultVersion: string}};
+let contentHook: typeof import ('./locationChange/resolveContent');
+
+beforeEach(() => {
+  resetModules();
+  store = createTestStore();
+
+  helpers = {
+    ...createTestServices(),
+    dispatch: store.dispatch,
+    getState: store.getState,
+  };
+
+  mockBookConfig = {
+   [book.id]: {defaultVersion: book.version},
+   [mockBook.id]: {defaultVersion: mockBook.version},
+  };
+
+  Object.assign(helpers.bookConfigLoader.localBookConfig, mockBookConfig);
+  dispatch = jest.spyOn(helpers, 'dispatch');
+  contentHook = require('./locationChange/resolveContent');
+  intlHook = require('./intlHook');
+});
 
 describe('contentRouteHookBody', () => {
-  let store: Store;
-  let dispatch: jest.SpyInstance;
-  let helpers: ReturnType<typeof createTestServices> & MiddlewareAPI;
   let payload: {location: Location, match: Match<typeof routes.content>};
   let hook = require('./locationChange').contentRouteHookBody;
-  let contentHook: typeof import ('./locationChange/resolveContent');
-  let intlHook: typeof import ('./intlHook');
-  let mockBookConfig: {[key: string]: {defaultVersion: string}};
 
   beforeEach(() => {
-    resetModules();
-    store = createTestStore();
-
-    helpers = {
-      ...createTestServices(),
-      dispatch: store.dispatch,
-      getState: store.getState,
-    };
-
-    mockBookConfig = {
-     [book.id]: {defaultVersion: book.version},
-     [mockBook.id]: {defaultVersion: mockBook.version},
-    };
-
-    Object.assign(helpers.bookConfigLoader.localBookConfig, mockBookConfig);
-
-    dispatch = jest.spyOn(helpers, 'dispatch');
-
     helpers.osWebLoader.getBookIdFromSlug.mockReturnValue(Promise.resolve(book.id));
 
     payload = {
@@ -63,8 +66,6 @@ describe('contentRouteHookBody', () => {
     };
 
     hook = (require('./locationChange').contentRouteHookBody)(helpers);
-    contentHook = require('./locationChange/resolveContent');
-    intlHook = require('./intlHook');
   });
 
   it('loads book', async() => {
@@ -281,5 +282,48 @@ describe('contentRouteHookBody', () => {
         + `, archive thought it would be in "${mockOtherBook.id}", but it wasn't`
       );
     });
+  });
+});
+
+describe('assignedRouteHookBody', () => {
+  let payload: {location: Location, match: Match<typeof routes.assigned>};
+  let hook = require('./locationChange').assignedRouteHookBody;
+  let selectQuerySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    payload = {
+      location: {} as Location,
+      match: {
+        params: {
+          activityId: 'cool reading',
+        },
+        route: routes.assigned,
+        state: {},
+      },
+    };
+
+    selectQuerySpy = jest.spyOn(require('../../navigation/selectors'), 'query');
+
+    selectQuerySpy.mockReturnValue({book: 'testbook1-uuid'});
+
+    hook = (require('./locationChange').assignedRouteHookBody)(helpers);
+  });
+
+  it('loads book', async() => {
+    await hook(payload);
+    expect(dispatch).toHaveBeenCalledWith(actions.requestBook({uuid: 'testbook1-uuid'}));
+    expect(helpers.archiveLoader.mock.loadBook).toHaveBeenCalledWith('testbook1-uuid', expect.objectContaining({
+      booksConfig: expect.anything(),
+    }));
+  });
+
+  it('calls intl', async() => {
+    const intlSpy = jest.spyOn(intlHook, 'default');
+    await hook(payload);
+    expect(dispatch).toHaveBeenCalledWith(actions.requestBook({uuid: 'testbook1-uuid'}));
+    expect(helpers.archiveLoader.mock.loadBook).toHaveBeenCalledWith('testbook1-uuid', expect.objectContaining({
+      booksConfig: expect.anything(),
+    }));
+    expect(intlSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/content/hooks/locationChange/index.ts
+++ b/src/app/content/hooks/locationChange/index.ts
@@ -24,7 +24,6 @@ const hookBody: RouteHookBody<typeof content> = (services) => {
       boundRegisterPageView(action),
       syncSearch(services)(action),
       loadBuyPrintConfig(services)(),
-      loadHighlights(services)(locationChange(action)),
       loadStudyGuides(services)(),
       loadPracticeQuestions(services)(),
       initializeIntl(services)(),

--- a/src/app/content/hooks/locationChange/index.ts
+++ b/src/app/content/hooks/locationChange/index.ts
@@ -1,16 +1,17 @@
-import { locationChange } from '../../../navigation/actions';
+import * as selectNavigation from '../../../navigation/selectors';
 import { RouteHookBody } from '../../../navigation/types';
-import { loadHighlights } from '../../highlights/hooks';
+import { assertString } from '../../../utils/assertions';
 import { loadPracticeQuestions } from '../../practiceQuestions/hooks';
-import { content } from '../../routes';
+import { assigned, content } from '../../routes';
 import { syncSearch } from '../../search/hooks';
 import { loadStudyGuides } from '../../studyGuides/hooks';
 import initializeIntl from '../intlHook';
 import registerPageView from '../registerPageView';
 import loadBuyPrintConfig from './buyPrintConfig';
 import resolveContent from './resolveContent';
+import { resolveBook } from './resolveContent';
 
-const hookBody: RouteHookBody<typeof content> = (services) => {
+export const contentRouteHookBody: RouteHookBody<typeof content> = (services) => {
   const boundRegisterPageView = registerPageView(services);
 
   return async(action) => {
@@ -31,4 +32,17 @@ const hookBody: RouteHookBody<typeof content> = (services) => {
   };
 };
 
-export default hookBody;
+export const assignedRouteHookBody: RouteHookBody<typeof assigned> = (services) => {
+  const boundRegisterPageView = registerPageView(services);
+
+  return async(action) => {
+    const query = selectNavigation.query(services.getState());
+
+    await resolveBook(services, {uuid: assertString(query.book, 'book must be a string')});
+
+    await Promise.all([
+      boundRegisterPageView(action),
+      initializeIntl(services)(),
+    ]);
+  };
+};

--- a/src/app/content/hooks/locationChange/resolveContent-in-development.spec.ts
+++ b/src/app/content/hooks/locationChange/resolveContent-in-development.spec.ts
@@ -240,7 +240,7 @@ describe('locationChange', () => {
       helpers.osWebLoader.getBookIdFromSlug.mockImplementation(() => Promise.resolve(undefined) as any);
 
       await expect(
-        resolveContentUtils.resolveBookReference(helpers, match)
+        resolveContentUtils.resolveBookReference(helpers, match.params.book)
       ).rejects.toThrow(`Could not resolve uuid for params: {"slug":"${testBookSlug}"}`);
     });
 

--- a/src/app/content/hooks/registerPageView.ts
+++ b/src/app/content/hooks/registerPageView.ts
@@ -1,10 +1,9 @@
 import googleAnalyticsClient from '../../../gateways/googleAnalyticsClient';
 import * as selectNavigation from '../../navigation/selectors';
-import { RouteHookBody } from '../../navigation/types';
+import { AnyRoute, RouteHookBody } from '../../navigation/types';
 import { AppServices, MiddlewareAPI } from '../../types';
-import { content } from '../routes';
 
-export const hookBody: RouteHookBody<typeof content> = (services: MiddlewareAPI & AppServices) => {
+export const hookBody: RouteHookBody<AnyRoute> = (services: MiddlewareAPI & AppServices) => {
   let lastTrackedLocation: any;
 
   return async(action) => {

--- a/src/app/content/routes.spec.tsx
+++ b/src/app/content/routes.spec.tsx
@@ -5,6 +5,7 @@ import { mockCmsBook } from '../../test/mocks/osWebLoader';
 import { reactAndFriends, resetModules } from '../../test/utils';
 import { locationChange } from '../navigation/actions';
 import { Match } from '../navigation/types';
+import { AppServices } from '../types';
 
 const longID = 'longidin-vali-dfor-mat1-111111111111';
 
@@ -169,6 +170,9 @@ describe('assigned route', () => {
 
   describe('route renders', () => {
     let preloadAll: any;
+    let services: AppServices;
+    let app: any;
+    let match: Match<typeof assigned>;
 
     beforeEach(() => {
       resetModules();
@@ -176,10 +180,7 @@ describe('assigned route', () => {
       preloadAll = require('react-loadable').preloadAll;
       assigned = require('./routes').assigned;
       createApp = require('../index').default;
-    });
-
-    it('renders a component', async() => {
-      const services = createTestServices();
+      services = createTestServices();
 
       jest.spyOn(services.highlightClient, 'getHighlights').mockReturnValue(
         Promise.resolve({
@@ -188,19 +189,21 @@ describe('assigned route', () => {
         })
       );
 
-      const params = {
-        activityId: book.id,
-      };
+      const params = {activityId: book.id};
+      match = {params, route: assigned, state: {}};
+      app = createApp({services});
+    });
 
-      const match: Match<typeof assigned> = {
-        params,
-        route: assigned,
-        state: {},
-      };
+    it('renders loading state (for loadable component)', async() => {
+      const tree = renderer.create(<app.container />);
 
-      const app = createApp({
-        services,
-      });
+      expect(tree.toJSON()).toMatchSnapshot();
+
+      tree.unmount();
+    });
+
+    it('renders a component', async() => {
+      await preloadAll();
 
       app.store.dispatch(locationChange({
         action: 'PUSH',
@@ -212,8 +215,6 @@ describe('assigned route', () => {
         },
         match,
       }));
-
-      await preloadAll();
 
       const tree = renderer.create(<app.container />);
 

--- a/src/app/content/routes.spec.tsx
+++ b/src/app/content/routes.spec.tsx
@@ -195,6 +195,17 @@ describe('assigned route', () => {
     });
 
     it('renders loading state (for loadable component)', async() => {
+      app.store.dispatch(locationChange({
+        action: 'PUSH',
+        location: {
+          hash: '',
+          pathname: '/apps/rex/assigned/123456',
+          search: `?book=${book.id}&section=${page.id}`,
+          state: {},
+        },
+        match,
+      }));
+
       const tree = renderer.create(<app.container />);
 
       expect(tree.toJSON()).toMatchSnapshot();

--- a/src/app/content/routes.ts
+++ b/src/app/content/routes.ts
@@ -70,7 +70,7 @@ export const content: ContentRoute = {
   paths: contentPaths,
 };
 
-const assignedPath = dynamicPrefix + '/assigned/:activity';
+const assignedPath = dynamicPrefix + '/assigned/:activityId';
 
 // tslint:disable-next-line:variable-name
 const AssignedContent = Loadable({

--- a/src/app/content/routes.ts
+++ b/src/app/content/routes.ts
@@ -1,13 +1,16 @@
 import pathToRegexp from 'path-to-regexp';
 import Loadable from 'react-loadable';
 import { REACT_APP_ARCHIVE_URL_OVERRIDE } from '../../config';
+import { Route } from '../navigation/types';
 import { findPathForParams, getUrlRegexParams, injectParamsToBaseUrl } from '../navigation/utils';
 import { assertDefined } from '../utils';
 import { ContentRoute, Params } from './types';
 
 const MATCH_UUID = '[\\da-z]{8}-[\\da-z]{4}-[\\da-z]{4}-[\\da-z]{4}-[\\da-z]{12}';
+const dynamicPrefix = '/apps/rex';
+
 const prerenderedBase = '/books/:book/pages/:page';
-const dynamicBase = '/apps/rex' + prerenderedBase;
+const dynamicBase = dynamicPrefix + prerenderedBase;
 
 /*
  * this is in a transition phase. we are moving all of the more dynamic routing
@@ -65,4 +68,26 @@ export const content: ContentRoute = {
   },
   name: 'Content',
   paths: contentPaths,
+};
+
+const assignedPath = dynamicPrefix + '/assigned/:activity';
+
+// tslint:disable-next-line:variable-name
+const AssignedContent = Loadable({
+  loader: () => import(/* webpackChunkName: "Assigned" */ './components/Assigned'),
+  loading: () => null,
+  modules: ['Assigned'],
+});
+
+export const assigned: Route<{activityId: string}> = {
+  component: AssignedContent,
+  getSearch: (_params: {activityId: string}): string => REACT_APP_ARCHIVE_URL_OVERRIDE
+    ? `archive=${REACT_APP_ARCHIVE_URL_OVERRIDE}`
+    : ''
+  ,
+  getUrl: (params: {activityId: string}): string => {
+    return pathToRegexp.compile(assignedPath)(params);
+  },
+  name: 'Assigned',
+  paths: [assignedPath],
 };

--- a/src/app/content/types.ts
+++ b/src/app/content/types.ts
@@ -35,7 +35,7 @@ type VersionedUuidParams = UuidParams & VersionParams;
 
 // Really could be ContentParams, but the content route is currently the only route in Rex
 export type Params = {
-  book: SlugParams | VersionedSlugParams | VersionedUuidParams;
+  book: SlugParams | VersionedSlugParams | VersionedUuidParams | UuidParams;
   page: SlugParams | UuidParams;
 };
 

--- a/src/app/content/utils/archiveTreeUtils.ts
+++ b/src/app/content/utils/archiveTreeUtils.ts
@@ -125,17 +125,23 @@ interface Sections {
   next?: LinkedArchiveTreeSection | undefined;
 }
 
+export const getPrevNext = (
+  sections: LinkedArchiveTreeSection[],
+  pageId: string
+): Sections => {
+  const index = sections.findIndex(nodeMatcher(pageId));
+
+  return {
+    next: sections[index + 1],
+    prev: sections[index - 1],
+  };
+};
+
 export const prevNextBookPage = (
   book: {tree: ArchiveTree},
   pageId: string
 ): Sections => {
-  const flattenTree = findTreePages(book.tree);
-  const index = flattenTree.findIndex(nodeMatcher(pageId));
-
-  return {
-    next: flattenTree[index + 1],
-    prev: flattenTree[index - 1],
-  };
+  return getPrevNext(findTreePages(book.tree), pageId);
 };
 
 const getTitleNodeFromArchiveNode = (book: ArchiveBook, node: ArchiveTree | ArchiveTreeSection): Element => {

--- a/src/app/context/Services.tsx
+++ b/src/app/context/Services.tsx
@@ -6,11 +6,14 @@ export const servicesContext = React.createContext({} as AppServices & Middlewar
 
 const {Consumer, Provider} = servicesContext;
 
-export const useServices = (): AppServices & MiddlewareAPI => ({
-  ...React.useContext(servicesContext),
-  dispatch: useStore().dispatch,
-  getState: useStore().getState,
-});
+export const useServices = (): AppServices & MiddlewareAPI => {
+  const appServices = React.useContext(servicesContext);
+  const {dispatch, getState} = useStore();
+
+  return React.useMemo(() => ({
+    ...appServices, dispatch, getState,
+  }), [appServices, dispatch, getState]);
+};
 
 export {
   Consumer,

--- a/src/app/developer/components/__snapshots__/Home.spec.tsx.snap
+++ b/src/app/developer/components/__snapshots__/Home.spec.tsx.snap
@@ -188,7 +188,7 @@ Array [
                   Assigned
                 </h3>
                 path: 
-                /apps/rex/assigned/:activity
+                /apps/rex/assigned/:activityId
                 <br />
               </div>
               <div>

--- a/src/app/developer/components/__snapshots__/Home.spec.tsx.snap
+++ b/src/app/developer/components/__snapshots__/Home.spec.tsx.snap
@@ -185,6 +185,16 @@ Array [
                 <h3
                   className="headings__H3-sc-1xfiggv-2 dxSanG"
                 >
+                  Assigned
+                </h3>
+                path: 
+                /apps/rex/assigned/:activity
+                <br />
+              </div>
+              <div>
+                <h3
+                  className="headings__H3-sc-1xfiggv-2 dxSanG"
+                >
                   NotFound
                 </h3>
                 path: 

--- a/src/app/fpUtils.ts
+++ b/src/app/fpUtils.ts
@@ -3,6 +3,9 @@ import { FirstArgumentType } from './types';
 export const and = <A extends any[]>(...predicates: Array<(...args: A) => boolean>) => (...args: A) =>
   predicates.reduce((result, predicate) => result && predicate(...args), true);
 
+export const or = <A extends any[]>(...predicates: Array<(...args: A) => boolean>) => (...args: A) =>
+  predicates.reduce((result, predicate) => result || predicate(...args), false);
+
 export const ifUndefined = <I, D>(item: I | undefined, defaultValue: D): I | D  =>
   item === undefined ? defaultValue : item;
 


### PR DESCRIPTION
for: openstax/unified#2059

test link:
https://rex-web-assignable-read-uckuxf.herokuapp.com/apps/rex/assigned/123456?book=13ac107a-f15f-49d2-97e8-60ab2e3b519c&section=d0a86917-6447-4b49-bed1-efb5c352cc77&section=065c3182-adac-48fc-a3ab-03d487982dd5&redirect=https%3A%2F%2Fdev.assessments.sandbox.openstax.org%2Flaunch-assessment%2F4b7cdede18641db4cfc7ec0e0cee5c14c6c9307b3db95d6cb1e46842cc2fadc0%3Fregistration%3D01386699-3eb8-4f70-9850-4692f14f2eca

this doesn't implement the toolbar

this:
- adds route at `/apps/rex/assignable/:activityId` for the assigned reading
- requires a `book` query param with a book id
- requires at least one section id via `section` query param (duplicate the param to assign more than one)
- when more than one section is assigned, adds next/prev links
- highlights on page are loaded, new highlights can be created
- if a `redirect` query param is specified, show a "finish reading" button at the end

follow up necessary after merging this pr:
- add toolbar with text resizer and section title
- design review on "finish reading" button
- xapi integration