### PR TITLE
Add canonical maps for the old econ editions and the new macro/micro

### DIFF
--- a/src/app/developer/utils/generateBookPageSpreadsheet.ts
+++ b/src/app/developer/utils/generateBookPageSpreadsheet.ts
@@ -8,8 +8,8 @@ import {
 import { getCanonicalUrlParams } from '../../content/utils/canonicalUrl';
 import { getParentPrefix } from '../../content/utils/seoUtils';
 import { getBookPageUrlAndParams } from '../../content/utils/urlUtils';
+import createIntl from '../../messages/createIntl';
 import { AppServices } from '../../types';
-import { assertNotNull } from '../../utils/assertions';
 
 const domParser = new DOMParser();
 
@@ -22,8 +22,8 @@ const getPageRow = (book: Book, services: AppServices) => {
   const {archiveLoader, osWebLoader} = services;
 
   return async(section: LinkedArchiveTreeSection | LinkedArchiveTree) => {
-    // TODO - this is actually wrong, since different books will want different intl
-    const parentPrefix = getParentPrefix(section.parent, assertNotNull(services.intl.current, 'must have intl')).trim();
+    const intl = await createIntl(book.language);
+    const parentPrefix = getParentPrefix(section.parent, intl).trim();
 
     const { url } = getBookPageUrlAndParams(book, section);
 

--- a/src/canonicalBookMap.ts
+++ b/src/canonicalBookMap.ts
@@ -44,9 +44,6 @@ export const CANONICAL_MAP: CanonicalBookMap = {
   /* Astronomy */ '2e737be8-ea65-48c3-aa0a-9f35b4c6a966': [
     /* Astronomy 2e */ ['4c29f9e5-a53d-42c0-bdb5-091990527d79', {}],
   ],
-  /* Principles of Macroeconomics 2e */ '27f59064-990e-48f1-b604-5188b9086c29': [
-    /* Principles of Economics 2e */['bc498e1f-efe9-43a0-8dea-d3569ad09a82', {}],
-  ],
   /* Organizational Behavior */ '2d941ab9-ac5b-4eb8-b21c-965d36a4f296': [
     /* Principles of Management */['c3acb2ab-7d5c-45ad-b3cd-e59673fedd4e', {}],
   ],
@@ -275,15 +272,6 @@ export const CANONICAL_MAP: CanonicalBookMap = {
       /* References to the same module in 2e */
       'ffc33c5c-9381-50a0-842a-8d3e1238b8c7': '90d79060-d63e-55b7-b333-acc6b90561ca',
     }],
-  ],
-  /* Principles of Microeconomics 2e */ '5c09762c-b540-47d3-9541-dda1f44f16e5': [
-    /* Principles of Economics 2e */['bc498e1f-efe9-43a0-8dea-d3569ad09a82', {}],
-  ],
-  /* Principles of Microeconomics for AP Courses 2e */ '636cbfd9-4e37-4575-83ab-9dec9029ca4e': [
-    /* Principles of Economics 2e */['bc498e1f-efe9-43a0-8dea-d3569ad09a82', {}],
-  ],
-  /* Principles of Macroeconomics for AP Courses 2e */ '9117cf8c-a8a3-4875-8361-9cb0f1fc9362': [
-    /* Principles of Economics 2e */['bc498e1f-efe9-43a0-8dea-d3569ad09a82', {}],
   ],
   /* Introductory Business Statistics */ 'b56bb9e9-5eb8-48ef-9939-88b1b12ce22f': [
     /* Introductory Statistics */ ['30189442-6998-4686-ac05-ed152b91b9de', {}],

--- a/src/canonicalBookMap/economics.ts
+++ b/src/canonicalBookMap/economics.ts
@@ -4,7 +4,10 @@
 import { CanonicalBookMap } from '../canonicalBookMap';
 
 export default {
-   /* Principles of Economics 1e */ '69619d2b-68f0-44b0-b074-a9b2bf90b2c6': [
+  /* Principles of Economics 2e */ 'bc498e1f-efe9-43a0-8dea-d3569ad09a82': [
+    /* Principles of Economics 3e */ ['4c34671f-b057-4918-8796-38ca1b2f4151', {}],
+  ],
+  /* Principles of Economics 1e */ '69619d2b-68f0-44b0-b074-a9b2bf90b2c6': [
     /* Principles of Economics 2e */ ['bc498e1f-efe9-43a0-8dea-d3569ad09a82', {
       /* Preface to the same module in 2e */
       '7a6f73c5-5378-408b-986f-e54416e12ad0': '44954322-6754-4a69-aa9c-948e3ea86102',

--- a/src/canonicalBookMap/macroeconomics.ts
+++ b/src/canonicalBookMap/macroeconomics.ts
@@ -4,6 +4,12 @@
 import { CanonicalBookMap } from '../canonicalBookMap';
 
 export default {
+  /* Principles of Macroeconomics 3e */ 'aff0c733-b223-4dfb-aad6-297bd361bdcf': [
+    /* Principles of Economics 3e */ ['4c34671f-b057-4918-8796-38ca1b2f4151', {}],
+  ],
+  /* Principles of Macroeconomics 2e */ '27f59064-990e-48f1-b604-5188b9086c29': [
+    /* Principles of Macroeconomics 3e */ ['aff0c733-b223-4dfb-aad6-297bd361bdcf', {}],
+  ],
   /* Principles of Macroeconomics 1e */ '4061c832-098e-4b3c-a1d9-7eb593a2cb31': [
     /* Principles of Macroeconomics 2e */ ['27f59064-990e-48f1-b604-5188b9086c29', {
       /* Preface to the same module in 2e */

--- a/src/canonicalBookMap/macroeconomics.ts
+++ b/src/canonicalBookMap/macroeconomics.ts
@@ -8,7 +8,7 @@ export default {
     /* Principles of Economics 3e */ ['4c34671f-b057-4918-8796-38ca1b2f4151', {}],
   ],
   /* Principles of Macroeconomics 2e */ '27f59064-990e-48f1-b604-5188b9086c29': [
-    /* Principles of Macroeconomics 3e */ ['aff0c733-b223-4dfb-aad6-297bd361bdcf', {}],
+    /* Principles of Economics 2e */ ['bc498e1f-efe9-43a0-8dea-d3569ad09a82', {}],
   ],
   /* Principles of Macroeconomics 1e */ '4061c832-098e-4b3c-a1d9-7eb593a2cb31': [
     /* Principles of Macroeconomics 2e */ ['27f59064-990e-48f1-b604-5188b9086c29', {

--- a/src/canonicalBookMap/macroeconomicsAP.ts
+++ b/src/canonicalBookMap/macroeconomicsAP.ts
@@ -4,6 +4,9 @@
 import { CanonicalBookMap } from '../canonicalBookMap';
 
 export default {
+  /* Principles of Macroeconomics for AP Courses 2e */ '9117cf8c-a8a3-4875-8361-9cb0f1fc9362': [
+    /* Principles of Economics 2e */['bc498e1f-efe9-43a0-8dea-d3569ad09a82', {}],
+  ],
   /* Principles of Macroeconomics for AP Courses 1e */ '33076054-ec1d-4417-8824-ce354efe42d0': [
     /* Principles of Macroeconomics for AP Courses 2e */ ['9117cf8c-a8a3-4875-8361-9cb0f1fc9362', {
       /* Preface to the same module in 2e */

--- a/src/canonicalBookMap/microeconomics.ts
+++ b/src/canonicalBookMap/microeconomics.ts
@@ -8,7 +8,7 @@ export default {
     /* Principles of Economics 3e */ ['4c34671f-b057-4918-8796-38ca1b2f4151', {}],
   ],
   /* Principles of Microeconomics 2e */ '5c09762c-b540-47d3-9541-dda1f44f16e5': [
-    /* Principles of Microeconomics 3e */ ['759181db-a886-4a98-8f5c-770a83a78832', {}],
+    /* Principles of Economics 2e */ ['bc498e1f-efe9-43a0-8dea-d3569ad09a82', {}],
   ],
   /* Principles of Microeconomics */ 'ea2f225e-6063-41ca-bcd8-36482e15ef65': [
     /* Principles of Microeconomics 2e */ ['5c09762c-b540-47d3-9541-dda1f44f16e5', {

--- a/src/canonicalBookMap/microeconomics.ts
+++ b/src/canonicalBookMap/microeconomics.ts
@@ -4,6 +4,12 @@
 import { CanonicalBookMap } from '../canonicalBookMap';
 
 export default {
+  /* Principles of Microeconomics 3e */ '759181db-a886-4a98-8f5c-770a83a78832': [
+    /* Principles of Economics 3e */ ['4c34671f-b057-4918-8796-38ca1b2f4151', {}],
+  ],
+  /* Principles of Microeconomics 2e */ '5c09762c-b540-47d3-9541-dda1f44f16e5': [
+    /* Principles of Microeconomics 3e */ ['759181db-a886-4a98-8f5c-770a83a78832', {}],
+  ],
   /* Principles of Microeconomics */ 'ea2f225e-6063-41ca-bcd8-36482e15ef65': [
     /* Principles of Microeconomics 2e */ ['5c09762c-b540-47d3-9541-dda1f44f16e5', {
       /* Preface to the same module in 2e */

--- a/src/canonicalBookMap/microeconomicsAP.ts
+++ b/src/canonicalBookMap/microeconomicsAP.ts
@@ -4,6 +4,9 @@
 import { CanonicalBookMap } from '../canonicalBookMap';
 
 export default {
+  /* Principles of Microeconomics for AP Courses 2e */ '636cbfd9-4e37-4575-83ab-9dec9029ca4e': [
+    /* Principles of Economics 2e */['bc498e1f-efe9-43a0-8dea-d3569ad09a82', {}],
+  ],
   /* Principles of Microeconomics for AP Courses */ 'ca344e2d-6731-43cd-b851-a7b3aa0b37aa': [
     /* Principles of Microeconomics for AP Courses 2e */ ['636cbfd9-4e37-4575-83ab-9dec9029ca4e', {
       /* Preface to the same module in 2e */


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2100
I added maps for macro/micro 3e to econ 3e but 2e didn't have that so now I'm wondering...