### PR TITLE
add loader script tag for chatbot

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
       }
     </style>
     <script src="https://cmp.osano.com/AzZqbXTbzhHsU3cv1/68d8e8ae-4024-4489-a000-72766ad284a6/osano.js"></script>
+    <script src="https://chat.research.openstax.org/assets/static/loader.js" async></script>
 
     <!-- Google Tag Manager -->
     <script>


### PR DESCRIPTION
for: https://github.com/openstax/research/issues/546

This is the script that gets loaded by the tag: https://github.com/openstax/research-chatbot/blob/main/embed/loader.ts

It looks to me like our cloudfront config isn't compressing script, but I'll get that fixed before this is deployed and the src won't change.

The actual embed script has [some logic](https://github.com/openstax/research-chatbot/blob/main/embed/chatbot-embed.ts#L151-L161) to prevent duplicate loads so it *should be* fine to run this and the tag-manager loading at the same time, but we should still plan on deleting the tag once this is deployed.