### PR TITLE
FE selenium test: fix smoke test failures

### DIFF
--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -42,7 +42,7 @@ test-rail-sauce: venv
 		--driver SauceLabs \
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
-		--capability screenResolution 1600x1300 \
+		--capability screenResolution 2560x1600 \
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \
 		pytest-selenium/tests
@@ -54,7 +54,7 @@ sauce: venv
 		--driver SauceLabs \
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
-		--capability screenResolution 1600x1300 \
+		--capability screenResolution 2560x1600 \
 		--highlighting \
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \

--- a/pytest-selenium/Makefile-py
+++ b/pytest-selenium/Makefile-py
@@ -42,7 +42,7 @@ test-rail-sauce: venv
 		--driver SauceLabs \
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
-		--capability screenResolution 1600x1200 \
+		--capability screenResolution 1600x1300 \
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \
 		pytest-selenium/tests
@@ -54,7 +54,7 @@ sauce: venv
 		--driver SauceLabs \
 		--capability avoidProxy True \
 		--capability browserName $(BROWSER) \
-		--capability screenResolution 1600x1200 \
+		--capability screenResolution 1600x1300 \
 		--highlighting \
 		--secure-store-filename=pytest-selenium/store/store.aes \
 		--secure-store-password=$(SECURE_STORE_PASSWORD) \

--- a/pytest-selenium/tests/conftest.py
+++ b/pytest-selenium/tests/conftest.py
@@ -9,7 +9,7 @@ from utils import utility
 # Window resolutions. Pytest takes these inputs backwards.
 DESKTOP = (1600, 1300)
 # this used to be 414x738, but it looks like chrome won't resize lower than 500
-MOBILE = (500, 738)
+MOBILE = (516, 738)
 
 
 @pytest.fixture(

--- a/pytest-selenium/tests/conftest.py
+++ b/pytest-selenium/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from utils import utility
 
 # Window resolutions. Pytest takes these inputs backwards.
-DESKTOP = (1600, 1300)
+DESKTOP = (1600, 2560)
 # this used to be 414x738, but it looks like chrome won't resize lower than 500
 MOBILE = (516, 738)
 

--- a/pytest-selenium/tests/conftest.py
+++ b/pytest-selenium/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from utils import utility
 
 # Window resolutions. Pytest takes these inputs backwards.
-DESKTOP = (1500, 1080)
+DESKTOP = (1600, 1300)
 # this used to be 414x738, but it looks like chrome won't resize lower than 500
 MOBILE = (500, 738)
 

--- a/pytest-selenium/tests/test_attribution.py
+++ b/pytest-selenium/tests/test_attribution.py
@@ -84,10 +84,15 @@ def test_attribution_collapses_on_navigating_to_new_page(selenium, base_url, boo
     attribution.click_attribution_link()
 
     # WHEN: Navigating via TOC link
+    width, height = content.get_window_size()
+    print(width, height)
     if content.is_mobile:
+        print("o")
         topbar.click_mobile_menu_button()
+        print("a")
         toolbar.click_toc_toggle_button()
-
+        print("b")
+    print("c")
     toc.sections[-1].click()
 
     # THEN: The citation/attribution section is not open on the new page
@@ -152,7 +157,9 @@ def test_license_details(selenium, base_url, page_slug):
     for book_slug in list(book_slugs):
 
         # GIVEN: Book page is loaded
-        book = Content(selenium, base_url, book_slug=book_slug, page_slug=get_default_page(book_slug)).open()
+        book = Content(
+            selenium, base_url, book_slug=book_slug, page_slug=get_default_page(book_slug)
+        ).open()
         attribution = book.attribution
 
         # Skip any notification/nudge popups

--- a/pytest-selenium/tests/test_attribution.py
+++ b/pytest-selenium/tests/test_attribution.py
@@ -84,15 +84,10 @@ def test_attribution_collapses_on_navigating_to_new_page(selenium, base_url, boo
     attribution.click_attribution_link()
 
     # WHEN: Navigating via TOC link
-    width, height = content.get_window_size()
-    print(width, height)
     if content.is_mobile:
-        print("o")
         topbar.click_mobile_menu_button()
-        print("a")
         toolbar.click_toc_toggle_button()
-        print("b")
-    print("c")
+
     toc.sections[-1].click()
 
     # THEN: The citation/attribution section is not open on the new page

--- a/pytest-selenium/tests/test_search.py
+++ b/pytest-selenium/tests/test_search.py
@@ -122,7 +122,6 @@ def test_scroll_position_when_search_yields_no_results(
 
 
 @markers.test_case("C543231")
-@markers.smoke_test
 @markers.parametrize("page_slug", ["preface"])
 @markers.nondestructive
 def test_TOC_closed_if_search_sidebar_is_displayed(selenium, base_url, book_slug, page_slug):


### PR DESCRIPTION
for: https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/2291

1. Search is running an [a/b testing](https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/gh/openstax/unified/2047). Removing search related tests from smoke tests till the a//b testing is complete
2. The earlier desktop resolution  (1200 width) was opening book page in mid desktop (ipad) resolution with TOC closed. This was causing some failures in CI checks, so updated the desktop resolution to be wider
3. The mobile resolution that opens in saucelabs was greater than the absolute value set in 'is_mobile' function in '/pages/base.py' causing CI check failures in mobile resolution. So updated the mobile resolution 