### PR TITLE
Attempt to make Heroku use node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "rex-web",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "14.x"
+  },
   "dependencies": {
     "@craco/craco": "^6.1.2",
     "@formatjs/intl-pluralrules": "^4.0.6",


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2126

I considered Node 16 but we should probably do that when we are ready to switch `.nvmrc` as well.

Which maybe we could just do right now, I think Node 16 just works for Rex.