### PR TITLE
Use polyfll for Intl-DisplayNames

### DIFF
--- a/src/app/content/components/utils/attributionValues.spec.ts
+++ b/src/app/content/components/utils/attributionValues.spec.ts
@@ -9,8 +9,8 @@ jest.mock(
     })
 );
 
-describe('locale not found', () => {
-  it('loads english messages', () => {
+describe('setting language', () => {
+  it('uses Intl.DisplayName to set language when DisplayNames is available', () => {
     const {language} = attributionValues(book);
     expect(language).toBe('English');
   });
@@ -21,5 +21,4 @@ describe('locale not found', () => {
 
     expect(language).toBe('en');
   });
-
 });

--- a/src/app/content/components/utils/attributionValues.spec.ts
+++ b/src/app/content/components/utils/attributionValues.spec.ts
@@ -1,0 +1,25 @@
+import { attributionValues } from './attributionValues';
+import { book } from '../../../../test/mocks/archiveLoader';
+import { shouldPolyfill } from '@formatjs/intl-displaynames/should-polyfill';
+
+jest.mock(
+    '@formatjs/intl-displaynames/should-polyfill',
+    () => ({
+        shouldPolyfill: jest.fn(() => false),
+    })
+);
+
+describe('locale not found', () => {
+  it('loads english messages', () => {
+    const {language} = attributionValues(book);
+    expect(language).toBe('English');
+  });
+
+  it('uses locale for language when polyfill required', () => {
+    (shouldPolyfill as jest.Mock).mockReturnValue(true);
+    const {language} = attributionValues(book);
+
+    expect(language).toBe('en');
+  });
+
+});

--- a/src/app/content/components/utils/attributionValues.ts
+++ b/src/app/content/components/utils/attributionValues.ts
@@ -1,4 +1,5 @@
 import { Book } from '../../types';
+import { shouldPolyfill } from '@formatjs/intl-displaynames/should-polyfill';
 
 // date is initialized as UTC, conversion to local time can change the date.
 // this compensates
@@ -54,7 +55,9 @@ export function attributionValues(book: Book) {
   return {
     bookTitle: book.title,
     publisher: locale === 'pl' ? 'OpenStax Poland' : 'OpenStax',
-    language: new Intl.DisplayNames([locale], { type: 'language' }).of(locale) as string,
+    language: shouldPolyfill() ?
+      locale :
+      new Intl.DisplayNames([locale], { type: 'language' }).of(locale) as string,
     bookPublishDate,
     authorsToDisplay,
   };


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2650 Since it's only outdated browsers that need the polyfill, it didn't seem worth it to make the whole attribution chain async. Instead, if the polyfll is needed, it just lists the locale for the Language.