### PR TITLE
fix build

### DIFF
--- a/script/prerender/constants.ts
+++ b/script/prerender/constants.ts
@@ -1,0 +1,8 @@
+import config from '../../src/config';
+import { assertDefined } from '../../src/app/utils';
+
+export const RELEASE_ID = assertDefined(config.RELEASE_ID, 'REACT_APP_RELEASE_ID environment variable must be set');
+export const BUCKET_NAME = process.env.BUCKET_NAME || 'sandbox-unified-web-primary';
+export const BUCKET_REGION = process.env.BUCKET_REGION || 'us-east-1';
+export const PUBLIC_URL = process.env.PUBLIC_URL || `/rex/releases/${RELEASE_ID}`;
+export const WORK_REGION = process.env.WORK_REGION || 'us-east-2';

--- a/script/prerender/fileUtils.ts
+++ b/script/prerender/fileUtils.ts
@@ -7,7 +7,7 @@ import once from 'lodash/once';
 import path from 'path';
 import createCache, { Cache } from '../../src/helpers/createCache';
 import { directoryExists, readFile, writeFile } from '../../src/helpers/fileUtils';
-import { BUCKET_REGION, PUBLIC_URL, BUCKET_NAME } from "./constants";
+import { BUCKET_REGION, PUBLIC_URL, BUCKET_NAME } from './constants';
 
 const ASSET_DIR = path.resolve(__dirname, '../../build');
 const CACHE_DIR = path.resolve(__dirname, '../../cache');

--- a/script/prerender/fileUtils.ts
+++ b/script/prerender/fileUtils.ts
@@ -5,9 +5,9 @@ import { fromContainerMetadata } from '@aws-sdk/credential-providers';
 import flow from 'lodash/fp/flow';
 import once from 'lodash/once';
 import path from 'path';
-import { assertDefined } from '../../src/app/utils';
 import createCache, { Cache } from '../../src/helpers/createCache';
 import { directoryExists, readFile, writeFile } from '../../src/helpers/fileUtils';
+import { BUCKET_REGION, PUBLIC_URL, BUCKET_NAME } from "./constants";
 
 const ASSET_DIR = path.resolve(__dirname, '../../build');
 const CACHE_DIR = path.resolve(__dirname, '../../cache');
@@ -51,7 +51,7 @@ export const createDiskCache = <K extends string, V>(prefix: string): Cache<K, V
 
 // Generates a release path for a file without a leading /, used when uploading the release to S3
 function prefixReleasePath(filepath: string) {
-  let basePath = assertDefined(process.env.PUBLIC_URL, 'PUBLIC_URL environment variable not set');
+  let basePath = `${PUBLIC_URL}`; // clone string to not leak the potential slice on next line.
   if (basePath[0] === '/') { basePath = basePath.slice(1); }
   return `${basePath}${filepath}`;
 }
@@ -61,7 +61,7 @@ const getS3Client = once(async() => {
   const credentials = await fromContainerMetadata();
 
   console.log('Initializing S3 client');
-  return new S3Client({ credentials, region: process.env.BUCKET_REGION });
+  return new S3Client({ credentials, region: BUCKET_REGION });
 });
 
 async function writeS3File(key: string, contents: string, contentType: string) {
@@ -70,7 +70,7 @@ async function writeS3File(key: string, contents: string, contentType: string) {
   console.log(`Writing s3 file: /${key}`);
   return s3Client.send(new PutObjectCommand({
     Body: contents,
-    Bucket: process.env.BUCKET_NAME,
+    Bucket: BUCKET_NAME,
     CacheControl: 'max-age=0',
     ContentType: contentType,
     Key: key,

--- a/script/prerender/fileUtils.ts
+++ b/script/prerender/fileUtils.ts
@@ -51,7 +51,7 @@ export const createDiskCache = <K extends string, V>(prefix: string): Cache<K, V
 
 // Generates a release path for a file without a leading /, used when uploading the release to S3
 function prefixReleasePath(filepath: string) {
-  let basePath = `${PUBLIC_URL}`; // clone string to not leak the potential slice on next line.
+  let basePath = PUBLIC_URL;
   if (basePath[0] === '/') { basePath = basePath.slice(1); }
   return `${basePath}${filepath}`;
 }

--- a/script/prerender/fleet.ts
+++ b/script/prerender/fleet.ts
@@ -36,7 +36,6 @@ import path from 'path';
 import asyncPool from 'tiny-async-pool';
 import { makeUnifiedBookLoader } from '../../src/app/content/utils';
 import { assertDefined } from '../../src/app/utils';
-import config from '../../src/config';
 import BOOKS from '../../src/config.books';
 import createArchiveLoader from '../../src/gateways/createArchiveLoader';
 import { getBooksConfigSync } from '../../src/gateways/createBookConfigLoader';
@@ -50,16 +49,8 @@ import renderManifest from './renderManifest';
 import { SitemapPayload, renderAndSaveSitemapIndex } from './sitemap';
 import { writeS3ReleaseXmlFile } from './fileUtils';
 import { renderAndSaveContentManifest } from './contentManifest';
-
-const {
-  ARCHIVE_URL,
-  CODE_VERSION,
-  OS_WEB_URL,
-  REACT_APP_OS_WEB_API_URL,
-  RELEASE_ID,
-} = config;
-
-assertDefined(RELEASE_ID, 'REACT_APP_RELEASE_ID environment variable must be set');
+import { ARCHIVE_URL, OS_WEB_URL, REACT_APP_OS_WEB_API_URL, CODE_VERSION } from '../../src/config';
+import { RELEASE_ID, WORK_REGION, BUCKET_NAME, BUCKET_REGION, PUBLIC_URL } from './constants';
 
 // Increasing this too much can lead to connection issues and greater memory usage in the manager
 const MAX_CONCURRENT_BOOKS = 5;
@@ -74,11 +65,6 @@ const PRERENDER_TIMEOUT_SECONDS = 3600;
 // Abort the build if the workers stack is not created/deleted within this many seconds
 const WORKERS_STACK_CREATE_TIMEOUT_SECONDS = 300;
 const WORKERS_STACK_DELETE_TIMEOUT_SECONDS = WORKERS_STACK_CREATE_TIMEOUT_SECONDS;
-
-const BUCKET_NAME = process.env.BUCKET_NAME || 'sandbox-unified-web-primary';
-const BUCKET_REGION = process.env.BUCKET_REGION || 'us-east-1';
-const PUBLIC_URL = process.env.PUBLIC_URL || `/rex/releases/${RELEASE_ID}`;
-const WORK_REGION = process.env.WORK_REGION || 'us-east-2';
 
 // Docker does not accept forward slashes in the image tag
 const IMAGE_TAG = process.env.IMAGE_TAG || `${RELEASE_ID.replace(/\//g, '-')}`;

--- a/script/prerender/fleet.ts
+++ b/script/prerender/fleet.ts
@@ -355,7 +355,7 @@ async function queueWork(workQueueUrl: string) {
 
   await Promise.all([
     renderAndSaveSitemapIndex(writeS3ReleaseXmlFile, books),
-    renderAndSaveContentManifest(writeS3ReleaseXmlFile, books)
+    renderAndSaveContentManifest(writeS3ReleaseXmlFile, books),
   ]);
 
   return stats;

--- a/script/prerender/fleet.ts
+++ b/script/prerender/fleet.ts
@@ -353,8 +353,10 @@ async function queueWork(workQueueUrl: string) {
     `All ${stats.pages} page prerendering jobs and all ${stats.sitemaps} sitemap jobs queued`
   );
 
-  renderAndSaveSitemapIndex(writeS3ReleaseXmlFile, books);
-  renderAndSaveContentManifest(writeS3ReleaseXmlFile, books);
+  await Promise.all([
+    renderAndSaveSitemapIndex(writeS3ReleaseXmlFile, books),
+    renderAndSaveContentManifest(writeS3ReleaseXmlFile, books)
+  ]);
 
   return stats;
 }


### PR DESCRIPTION
https://openstax.atlassian.net/browse/DISCO-467


the problem seems to be because in https://github.com/openstax/rex-web/pull/2268/files i moved the `renderAndSaveSitemapIndex` call out of a worker and into the scheduling thread, because all the required book data is already loaded. but because the scheduling thread is not running in a worker it didn't have the same environment variables loaded (also missing the default value assigned in `fleet.ts`). i moved some of the config definitions to a new file so they could share their defaults, i think that'll fix it.