### PR TITLE
Make search highlight not tab-navigable

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@craco/craco": "<7",
     "@formatjs/intl-pluralrules": "^5.2.3",
     "@openstax/event-capture-client": "^2.0.2",
-    "@openstax/highlighter": "https://github.com/openstax/highlighter#add-tabbable-option",
+    "@openstax/highlighter": "https://github.com/openstax/highlighter#add-tabbable-test",
     "@openstax/open-search-client": "0.1.0-build.7",
     "@openstax/ts-utils": "1.6.0",
     "@openstax/ui-components": "https://github.com/openstax/ui-components#1.3.4-post2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@craco/craco": "<7",
     "@formatjs/intl-pluralrules": "^5.2.3",
     "@openstax/event-capture-client": "^2.0.2",
-    "@openstax/highlighter": "1.13.0",
+    "@openstax/highlighter": "https://github.com/openstax/highlighter#add-tabbable-option",
     "@openstax/open-search-client": "0.1.0-build.7",
     "@openstax/ts-utils": "1.6.0",
     "@openstax/ui-components": "https://github.com/openstax/ui-components#1.3.4-post2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@craco/craco": "<7",
     "@formatjs/intl-pluralrules": "^5.2.3",
     "@openstax/event-capture-client": "^2.0.2",
-    "@openstax/highlighter": "https://github.com/openstax/highlighter#add-tabbable-test",
+    "@openstax/highlighter": "https://github.com/openstax/highlighter#v1.14.1",
     "@openstax/open-search-client": "0.1.0-build.7",
     "@openstax/ts-utils": "1.6.0",
     "@openstax/ui-components": "https://github.com/openstax/ui-components#1.3.4-post2",

--- a/src/app/content/components/Page/searchHighlightManager.ts
+++ b/src/app/content/components/Page/searchHighlightManager.ts
@@ -101,6 +101,7 @@ const searchHighlightManager = (container: HTMLElement, intl: IntlShape) => {
     highlighter: new Highlighter(container, {
       className: 'search-highlight',
       formatMessage: ({ id }) => intl.formatMessage({ id: `${id}:search` }),
+      tabbable: false,
     }),
     searchResultMap: [],
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,9 +5083,9 @@
   dependencies:
     uuid "^8.3.2"
 
-"@openstax/highlighter@https://github.com/openstax/highlighter#add-tabbable-test":
-  version "1.13.0"
-  resolved "https://github.com/openstax/highlighter#1e2b6c0ea150e64c83a24ff8e9a913ce50ea3d3b"
+"@openstax/highlighter@https://github.com/openstax/highlighter#v1.14.1":
+  version "1.14.0"
+  resolved "https://github.com/openstax/highlighter#60b8be9edb6ef1a1f189000c1c1a51f23e8c9c66"
   dependencies:
     "@openstax/highlights-client" "0.2.3"
     change-case "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,9 +5083,9 @@
   dependencies:
     uuid "^8.3.2"
 
-"@openstax/highlighter@https://github.com/openstax/highlighter#add-tabbable-option":
+"@openstax/highlighter@https://github.com/openstax/highlighter#add-tabbable-test":
   version "1.13.0"
-  resolved "https://github.com/openstax/highlighter#fdc33f534262d93a498e8b1b5d6120bc668e5fe2"
+  resolved "https://github.com/openstax/highlighter#1e2b6c0ea150e64c83a24ff8e9a913ce50ea3d3b"
   dependencies:
     "@openstax/highlights-client" "0.2.3"
     change-case "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,10 +5083,9 @@
   dependencies:
     uuid "^8.3.2"
 
-"@openstax/highlighter@1.13.0":
+"@openstax/highlighter@https://github.com/openstax/highlighter#add-tabbable-option":
   version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@openstax/highlighter/-/highlighter-1.13.0.tgz#77536bea9b36ff3ec79f3fcd0355e94bc8e33580"
-  integrity sha512-1OLuqAKgN+oGZMIWB9dFQFHRHPh5YuoWBvyGW/cLXAm0Pl77U6WsJtjww3//Ej0bnsyL4AhxT5TAY4FmJzopFg==
+  resolved "https://github.com/openstax/highlighter#fdc33f534262d93a498e8b1b5d6120bc668e5fe2"
   dependencies:
     "@openstax/highlights-client" "0.2.3"
     change-case "^4.0.0"


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2750
For: https://openstax.atlassian.net/browse/DISCO-115
This is a one-line change, plus an update to what version of @openstax/highlighter is used. The Highlighter version is a tag that includes two approved PRs.