### PR TITLE
fix unload eventAction using pathname

### DIFF
--- a/src/environment.development.json
+++ b/src/environment.development.json
@@ -9,7 +9,6 @@
     "feature_flags": [
       "practiceQuestionsEnabled",
       "studyGuidesEnabled"
-    ],
-
+    ]
   }
 }

--- a/src/environment.development.json
+++ b/src/environment.development.json
@@ -3,7 +3,8 @@
   "messages": [],
   "configs": {
     "google_analytics": [
-      "G-0D68920QV9"
+      "G-0D68920QV9",
+      "UA-73668038-11"
     ],
     "quasar_api": "default",
     "feature_flags": [

--- a/src/environment.development.json
+++ b/src/environment.development.json
@@ -2,10 +2,14 @@
   "release_id": "development",
   "messages": [],
   "configs": {
+    "google_analytics": [
+      "G-0D68920QV9"
+    ],
     "quasar_api": "default",
     "feature_flags": [
       "practiceQuestionsEnabled",
       "studyGuidesEnabled"
-    ]
+    ],
+
   }
 }

--- a/src/helpers/analytics/events/unload.spec.ts
+++ b/src/helpers/analytics/events/unload.spec.ts
@@ -1,6 +1,6 @@
 import { track } from './unload';
 
-const pathname = '/some/path'
+const pathname = '/some/path';
 
 describe('unload', () => {
 

--- a/src/helpers/analytics/events/unload.spec.ts
+++ b/src/helpers/analytics/events/unload.spec.ts
@@ -1,0 +1,23 @@
+import { track } from './unload';
+
+const pathname = '/some/path'
+
+describe('unload', () => {
+
+  describe('google analytics', () => {
+    it('tracks unload', () => {
+      const result = track({ pathname });
+      if (!result) {
+        return expect(result).toBeTruthy();
+      } else if (!result.getGoogleAnalyticsPayload) {
+        return expect(result.getGoogleAnalyticsPayload).toBeTruthy();
+      }
+      expect(result.getGoogleAnalyticsPayload()).toEqual({
+        eventAction: 'unload',
+        eventCategory: 'REX unload',
+        eventLabel: pathname,
+        nonInteraction: true,
+      });
+    });
+  });
+});

--- a/src/helpers/analytics/events/unload.ts
+++ b/src/helpers/analytics/events/unload.ts
@@ -14,8 +14,9 @@ export const track = (
 ): AnalyticsEvent | void => {
   return {
     getGoogleAnalyticsPayload: () => ({
-      eventAction: pathname,
+      eventAction: 'unload',
       eventCategory: eventName,
+      eventLabel: pathname,
       nonInteraction: true,
     }),
   };


### PR DESCRIPTION
for: https://github.com/openstax/unified/issues/2211

Unload events are showing up in GA with the current pathname as the event action. This PR makes the event work like most of the other events by sending an action of 'unload', and sending the pathname as an event label instead.

<img width="897" alt="image" src="https://user-images.githubusercontent.com/34174/216461423-4830e2a9-d4b1-4363-bf97-927d00f95ead.png">

