### PR TITLE
Style section highlights headers as h2/h3

### DIFF
--- a/src/app/content/components/SectionHighlights.tsx
+++ b/src/app/content/components/SectionHighlights.tsx
@@ -30,7 +30,7 @@ export const HighlightsChapterWrapper = styled.div`
 `;
 
 // tslint:disable-next-line:variable-name
-const HighlightsChapter = styled.div`
+const HighlightsChapter = styled.h2`
   ${h4Style}
   font-weight: bold;
   display: flex;
@@ -66,7 +66,7 @@ export const HighlightWrapper = styled.div`
 `;
 
 // tslint:disable-next-line:variable-name
-export const HighlightSection = styled.div`
+export const HighlightSection = styled.h3`
   ${labelStyle}
   padding: 0 ${popupBodyPadding}rem 0 ${popupPadding}rem;
   background: ${theme.color.neutral.darkest};

--- a/src/app/content/highlights/components/HighlightsPopUp.tsx
+++ b/src/app/content/highlights/components/HighlightsPopUp.tsx
@@ -128,9 +128,11 @@ const HighlightsPopUp = ({ closeMyHighlights, ...props }: Props) => {
       }}
     >
       <Header colorSchema={props.bookTheme}>
-        <FormattedMessage id='i18n:toolbar:highlights:popup:heading'>
-          {(msg) => msg}
-        </FormattedMessage>
+        <h1>
+          <FormattedMessage id='i18n:toolbar:highlights:popup:heading'>
+            {(msg) => msg}
+          </FormattedMessage>
+        </h1>
         <CloseIconWrapper
           data-testid='close-highlights-popup'
           aria-label={intl.formatMessage({id: 'i18n:toolbar:highlights:popup:close-button:aria-label'})}

--- a/src/app/content/keyboardShortcuts/components/KeyboardShortcutsPopup.tsx
+++ b/src/app/content/keyboardShortcuts/components/KeyboardShortcutsPopup.tsx
@@ -60,9 +60,11 @@ const KeyboardShortcutsPopup = () => {
       }}
     >
       <Header colorSchema={bookTheme}>
-        <FormattedMessage id='i18n:a11y:keyboard-shortcuts:heading'>
-          {(msg) => msg}
-        </FormattedMessage>
+        <h1>
+          <FormattedMessage id='i18n:a11y:keyboard-shortcuts:heading'>
+            {(msg) => msg}
+          </FormattedMessage>
+        </h1>
         <CloseIconWrapper
           data-testid='close-keyboard-shortcuts-popup'
           aria-label={intl.formatMessage({id: 'i18n:a11y:keyboard-shortcuts:close'})}

--- a/src/app/content/keyboardShortcuts/components/__snapshots__/KeyboardShortcutsPopup.spec.tsx.snap
+++ b/src/app/content/keyboardShortcuts/components/__snapshots__/KeyboardShortcutsPopup.spec.tsx.snap
@@ -57,6 +57,14 @@ exports[`KeyboardShortcuts renders keyboard shortcuts modal if it is open 1`] = 
   z-index: 5;
 }
 
+.c4 h1 {
+  font-size: inherit;
+  -webkit-letter-spacing: inherit;
+  -moz-letter-spacing: inherit;
+  -ms-letter-spacing: inherit;
+  letter-spacing: inherit;
+}
+
 .c2 {
   top: 0;
   z-index: 110;
@@ -286,10 +294,12 @@ exports[`KeyboardShortcuts renders keyboard shortcuts modal if it is open 1`] = 
     data-testid="keyboard-shortcuts-popup-wrapper"
     tabIndex="-1"
   >
-    <h1
+    <div
       className="c4"
     >
-      Keyboard Shortcuts
+      <h1>
+        Keyboard Shortcuts
+      </h1>
       <button
         aria-label="Click to close Keyboard Shortcuts menu"
         className="c5"
@@ -327,7 +337,7 @@ exports[`KeyboardShortcuts renders keyboard shortcuts modal if it is open 1`] = 
           </g>
         </svg>
       </button>
-    </h1>
+    </div>
     <div
       className="c7"
       data-analytics-region="KS popup"

--- a/src/app/content/keyboardShortcuts/components/__snapshots__/KeyboardShortcutsPopup.spec.tsx.snap
+++ b/src/app/content/keyboardShortcuts/components/__snapshots__/KeyboardShortcutsPopup.spec.tsx.snap
@@ -286,7 +286,7 @@ exports[`KeyboardShortcuts renders keyboard shortcuts modal if it is open 1`] = 
     data-testid="keyboard-shortcuts-popup-wrapper"
     tabIndex="-1"
   >
-    <h3
+    <h1
       className="c4"
     >
       Keyboard Shortcuts
@@ -327,7 +327,7 @@ exports[`KeyboardShortcuts renders keyboard shortcuts modal if it is open 1`] = 
           </g>
         </svg>
       </button>
-    </h3>
+    </h1>
     <div
       className="c7"
       data-analytics-region="KS popup"

--- a/src/app/content/practiceQuestions/components/PracticeQuestionsPopup.tsx
+++ b/src/app/content/practiceQuestions/components/PracticeQuestionsPopup.tsx
@@ -59,9 +59,11 @@ const PracticeQuestionsPopup = () => {
       }}
     >
       <Header colorSchema={bookTheme}>
-        <FormattedMessage id='i18n:practice-questions:popup:heading'>
-          {(msg) => msg}
-        </FormattedMessage>
+        <h1>
+          <FormattedMessage id='i18n:practice-questions:popup:heading'>
+            {(msg) => msg}
+          </FormattedMessage>
+        </h1>
         <CloseIconWrapper
           data-testid='close-practice-questions-popup'
           aria-label={intl.formatMessage({id: 'i18n:practice-questions:popup:close'})}

--- a/src/app/content/practiceQuestions/components/__snapshots__/PracticeQuestionsPopup.spec.tsx.snap
+++ b/src/app/content/practiceQuestions/components/__snapshots__/PracticeQuestionsPopup.spec.tsx.snap
@@ -412,7 +412,7 @@ exports[`PracticeQuestions renders practice questions modal if it is open 1`] = 
     data-testid="practice-questions-popup-wrapper"
     tabIndex="-1"
   >
-    <h3
+    <h1
       className="c3"
     >
       Practice Questions
@@ -453,7 +453,7 @@ exports[`PracticeQuestions renders practice questions modal if it is open 1`] = 
           </g>
         </svg>
       </button>
-    </h3>
+    </h1>
     <div
       className="c6"
       data-analytics-location="section not loaded"

--- a/src/app/content/practiceQuestions/components/__snapshots__/PracticeQuestionsPopup.spec.tsx.snap
+++ b/src/app/content/practiceQuestions/components/__snapshots__/PracticeQuestionsPopup.spec.tsx.snap
@@ -71,6 +71,14 @@ exports[`PracticeQuestions renders practice questions modal if it is open 1`] = 
   z-index: 5;
 }
 
+.c3 h1 {
+  font-size: inherit;
+  -webkit-letter-spacing: inherit;
+  -moz-letter-spacing: inherit;
+  -ms-letter-spacing: inherit;
+  letter-spacing: inherit;
+}
+
 .c2 {
   top: 0;
   z-index: 110;
@@ -412,10 +420,12 @@ exports[`PracticeQuestions renders practice questions modal if it is open 1`] = 
     data-testid="practice-questions-popup-wrapper"
     tabIndex="-1"
   >
-    <h1
+    <div
       className="c3"
     >
-      Practice Questions
+      <h1>
+        Practice Questions
+      </h1>
       <button
         aria-label="Click to close Practice Questions modal"
         className="c4"
@@ -453,7 +463,7 @@ exports[`PracticeQuestions renders practice questions modal if it is open 1`] = 
           </g>
         </svg>
       </button>
-    </h1>
+    </div>
     <div
       className="c6"
       data-analytics-location="section not loaded"

--- a/src/app/content/studyGuides/components/StudyGuidesPopUp.tsx
+++ b/src/app/content/studyGuides/components/StudyGuidesPopUp.tsx
@@ -51,9 +51,11 @@ const StudyguidesPopUp = () => {
       }}
     >
       <Header colorSchema={bookTheme}>
-        <FormattedMessage id='i18n:toolbar:studyguides:popup:heading'>
-          {(msg) => msg}
-        </FormattedMessage>
+        <h1>
+          <FormattedMessage id='i18n:toolbar:studyguides:popup:heading'>
+            {(msg) => msg}
+          </FormattedMessage>
+        </h1>
         <CloseIconWrapper
           data-testid='close-studyguides-popup'
           aria-label={intl.formatMessage({id: 'i18n:toolbar:studyguides:popup:close-button:aria-label'})}

--- a/src/app/content/studyGuides/components/__snapshots__/StudyGuides.spec.tsx.snap
+++ b/src/app/content/studyGuides/components/__snapshots__/StudyGuides.spec.tsx.snap
@@ -372,7 +372,7 @@ exports[`StudyGuides properly display summary highlights 1`] = `
     <div
       className="c2 c3"
     >
-      <div
+      <h2
         className="c4"
         dangerouslySetInnerHTML={
           Object {
@@ -385,7 +385,7 @@ exports[`StudyGuides properly display summary highlights 1`] = `
     <div
       className="c5 c6"
     >
-      <div
+      <h3
         className="c7 c8"
         dangerouslySetInnerHTML={
           Object {
@@ -516,7 +516,7 @@ exports[`StudyGuides properly display summary highlights 1`] = `
     <div
       className="c2 c3"
     >
-      <div
+      <h2
         className="c4"
         dangerouslySetInnerHTML={
           Object {
@@ -529,7 +529,7 @@ exports[`StudyGuides properly display summary highlights 1`] = `
     <div
       className="c5 c6"
     >
-      <div
+      <h3
         className="c7 c8"
         dangerouslySetInnerHTML={
           Object {

--- a/src/app/content/styles/PopupStyles.tsx
+++ b/src/app/content/styles/PopupStyles.tsx
@@ -42,7 +42,7 @@ export const PopupWrapper = styled.div`
 `;
 
 // tslint:disable-next-line:variable-name
-export const Header = styled.h1`
+export const Header = styled.div`
   ${h3Style}
   ${disablePrint}
   ${applyBookTextColor}
@@ -57,6 +57,11 @@ export const Header = styled.h1`
   ${theme.breakpoints.mobile(css`
     padding: ${mobilePaddingSides}rem;
   `)}
+
+  h1 {
+    font-size: inherit;
+    letter-spacing: inherit;
+  }
 `;
 
 // tslint:disable-next-line:variable-name

--- a/src/app/content/styles/PopupStyles.tsx
+++ b/src/app/content/styles/PopupStyles.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled, { css } from 'styled-components/macro';
 import Times from '../../../../src/app/components/Times';
 import { PlainButton } from '../../components/Button';
-import { H3 } from '../../components/Typography/headings';
+import { h3Style } from '../../components/Typography/headings';
 import theme from '../../theme';
 import { contentWrapperMaxWidth } from '../components/constants';
 import { applyBookTextColor } from '../components/utils/applyBookTextColor';
@@ -42,7 +42,8 @@ export const PopupWrapper = styled.div`
 `;
 
 // tslint:disable-next-line:variable-name
-export const Header = styled(H3)`
+export const Header = styled.h1`
+  ${h3Style}
   ${disablePrint}
   ${applyBookTextColor}
   background: ${({colorSchema}: {colorSchema: BookWithOSWebData['theme']}) => theme.color.primary[colorSchema].base};


### PR DESCRIPTION
[DISCO-43]
I made the Popup Header an h1 so that we have the correct sequence of headers.
It made no sense to me that it was an h3 previously. It is a major, separate section. If we think it should be h3, then the section headers need to become h4 and h5.

[DISCO-43]: https://openstax.atlassian.net/browse/DISCO-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ