### PR TITLE
don't set container metadata outside of container

### DIFF
--- a/script/prerender/fileUtils.ts
+++ b/script/prerender/fileUtils.ts
@@ -58,7 +58,10 @@ function prefixReleasePath(filepath: string) {
 
 const getS3Client = once(async() => {
   console.log('Fetching container credentials');
-  const credentials = await fromContainerMetadata();
+
+  const credentials = process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+    ? await fromContainerMetadata()
+    : undefined;
 
   console.log('Initializing S3 client');
   return new S3Client({ credentials, region: BUCKET_REGION });


### PR DESCRIPTION
https://openstax.atlassian.net/browse/DISCO-467

the error said that this provider can only be used when this environment variable is set, so that seems like a reasonable check. the other clients don't set credentials at all, so hopefully this works. my only concern is that the sdk might do something wrong based on the key existing with an undefined value, but we'll see i guess.