### PR TITLE
Replace set-output in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         GIT_REF: ${{ github.event.pull_request.head.sha }}
         GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        echo "::set-output name=url::$(./script/get-review-environment.bash)"
+        echo "{url}={$(./script/get-review-environment.bash)}" >> $GITHUB_OUTPUT
 
   selenium:
     name: Selenium


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2153
per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/