### PR TITLE
filter outlook errors

### DIFF
--- a/src/helpers/Sentry.ts
+++ b/src/helpers/Sentry.ts
@@ -31,6 +31,10 @@ export default {
       dist: normalize(config.RELEASE_ID),
       dsn: 'https://d2a5f17c9d8f40369446ea0cfaf21e73@o484761.ingest.sentry.io/5538506',
       environment: config.DEPLOYED_ENV,
+      ignoreErrors: [
+        // https://github.com/getsentry/sentry-javascript/issues/3440#issuecomment-1233146122
+        /^Non-Error promise rejection captured with value: Object Not Found Matching Id:\d+$/,
+      ],
       integrations: [
         new Integrations.ExtraErrorData(),
         new Integrations.Dedupe(),


### PR DESCRIPTION
for: openstax/unified#2075

i waited a long time for a better solution to this problem and i guess its just not coming. the best we can do is this very specific ignore rule, so that we don't also ignore correctly broken things like these:
<img width="1011" alt="image" src="https://user-images.githubusercontent.com/636227/193633074-4e1ec66b-a3a6-46f3-a03a-5424eb243227.png">
