### PR TITLE
ignore resize observer loop

### DIFF
--- a/src/helpers/Sentry.ts
+++ b/src/helpers/Sentry.ts
@@ -34,6 +34,8 @@ export default {
       ignoreErrors: [
         // https://github.com/getsentry/sentry-javascript/issues/3440#issuecomment-1233146122
         /^Non-Error promise rejection captured with value: Object Not Found Matching Id:\d+$/,
+        // https://stackoverflow.com/a/50387233/14809536
+        /^ResizeObserver loop limit exceeded$/,
       ],
       integrations: [
         new Integrations.ExtraErrorData(),


### PR DESCRIPTION
for: openstax/unified#2076

this probably indicates a performance problem (... with the highlights sidebar probably?) but the public perception seems to be that its a useless error