### PR TITLE
Use Highlighter version that does not use text in screenreader markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@craco/craco": "<7",
     "@formatjs/intl-pluralrules": "^5.2.3",
     "@openstax/event-capture-client": "^2.0.2",
-    "@openstax/highlighter": "https://github.com/openstax/highlighter#v1.14.1",
+    "@openstax/highlighter": "https://github.com/openstax/highlighter#v1.14.2",
     "@openstax/open-search-client": "0.1.0-build.7",
     "@openstax/ts-utils": "1.6.0",
     "@openstax/ui-components": "https://github.com/openstax/ui-components#1.3.4-post2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,9 +5083,9 @@
   dependencies:
     uuid "^8.3.2"
 
-"@openstax/highlighter@https://github.com/openstax/highlighter#v1.14.1":
-  version "1.14.0"
-  resolved "https://github.com/openstax/highlighter#60b8be9edb6ef1a1f189000c1c1a51f23e8c9c66"
+"@openstax/highlighter@https://github.com/openstax/highlighter#v1.14.2":
+  version "1.14.1"
+  resolved "https://github.com/openstax/highlighter#fcd259e1642e243de6ed95771d0b97249ff2d162"
   dependencies:
     "@openstax/highlights-client" "0.2.3"
     change-case "^4.0.0"


### PR DESCRIPTION
for: [DISCO-160](https://openstax.atlassian.net/browse/DISCO-160)
for: https://github.com/openstax/rex-web/pull/2198

This just changes the version of Highlighter used.

[DISCO-160]: https://openstax.atlassian.net/browse/DISCO-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ