### PR TITLE
FE selenium test: Update tests based on changes to citation section on rex 404 page

### DIFF
--- a/pytest-selenium/tests/test_attribution.py
+++ b/pytest-selenium/tests/test_attribution.py
@@ -152,7 +152,7 @@ def test_license_details(selenium, base_url, page_slug):
     for book_slug in list(book_slugs):
 
         # GIVEN: Book page is loaded
-        book = Content(selenium, base_url, book_slug=book_slug, page_slug=page_slug).open()
+        book = Content(selenium, base_url, book_slug=book_slug, page_slug=get_default_page(book_slug)).open()
         attribution = book.attribution
 
         # Skip any notification/nudge popups

--- a/pytest-selenium/tests/test_book.py
+++ b/pytest-selenium/tests/test_book.py
@@ -252,15 +252,17 @@ def test_attribution_behavior_in_rex_404_page(selenium, base_url, book_slug, pag
     # WHEN: Rex 404 page is displayed
     assert book.content.page_error_displayed
 
-    # THEN: Attribution can be expanded
-    attribution.click_attribution_link()
+    # THEN: Attribution section is not present
+    try:
+        assert not attribution.root.is_displayed()
+    except NoSuchElementException:
+        pass
+    
+    # AND: The "previous" link should be hidden
+    assert not book.previous_link_is_displayed
 
-    # AND: Clicking book url link in attribution works
-    attribution.click_book_url()
-    assert toc.sections[1].is_active
-
-    # AND: Rex 404 page is not displayed
-    assert not book.content.page_error_displayed
+    # AND: The "next" link should be hidden
+    assert not book.next_link_is_displayed
 
 
 @markers.test_case("C619385")


### PR DESCRIPTION
Test updates based on the recent change: citation section is removed on a rex 404 page

for: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/2106