### PR TITLE
Increase yarn network timeout to 1 minute

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ FROM utils AS release
 # Docker trickery so we can reuse the yarn install layer until package.json or yarn.lock change
 COPY package.json yarn.lock /code/
 WORKDIR /code
-RUN yarn install
+RUN yarn install --network-timeout 60000
 
 COPY . /code
 


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2799

I think changing the Concourse disk from gp2 to gp3 helped with overall speed, but it either didn't help with yarn or wasn't enough to make it install that icons package in less than 30 seconds. This PR increases the timeout to 60 seconds instead. It seems like the network timeout shouldn't matter for when installing a package that has already been downloaded, but it's actually an issue described here: https://github.com/yarnpkg/yarn/issues/8242

The issue that makes the icons package slow is that it has 45k files in it.