### PR TITLE
Increase prerender worker instance size

### DIFF
--- a/script/prerender/cfn.yml
+++ b/script/prerender/cfn.yml
@@ -136,10 +136,7 @@ Resources:
           {{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id}}
         InstanceInitiatedShutdownBehavior: terminate
         # Having less, larger instances is generally cheaper due to lower EBS costs
-        # However, our main thread code seems to struggle to keep all the worker threads busy
-        # on instances larger than c6i.2xlarge
-        # We would probably need to add multiple queuing threads for the larger instances
-        InstanceType: c6i.2xlarge
+        InstanceType: c6i.4xlarge
         SecurityGroupIds:
           - !ImportValue RexPrerenderWorkersSecurityGroupID
         TagSpecifications:


### PR DESCRIPTION
This PR should fix Rex prerendering, which is currently timing out.

The comment about the main thread not being able to keep up with the larger instance size doesn't seem to be true anymore, since the main thread finishes queuing up jobs in ~15 minutes but the workers take an hour to finish processing everything.

In theory the number of containers per instance is controlled by the MemoryReservation parameter here: https://github.com/openstax/rex-web/blob/2e1fc18246d63a01589b6d1c51a95be4606d7b59/script/prerender/cfn.yml#L106 which is currently set 1 GB, so doubling the instance size should automatically double the number of containers per instance.