### PR TITLE
CORE-854: Replace blockquote tag around attribution text

### DIFF
--- a/src/app/content/__snapshots__/routes.spec.tsx.snap
+++ b/src/app/content/__snapshots__/routes.spec.tsx.snap
@@ -1009,16 +1009,16 @@ Array [
   <li>
     If you are redistributing all or part of this book in a print format,
     then you must include on every physical page the following attribution:
-    <blockquote>
+    <p>
       Access for free at https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units
-    </blockquote>
+    </p>
   </li>
   <li>
     If you are redistributing all or part of this book in a digital format,
     then you must include on every digital page view the following attribution:
-    <blockquote>
+    <p>
       Access for free at <a target=\\"_blank\\" href=\\"https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units\\" aria-label=\\"Introduction to Science and the Realm of Physics, Physical Quantities, and Units - Test Book 1 | OpenStax\\">https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units</a>
-    </blockquote>
+    </p>
   </li>
 </ul>
 

--- a/src/app/content/components/__snapshots__/Attribution.spec.tsx.snap
+++ b/src/app/content/components/__snapshots__/Attribution.spec.tsx.snap
@@ -1807,16 +1807,16 @@ exports[`Attribution in browser renders CodeRunnerNote when slug includes python
   <li>
     If you are redistributing all or part of this book in a print format,
     then you must include on every physical page the following attribution:
-    <blockquote>
+    <p>
       Access for free at https://openstax.org/books/programming-python/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units
-    </blockquote>
+    </p>
   </li>
   <li>
     If you are redistributing all or part of this book in a digital format,
     then you must include on every digital page view the following attribution:
-    <blockquote>
+    <p>
       Access for free at <a target=\\"_blank\\" href=\\"https://openstax.org/books/programming-python/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units\\" aria-label=\\"Introduction to Science and the Realm of Physics, Physical Quantities, and Units - Test Book 1 | OpenStax\\">https://openstax.org/books/programming-python/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units</a>
-    </blockquote>
+    </p>
   </li>
 </ul>
 
@@ -3045,16 +3045,16 @@ exports[`Attribution in browser renders default attribution 1`] = `
   <li>
     If you are redistributing all or part of this book in a print format,
     then you must include on every physical page the following attribution:
-    <blockquote>
+    <p>
       Access for free at https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units
-    </blockquote>
+    </p>
   </li>
   <li>
     If you are redistributing all or part of this book in a digital format,
     then you must include on every digital page view the following attribution:
-    <blockquote>
+    <p>
       Access for free at <a target=\\"_blank\\" href=\\"https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units\\" aria-label=\\"Introduction to Science and the Realm of Physics, Physical Quantities, and Units - Test Book 1 | OpenStax\\">https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units</a>
-    </blockquote>
+    </p>
   </li>
 </ul>
 
@@ -4434,16 +4434,16 @@ exports[`Attribution in browser renders special licensing and attribution for HS
   <li>
     If you are redistributing all or part of this book in a print format,
     then you must include on every physical page the following attribution:
-    <blockquote>
+    <p>
       Access for free at https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units
-    </blockquote>
+    </p>
   </li>
   <li>
     If you are redistributing all or part of this book in a digital format,
     then you must include on every digital page view the following attribution:
-    <blockquote>
+    <p>
       Access for free at <a target=\\"_blank\\" href=\\"https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units\\" aria-label=\\"Introduction to Science and the Realm of Physics, Physical Quantities, and Units - Test Book 1 | OpenStax\\">https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units</a>
-    </blockquote>
+    </p>
   </li>
 </ul>
 
@@ -6139,16 +6139,16 @@ exports[`Attribution in browser renders special licensing and attribution for In
   <li>
     If you are redistributing all or part of this book in a print format,
     then you must include on every physical page the following attribution:
-    <blockquote>
+    <p>
       Access for free at https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units
-    </blockquote>
+    </p>
   </li>
   <li>
     If you are redistributing all or part of this book in a digital format,
     then you must include on every digital page view the following attribution:
-    <blockquote>
+    <p>
       Access for free at <a target=\\"_blank\\" href=\\"https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units\\" aria-label=\\"Introduction to Science and the Realm of Physics, Physical Quantities, and Units - Test Book 1 | OpenStax\\">https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units</a>
-    </blockquote>
+    </p>
   </li>
 </ul>
 
@@ -7687,16 +7687,16 @@ exports[`Attribution in browser renders special licensing and attribution for St
   <li>
     If you are redistributing all or part of this book in a print format,
     then you must include on every physical page the following attribution:
-    <blockquote>
+    <p>
       Access for free at https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units
-    </blockquote>
+    </p>
   </li>
   <li>
     If you are redistributing all or part of this book in a digital format,
     then you must include on every digital page view the following attribution:
-    <blockquote>
+    <p>
       Access for free at <a target=\\"_blank\\" href=\\"https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units\\" aria-label=\\"Introduction to Science and the Realm of Physics, Physical Quantities, and Units - Test Book 1 | OpenStax\\">https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units</a>
-    </blockquote>
+    </p>
   </li>
 </ul>
 

--- a/src/app/content/components/__snapshots__/Content.spec.tsx.snap
+++ b/src/app/content/components/__snapshots__/Content.spec.tsx.snap
@@ -4398,16 +4398,16 @@ li[aria-label="Current Page"] .c61 {
   <li>
     If you are redistributing all or part of this book in a print format,
     then you must include on every physical page the following attribution:
-    <blockquote>
+    <p>
       Access for free at https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units
-    </blockquote>
+    </p>
   </li>
   <li>
     If you are redistributing all or part of this book in a digital format,
     then you must include on every digital page view the following attribution:
-    <blockquote>
+    <p>
       Access for free at <a target=\\"_blank\\" href=\\"https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units\\" aria-label=\\"Introduction to Science and the Realm of Physics, Physical Quantities, and Units - Test Book 1 | OpenStax\\">https://openstax.org/books/book-slug-1/pages/1-introduction-to-science-and-the-realm-of-physics-physical-quantities-and-units</a>
-    </blockquote>
+    </p>
   </li>
 </ul>
 

--- a/src/app/messages/en/attributionText.ts
+++ b/src/app/messages/en/attributionText.ts
@@ -20,16 +20,16 @@ export const defaultText = `
   <li>
     If you are redistributing all or part of this book in a print format,
     then you must include on every physical page the following attribution:
-    <blockquote>
+    <p>
       Access for free at https://openstax.org{introPageUrl}
-    </blockquote>
+    </p>
   </li>
   <li>
     If you are redistributing all or part of this book in a digital format,
     then you must include on every digital page view the following attribution:
-    <blockquote>
+    <p>
       Access for free at <a target="_blank" href="https://openstax.org{introPageUrl}" aria-label="{introPageTitle}">https://openstax.org{introPageUrl}</a>
-    </blockquote>
+    </p>
   </li>
 </ul>
 


### PR DESCRIPTION
[CORE-854]
I replaced it with paragraph tags.

[CORE-854]: https://openstax.atlassian.net/browse/CORE-854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ