### PR TITLE
Ensure lazy loaded images load when visible initially

### DIFF
--- a/src/app/content/components/Page/PageComponent.tsx
+++ b/src/app/content/components/Page/PageComponent.tsx
@@ -81,6 +81,7 @@ export default class PageComponent extends Component<PagePropTypes> {
       });
     }
     this.scrollToTopOrHashManager(null, this.props.scrollToTopOrHash);
+    lazyResources.checkLazyResources();
   }
 
   public async componentDidUpdate(prevProps: PagePropTypes) {

--- a/src/app/content/components/Page/lazyResourceManager.ts
+++ b/src/app/content/components/Page/lazyResourceManager.ts
@@ -23,7 +23,6 @@ export const checkLazyResources = () => {
         element.setAttribute('src', src);
       }
       element.removeAttribute('data-lazy-src');
-
     }
   });
 };


### PR DESCRIPTION
[DISCO-285]

Lazy loaded items don't always notice that they're visible. There was a check already for when the component updated, but that doesn't fire on initial load, so it had to be added to `ComponentDidMount` as well.

[DISCO-285]: https://openstax.atlassian.net/browse/DISCO-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ