### PR TITLE
Proxy dev Highlights requests to https://dev.openstax.org

### DIFF
--- a/src/config.development.js
+++ b/src/config.development.js
@@ -32,7 +32,7 @@ module.exports = {
   ACCOUNTS_URL: process.env.ACCOUNTS_URL || 'https://dev.openstax.org',
   IMAGE_CDN_URL: process.env.IMAGE_CDN_URL || 'https://dev.openstax.org',
   OS_WEB_URL: process.env.OS_WEB_URL || 'https://dev.openstax.org',
-  HIGHLIGHTS_URL: process.env.HIGHLIGHTS_URL || 'https://highlights-hl-40b2567.sandbox.openstax.org',
+  HIGHLIGHTS_URL: process.env.HIGHLIGHTS_URL || 'https://dev.openstax.org',
   SEARCH_URL: process.env.SEARCH_URL || 'https://openstax.org',
 
   SKIP_OS_WEB_PROXY: process.env.SKIP_OS_WEB_PROXY !== undefined,


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2387

... instead of specifying a sandbox.

The highlights env used by dev.openstax.org is at least protected from deletion by the script that deletes old highlights envs.