### PR TITLE
remove logic that show all cards when blur or navigate with keyboard

### DIFF
--- a/src/app/content/highlights/components/Card.tsx
+++ b/src/app/content/highlights/components/Card.tsx
@@ -53,7 +53,6 @@ export interface CardProps {
   highlightOffsets?: { top: number; bottom: number };
   onHeightChange: (ref: React.RefObject<HTMLElement>) => void;
   isHidden: boolean;
-  onBlurOptional?: () => void;
 }
 
 type CardPropsWithBookAndPage = Omit<CardProps, 'book' | 'page'> & {
@@ -82,10 +81,7 @@ function useComputedProps(props: CardProps) {
       className: props.className,
       highlight: props.highlight,
       isActive: props.isActive,
-      onBlur: /* istanbul ignore next */ () => {
-        props.blur();
-        if (props.onBlurOptional) props.onBlurOptional();
-      },
+      onBlur: props.blur,
       onHeightChange: props.onHeightChange,
       ref: element,
       shouldFocusCard: props.shouldFocusCard,

--- a/src/app/content/highlights/components/CardWrapper.tsx
+++ b/src/app/content/highlights/components/CardWrapper.tsx
@@ -62,8 +62,8 @@ const Wrapper = ({highlights, className, container, highlighter}: WrapperProps) 
     dispatch({ type: 'HIDE', id: focusedId });
   };
 
-  const showCard = (focusedId: string | undefined) => {
-    dispatch({ type: 'SHOW', id: focusedId });
+  const showCard = (cardId: string | undefined) => {
+    dispatch({ type: 'SHOW', id: cardId });
   };
 
   useKeyCombination(highlightKeyCombination, moveFocus, noopKeyCombinationHandler([container, element]));
@@ -72,7 +72,7 @@ const Wrapper = ({highlights, className, container, highlighter}: WrapperProps) 
   * Allow to show EditCard using Enter key
   * It is important to preserve the default behavior of Enter key
   */
-  useKeyCombination({key: 'Enter'}, ()=> showCard(focusedId), undefined, false);
+  useKeyCombination({key: 'Enter'}, () => showCard(focusedId), undefined, false);
 
   // Allow to hide EditCard using Escape key
   useKeyCombination({key: 'Escape'}, hideCard, undefined, false);

--- a/src/app/content/highlights/components/CardWrapper.tsx
+++ b/src/app/content/highlights/components/CardWrapper.tsx
@@ -66,10 +66,6 @@ const Wrapper = ({highlights, className, container, highlighter}: WrapperProps) 
     dispatch({ type: 'SHOW', id: focusedId });
   };
 
-  const showAllCards = () => {
-    dispatch({ type: 'SHOW_ALL' });
-  };
-
   useKeyCombination(highlightKeyCombination, moveFocus, noopKeyCombinationHandler([container, element]));
 
   /*
@@ -80,10 +76,6 @@ const Wrapper = ({highlights, className, container, highlighter}: WrapperProps) 
 
   // Allow to hide EditCard using Escape key
   useKeyCombination({key: 'Escape'}, hideCard, undefined, false);
-
-  // After move focus, reset visibility of all cards
-  useKeyCombination({ key: 'Tab' }, showAllCards, undefined, false);
-  useKeyCombination({ key: 'Tab', shiftKey: true }, showAllCards, undefined, false);
 
   // Clear shouldFocusCard when focus is lost from the CardWrapper.
   // If we don't do this then card related for the focused highlight will be focused automatically.
@@ -155,7 +147,6 @@ const Wrapper = ({highlights, className, container, highlighter}: WrapperProps) 
           zIndex={highlights.length - index}
           shouldFocusCard={focusThisCard}
           isHidden={checkIfHiddenByCollapsedAncestor(highlight) || isHiddenByEscape.get(highlight.id)}
-          onBlurOptional={showAllCards}
         />;
       })}
     </div>

--- a/src/app/content/highlights/components/CardWrapper.tsx
+++ b/src/app/content/highlights/components/CardWrapper.tsx
@@ -5,7 +5,7 @@ import { connect, useSelector } from 'react-redux';
 import ResizeObserver from 'resize-observer-polyfill';
 import styled from 'styled-components';
 import { isHtmlElement } from '../../../guards';
-import { useFocusLost, useKeyCombination } from '../../../reactUtils';
+import { useFocusLost, useKeyCombination, useFocusHighlight } from '../../../reactUtils';
 import { AppState } from '../../../types';
 import { assertDefined } from '../../../utils';
 import * as selectSearch from '../../search/selectors';
@@ -62,7 +62,7 @@ const Wrapper = ({highlights, className, container, highlighter}: WrapperProps) 
     dispatch({ type: 'HIDE', id: focusedId });
   };
 
-  const showCard = () => {
+  const showCard = (focusedId: string | undefined) => {
     dispatch({ type: 'SHOW', id: focusedId });
   };
 
@@ -72,7 +72,7 @@ const Wrapper = ({highlights, className, container, highlighter}: WrapperProps) 
   * Allow to show EditCard using Enter key
   * It is important to preserve the default behavior of Enter key
   */
-  useKeyCombination({key: 'Enter'}, showCard, undefined, false);
+  useKeyCombination({key: 'Enter'}, ()=> showCard(focusedId), undefined, false);
 
   // Allow to hide EditCard using Escape key
   useKeyCombination({key: 'Escape'}, hideCard, undefined, false);
@@ -80,6 +80,7 @@ const Wrapper = ({highlights, className, container, highlighter}: WrapperProps) 
   // Clear shouldFocusCard when focus is lost from the CardWrapper.
   // If we don't do this then card related for the focused highlight will be focused automatically.
   useFocusLost(element, shouldFocusCard, React.useCallback(() => setShouldFocusCard(false), [setShouldFocusCard]));
+  useFocusHighlight(showCard, highlights);
 
   const onHeightChange = React.useCallback((id: string, ref: React.RefObject<HTMLElement>) => {
     const height = ref.current && ref.current.offsetHeight;

--- a/src/app/content/highlights/components/__snapshots__/CardWrapper.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/CardWrapper.spec.tsx.snap
@@ -61,7 +61,6 @@ exports[`CardWrapper matches snapshot 1`] = `
       }
     }
     isHidden={false}
-    onBlurOptional={[Function]}
     onHeightChange={[Function]}
     shouldFocusCard={false}
     zIndex={1}

--- a/src/app/content/highlights/components/cardUtils.spec.ts
+++ b/src/app/content/highlights/components/cardUtils.spec.ts
@@ -81,15 +81,6 @@ describe('editCardVisibilityHandler', () => {
     expect(result.get('highlight1')).toBe(false);
   });
 
-  it('show all highlights', () => {
-    const firstResult = editCardVisibilityHandler(state, { type: 'HIDE', id: 'highlight1'});
-    expect(firstResult.get('highlight1')).toBe(true);
-    const secondResult = editCardVisibilityHandler(state, { type: 'SHOW_ALL'});
-    expect(secondResult.get('highlight1')).toBe(false);
-    expect(secondResult.get('highlight2')).toBe(false);
-    expect(secondResult.get('highlight3')).toBe(false);
-  });
-
   it('return state when action type does not exist', () => {
     const result = editCardVisibilityHandler(state, { type: 'SHOW_ANY'});
     expect(result.get('highlight1')).toBe(false);

--- a/src/app/content/highlights/components/cardUtils.ts
+++ b/src/app/content/highlights/components/cardUtils.ts
@@ -230,11 +230,6 @@ export const editCardVisibilityHandler = (state: Map<string, boolean>, action: {
       updatedState.set(action.id, true);
       return updatedState;
     }
-    case 'SHOW_ALL': {
-      const allVisibleState = new Map(state);
-      allVisibleState.forEach((_, key) => allVisibleState.set(key, false));
-      return allVisibleState;
-    }
     default:
       return state;
   }

--- a/src/app/reactUtils.spec.tsx
+++ b/src/app/reactUtils.spec.tsx
@@ -672,19 +672,20 @@ describe('useFocusHighlight', () => {
   let highlightElement: HTMLElement;
   let highlights: Highlight[];
 
+  // tslint:disable-next-line: variable-name
   const TestComponent = ({
-    highlights,
-    showCard,
+    highlightsList,
+    callback,
   }: {
-    highlights: Highlight[];
-    showCard: (id: string) => void;
+    highlightsList: Highlight[];
+    callback: (id: string) => void;
   }) => {
-    utils.useFocusHighlight(showCard, highlights);
+    utils.useFocusHighlight(callback, highlightsList);
     return (
       <div>
-        <div tabIndex={0} id="outside">Outside</div>
-        <mark id="highlight" tabIndex={0}>
-          <span id="highlight-span" tabIndex={0}>Highlight text</span>
+        <div tabIndex={0} id='outside'>Outside</div>
+        <mark id='highlight' tabIndex={0}>
+          <span id='highlight-span' tabIndex={0}>Highlight text</span>
         </mark>
       </div>
     );
@@ -698,7 +699,7 @@ describe('useFocusHighlight', () => {
     // Initial mount to access <span>
     act(() => {
       ReactDOM.render(
-        <TestComponent highlights={[]} showCard={showCard} />,
+        <TestComponent highlightsList={[]} callback={showCard} />,
         container
       );
     });
@@ -709,7 +710,7 @@ describe('useFocusHighlight', () => {
     // Re-mount with highlights
     act(() => {
       ReactDOM.render(
-        <TestComponent highlights={highlights} showCard={showCard} />,
+        <TestComponent highlightsList={highlights} callback={showCard} />,
         container
       );
     });
@@ -747,6 +748,7 @@ describe('useFocusHighlight', () => {
   });
 
   it('does not call showCard if event.target is not an element', () => {
+    const document = assertDocument();
     const fakeEvent = new Event('click');
     Object.defineProperty(fakeEvent, 'target', { value: null });
     document.dispatchEvent(fakeEvent);

--- a/src/app/reactUtils.spec.tsx
+++ b/src/app/reactUtils.spec.tsx
@@ -1,10 +1,13 @@
 import type { KeyboardEvent, MediaQueryList, HTMLElement } from '@openstax/types/lib.dom';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import renderer from 'react-test-renderer';
 import { resetModules, runHooks } from '../test/utils';
 import * as utils from './reactUtils';
 import { assertDocument, assertWindow } from './utils';
 import { dispatchKeyDownEvent } from '../test/reactutils';
+import { Highlight } from '@openstax/highlighter';
+import { act } from 'react-dom/test-utils';
 
 describe('onFocusInOrOutHandler focusout', () => {
   let ref: React.RefObject<HTMLElement>;
@@ -152,8 +155,8 @@ describe('useTimeout', () => {
     };
   });
 
-  it('resets after delay changes' , () => {
-    const {root} = renderer.create(<Component />);
+  it('resets after delay changes', () => {
+    const { root } = renderer.create(<Component />);
 
     expect(callback).not.toHaveBeenCalled();
 
@@ -182,7 +185,7 @@ describe('useOnDOMEvent', () => {
     resetModules();
   });
 
-  describe('on html element' , () => {
+  describe('on html element', () => {
     let ref: React.RefObject<HTMLElement>;
     let htmlElement: HTMLElement;
 
@@ -197,11 +200,11 @@ describe('useOnDOMEvent', () => {
     });
 
     it('doesn\'t do anything without a target', () => {
-      const cleanup = utils.onDOMEventHandler({current: null}, true, 'click', cb)();
+      const cleanup = utils.onDOMEventHandler({ current: null }, true, 'click', cb)();
       expect(cleanup).not.toBeDefined();
     });
 
-    it('registers event listenr' , () => {
+    it('registers event listenr', () => {
       utils.onDOMEventHandler(ref, true, 'click', cb)();
       expect(addEventListener).toHaveBeenCalledWith('click', cb);
     });
@@ -222,7 +225,7 @@ describe('useOnDOMEvent', () => {
     });
   });
 
-  describe('on window' , () => {
+  describe('on window', () => {
     let window: Window;
 
     beforeEach(() => {
@@ -274,7 +277,7 @@ describe('useTrapTabNavigation', () => {
 
     renderer.act(
       () => {
-        dispatchKeyDownEvent({key: 'Tab'});
+        dispatchKeyDownEvent({ key: 'Tab' });
       }
     );
     tr.unmount();
@@ -306,12 +309,12 @@ describe('createTrapTab', () => {
     trapTab = utils.createTrapTab(htmlElement);
   });
   it('ignores non-Tab events', () => {
-    trapTab({key: 'a'} as KeyboardEvent);
+    trapTab({ key: 'a' } as KeyboardEvent);
   });
   it('tabs forward (wrap around)', () => {
     b.focus = jest.fn();
     Object.defineProperty(document, 'activeElement', { value: i, writable: false, configurable: true });
-    trapTab({key: 'Tab', preventDefault} as unknown as KeyboardEvent);
+    trapTab({ key: 'Tab', preventDefault } as unknown as KeyboardEvent);
     expect(b.focus).toHaveBeenCalled();
     expect(preventDefault).toHaveBeenCalled();
   });
@@ -319,33 +322,33 @@ describe('createTrapTab', () => {
     i.focus = jest.fn();
     Object.defineProperty(document, 'activeElement', { value: b, writable: false, configurable: true });
     preventDefault.mockClear();
-    trapTab({key: 'Tab', shiftKey: true, preventDefault} as unknown as KeyboardEvent);
+    trapTab({ key: 'Tab', shiftKey: true, preventDefault } as unknown as KeyboardEvent);
     expect(i.focus).toHaveBeenCalled();
     expect(preventDefault).toHaveBeenCalled();
-   });
-   it('tabs normally otherwise', () => {
+  });
+  it('tabs normally otherwise', () => {
     preventDefault.mockClear();
-    trapTab({key: 'Tab', preventDefault} as unknown as KeyboardEvent);
+    trapTab({ key: 'Tab', preventDefault } as unknown as KeyboardEvent);
     Object.defineProperty(document, 'activeElement', { value: i, writable: false, configurable: true });
-    trapTab({key: 'Tab', shiftKey: true, preventDefault} as unknown as KeyboardEvent);
+    trapTab({ key: 'Tab', shiftKey: true, preventDefault } as unknown as KeyboardEvent);
     expect(preventDefault).not.toHaveBeenCalled();
-   });
-   it('brings focus back from outside', () => {
+  });
+  it('brings focus back from outside', () => {
     const outsideEl = assertDocument().createElement('button');
     b.focus = jest.fn();
     expect(b.focus).not.toHaveBeenCalled();
     Object.defineProperty(document, 'activeElement', { value: outsideEl, writable: false, configurable: true });
     preventDefault.mockClear();
-    trapTab({key: 'Tab', shiftKey: true, preventDefault} as unknown as KeyboardEvent);
+    trapTab({ key: 'Tab', shiftKey: true, preventDefault } as unknown as KeyboardEvent);
     expect(b.focus).toHaveBeenCalled();
     expect(preventDefault).toHaveBeenCalled();
-   });
-   it('short circuits when no focusable elements', () => {
+  });
+  it('short circuits when no focusable elements', () => {
     const emptyEl = assertDocument().createElement('div');
 
     trapTab = utils.createTrapTab(emptyEl);
-    trapTab({key: 'Tab', shiftKey: true, preventDefault} as unknown as KeyboardEvent);
-   });
+    trapTab({ key: 'Tab', shiftKey: true, preventDefault } as unknown as KeyboardEvent);
+  });
 });
 
 describe('onKeyHandler', () => {
@@ -364,17 +367,17 @@ describe('onKeyHandler', () => {
   });
 
   it('registers event listener', () => {
-    utils.onKeyHandler({key: 'Escape'}, ref, true, () => null)();
+    utils.onKeyHandler({ key: 'Escape' }, ref, true, () => null)();
     expect(addEventListener).toHaveBeenCalled();
   });
 
   it('doesn\'t register event listener when ref.current doesn\'t exist', () => {
-    utils.onKeyHandler({key: 'Escape'}, { current: null }, true, () => null)();
+    utils.onKeyHandler({ key: 'Escape' }, { current: null }, true, () => null)();
     expect(addEventListener).not.toHaveBeenCalled();
   });
 
   it('removes event listener', () => {
-    const removeEvListener = utils.onKeyHandler({key: 'Escape'}, ref, true, () => null)();
+    const removeEvListener = utils.onKeyHandler({ key: 'Escape' }, ref, true, () => null)();
     expect(removeEvListener).toBeDefined();
     removeEvListener!();
     expect(removeEventListener).toHaveBeenCalled();
@@ -383,7 +386,7 @@ describe('onKeyHandler', () => {
   it('clicking Escape invokes callback', () => {
     const window = assertWindow();
     const cb = jest.fn();
-    utils.onKeyHandler({key: 'Escape'}, ref, true, cb)();
+    utils.onKeyHandler({ key: 'Escape' }, ref, true, cb)();
 
     const keyboardEvent = new KeyboardEvent('keydown', {
       bubbles: true,
@@ -400,7 +403,7 @@ describe('onKeyHandler', () => {
   it('clicking other button doesn\'t invokes callback', () => {
     const window = assertWindow();
     const cb = jest.fn();
-    utils.onKeyHandler({key: 'Escape'}, ref, true, cb)();
+    utils.onKeyHandler({ key: 'Escape' }, ref, true, cb)();
 
     const keyboardEvent = new KeyboardEvent('keydown', {
       bubbles: true,
@@ -437,7 +440,7 @@ describe('useMatchMobileQuery', () => {
     jest.spyOn(assertWindow(), 'matchMedia')
       .mockImplementation(() => mock);
 
-    const component = renderer.create(<Component/>);
+    const component = renderer.create(<Component />);
 
     runHooks(renderer);
 
@@ -457,7 +460,7 @@ describe('useMatchMobileQuery', () => {
     jest.spyOn(assertWindow(), 'matchMedia')
       .mockImplementation(() => mock);
 
-    const component = renderer.create(<Component/>);
+    const component = renderer.create(<Component />);
 
     runHooks(renderer);
 
@@ -477,7 +480,7 @@ describe('useMatchMobileQuery', () => {
     jest.spyOn(assertWindow(), 'matchMedia')
       .mockImplementation(() => mock);
 
-    const component = renderer.create(<Component/>);
+    const component = renderer.create(<Component />);
 
     runHooks(renderer);
 
@@ -517,7 +520,7 @@ describe('useOnScrollTopOffset', () => {
     const spyAddListener = jest.spyOn(assertDocument(), 'addEventListener');
     const spyRemoveListener = jest.spyOn(assertDocument(), 'removeEventListener');
 
-    const component = renderer.create(<Component/>);
+    const component = renderer.create(<Component />);
 
     runHooks(renderer);
 
@@ -535,7 +538,7 @@ describe('useOnScrollTopOffset', () => {
     const document = assertDocument();
     const spyAddListener = jest.spyOn(document, 'addEventListener');
 
-    const component = renderer.create(<Component/>);
+    const component = renderer.create(<Component />);
 
     runHooks(renderer);
 
@@ -660,5 +663,93 @@ describe('keyboardEventMatchesCombination', () => {
       { key: 'a', ctrlKey: true },
       { key: 'a', ctrlKey: true, altKey: false } as any
     )).toEqual(true);
+  });
+});
+
+describe('useFocusHighlight', () => {
+  let showCard: jest.Mock;
+  let container: HTMLElement;
+  let highlightElement: HTMLElement;
+  let highlights: Highlight[];
+
+  const TestComponent = ({
+    highlights,
+    showCard,
+  }: {
+    highlights: Highlight[];
+    showCard: (id: string) => void;
+  }) => {
+    utils.useFocusHighlight(showCard, highlights);
+    return (
+      <div>
+        <div tabIndex={0} id="outside">Outside</div>
+        <mark id="highlight" tabIndex={0}>
+          <span id="highlight-span" tabIndex={0}>Highlight text</span>
+        </mark>
+      </div>
+    );
+  };
+
+  beforeEach(() => {
+    showCard = jest.fn();
+    container = assertDocument().createElement('div');
+    assertDocument().body.appendChild(container);
+
+    // Initial mount to access <span>
+    act(() => {
+      ReactDOM.render(
+        <TestComponent highlights={[]} showCard={showCard} />,
+        container
+      );
+    });
+
+    highlightElement = container.querySelector('#highlight-span')!;
+    highlights = [{ id: 'h1', elements: [highlightElement] } as any as Highlight];
+
+    // Re-mount with highlights
+    act(() => {
+      ReactDOM.render(
+        <TestComponent highlights={highlights} showCard={showCard} />,
+        container
+      );
+    });
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+    container.remove();
+    showCard.mockReset();
+    jest.clearAllMocks();
+  });
+
+  it('calls showCard on focusin of highlight span', () => {
+    const span = container.querySelector('#highlight-span')!;
+    span.dispatchEvent(new Event('focusin', { bubbles: true }));
+    expect(showCard).toHaveBeenCalledWith('h1');
+  });
+
+  it('calls showCard on click on mark', () => {
+    const mark = container.querySelector('#highlight')!;
+    mark.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(showCard).toHaveBeenCalledWith('h1');
+  });
+
+  it('does not call showCard when clicking outside', () => {
+    const outside = container.querySelector('#outside')!;
+    outside.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(showCard).not.toHaveBeenCalled();
+  });
+
+  it('does not call showCard when focusing outside', () => {
+    const outside = container.querySelector('#outside')!;
+    outside.dispatchEvent(new Event('focusin', { bubbles: true }));
+    expect(showCard).not.toHaveBeenCalled();
+  });
+
+  it('does not call showCard if event.target is not an element', () => {
+    const fakeEvent = new Event('click');
+    Object.defineProperty(fakeEvent, 'target', { value: null });
+    document.dispatchEvent(fakeEvent);
+    expect(showCard).not.toHaveBeenCalled();
   });
 });

--- a/src/app/reactUtils.ts
+++ b/src/app/reactUtils.ts
@@ -5,6 +5,7 @@ import { addSafeEventListener } from './domUtils';
 import { isElement, isTextInputHtmlElement, isWindow } from './guards';
 import theme from './theme';
 import { assertDefined, assertDocument, assertWindow } from './utils';
+import { Highlight } from '@openstax/highlighter';
 
 export const useDrawFocus = <E extends HTMLElement = HTMLElement>() => {
   const ref = React.useRef<E>(null);
@@ -478,3 +479,44 @@ export const useFocusElement = (element: React.RefObject<HTMLElement>, shouldFoc
     }
   }, [element, shouldFocus]);
 };
+
+export const useFocusHighlight = (showCard: (id: string) => void, highlights: Highlight[]) => {
+  const document = assertDocument();
+  React.useEffect(() => {
+    if (!highlights || highlights.length === 0) return;
+    const handler = (event: Event) => {
+      let target: EventTarget | null;
+      if (event.type === 'click') {
+        if (isElement(event.target)) {
+          /* 
+            When clicking on a highlight, the target is a mark element and
+            we need to find the first span inside it to get the highlight as expected
+          */ 
+          target = event.target.querySelectorAll('span')[0];
+        }
+      } else {
+        target = event.target;
+      }
+      const highlight = highlights.find(h =>
+        h.elements && h.elements.some(el =>
+          el === target ||
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (!!el && typeof (el as any).contains === 'function' && (el as any).contains(target))
+        )
+      );
+
+      if (highlight) {
+        showCard(highlight.id);
+      }
+    };
+
+    // Listen for focusin and click events to show the card
+    // For some reason when focus using click, the focused element is div main-content
+    document.addEventListener('focusin', handler);
+    document.addEventListener('click', handler);
+    return () => {
+      document.removeEventListener('focusin', handler);
+      document.removeEventListener('click', handler);
+    };
+  }, [document, highlights, showCard]);
+}

--- a/src/app/reactUtils.ts
+++ b/src/app/reactUtils.ts
@@ -488,10 +488,10 @@ export const useFocusHighlight = (showCard: (id: string) => void, highlights: Hi
       let target: EventTarget | null;
       if (event.type === 'click') {
         if (isElement(event.target)) {
-          /* 
+          /*
             When clicking on a highlight, the target is a mark element and
             we need to find the first span inside it to get the highlight as expected
-          */ 
+          */
           target = event.target.querySelectorAll('span')[0];
         }
       } else {
@@ -519,7 +519,7 @@ export const useFocusHighlight = (showCard: (id: string) => void, highlights: Hi
       document.removeEventListener('click', handler);
     };
   }, [document, highlights, showCard]);
-}
+};
 export const isSSR = () => {
   return typeof window === 'undefined' || typeof document === 'undefined';
 };


### PR DESCRIPTION
[CORE-806]

Remove SHOW_ALL option for highlights when onBlur. Cards should stay away when press Esc and it can return pressing Enter.

[CORE-806]: https://openstax.atlassian.net/browse/CORE-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ