### PR TITLE
Increased the prerendering timeout to 1 hour

### DIFF
--- a/script/prerender/fleet.ts
+++ b/script/prerender/fleet.ts
@@ -67,7 +67,7 @@ const MAX_ATTEMPTS = 5;
 
 // The worker fleet is automatically terminated after this many seconds
 // This is insurance in case this process gets stuck or crashes without deleting the workers stack
-const PRERENDER_TIMEOUT_SECONDS = 1800;
+const PRERENDER_TIMEOUT_SECONDS = 3600;
 
 // Abort the build if the workers stack is not created/deleted within this many seconds
 const WORKERS_STACK_CREATE_TIMEOUT_SECONDS = 300;


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2641

I believe the timeout happens when instance startup is slow so I'm not sure using more instances would help.
Alternatively, maybe 45 minutes could also be enough, but I thought 1 hour was safer.