### PR TITLE
Core 1054 fix text resizer control

### DIFF
--- a/src/app/components/Dropdown.spec.tsx
+++ b/src/app/components/Dropdown.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import * as reactUtils from '../../app/reactUtils';
 import TestContainer from '../../test/TestContainer';
-import Dropdown, { DropdownItem, DropdownList } from './Dropdown';
+import Dropdown, { DropdownItem, DropdownList, callOrRefocus } from './Dropdown';
 
 describe('Dropdown', () => {
   it('matches snapshot', () => {
@@ -74,6 +74,17 @@ describe('Dropdown', () => {
     });
 
     expect(() => component.root.findByType(DropdownList)).toThrow();
+  });
+
+  it('callOrRefocus refocuses when container.match(:hover)', () => {
+    const cb = jest.fn();
+    const matches = jest.fn().mockReturnValue(true);
+    const focus = jest.fn();
+
+    // @ts-expect-error not HTMLElements
+    callOrRefocus(cb, {matches}, {focus});
+    expect(cb).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalled();
   });
 
   it('tab hidden closes on Esc', () => {

--- a/src/app/content/__snapshots__/routes.spec.tsx.snap
+++ b/src/app/content/__snapshots__/routes.spec.tsx.snap
@@ -149,7 +149,6 @@ Array [
 }
 
 .c4 {
-  margin-left: auto;
   z-index: 3;
 }
 
@@ -167,6 +166,7 @@ Array [
   top: 7rem;
   width: 100%;
   overflow: visible;
+  padding-left: 5rem;
   display: block;
   z-index: 30;
   box-shadow: 0 0.2rem 0.2rem 0 rgba(0,0,0,0.14);

--- a/src/app/content/components/ContentPane.tsx
+++ b/src/app/content/components/ContentPane.tsx
@@ -20,7 +20,7 @@ import { isVerticalNavOpenConnector, styleWhenSidebarClosed } from './utils/side
 export const contentWrapperWidthBreakpoint = '(max-width: ' + remsToEms(contentWrapperMaxWidth) + 'em)';
 export const contentWrapperAndNavWidthBreakpoint =
   '(max-width: ' + remsToEms(contentWrapperMaxWidth + verticalNavbarMaxWidth * 2) + 'em)';
-export const contentWrapperBreakpointStyles = `
+const contentWrapperBreakpointStyles = `
   @media screen and ${contentWrapperAndNavWidthBreakpoint} {
     padding-left: calc(${sidebarDesktopWithToolbarWidth}rem - (100vw - ${contentWrapperMaxWidth}rem) / 2);
   }

--- a/src/app/content/components/Topbar/__snapshots__/index.spec.tsx.snap
+++ b/src/app/content/components/Topbar/__snapshots__/index.spec.tsx.snap
@@ -36,6 +36,7 @@ exports[`text resizer does not render if textSize is null 1`] = `
   top: 7rem;
   width: 100%;
   overflow: visible;
+  padding-left: 5rem;
   display: block;
   z-index: 30;
 }
@@ -95,6 +96,7 @@ exports[`text resizer does not render if textSize is null 1`] = `
 
 .c8 {
   margin-left: auto;
+  margin-right: auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -103,7 +105,6 @@ exports[`text resizer does not render if textSize is null 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: -5.2rem;
   position: relative;
   color: #5e6062;
   border: solid 0.1rem;
@@ -230,7 +231,6 @@ exports[`text resizer does not render if textSize is null 1`] = `
   background-color: #fff;
   -webkit-transition: padding-left 300ms;
   transition: padding-left 300ms;
-  padding-left: 37.5rem;
   box-shadow: 0 0.2rem 0.2rem 0 rgba(0,0,0,0.14);
 }
 
@@ -364,25 +364,25 @@ exports[`text resizer does not render if textSize is null 1`] = `
 }
 
 @media screen and (max-width:75em) {
-  .gPsjnW .c10 {
+  .fNEgfW .c10 {
     color: #5e6062;
   }
 }
 
 @media screen and (max-width:75em) {
-  .kXPpuK .c10 {
+  .WUYvv .c10 {
     color: #fff;
   }
 
-  .kXPpuK .c10:hover,
-  .kXPpuK .c10:focus {
+  .WUYvv .c10:hover,
+  .WUYvv .c10:focus {
     color: #fff;
     -webkit-transition: color 200ms;
     transition: color 200ms;
   }
 
-  .kXPpuK .c10:hover::before,
-  .kXPpuK .c10:focus::before {
+  .WUYvv .c10:hover::before,
+  .WUYvv .c10:focus::before {
     content: "";
     display: block;
     height: 100%;
@@ -395,19 +395,19 @@ exports[`text resizer does not render if textSize is null 1`] = `
 }
 
 @media screen and (max-width:75em) {
-  .ulpVr .c10 {
+  .eLelrJ .c10 {
     color: #000;
   }
 
-  .ulpVr .c10:hover,
-  .ulpVr .c10:focus {
+  .eLelrJ .c10:hover,
+  .eLelrJ .c10:focus {
     color: #000;
     -webkit-transition: color 200ms;
     transition: color 200ms;
   }
 
-  .ulpVr .c10:hover::before,
-  .ulpVr .c10:focus::before {
+  .eLelrJ .c10:hover::before,
+  .eLelrJ .c10:focus::before {
     content: "";
     display: block;
     height: 100%;
@@ -422,18 +422,6 @@ exports[`text resizer does not render if textSize is null 1`] = `
 @media screen and (max-width:50em) {
   .c9 {
     display: none;
-  }
-}
-
-@media screen and (max-width:90em) {
-  .c1 {
-    padding-left: calc(45.5rem - (100vw - 128rem) / 2);
-  }
-}
-
-@media screen and (max-width:80em) {
-  .c1 {
-    padding-left: 45.5rem;
   }
 }
 
@@ -473,7 +461,7 @@ exports[`text resizer does not render if textSize is null 1`] = `
 }
 
 @media screen and (max-width:50em) {
-  .gjWAAG .c7 {
+  .fcMFyh .c7 {
     border: none;
     border-radius: 0;
     width: 45px;
@@ -514,7 +502,6 @@ exports[`text resizer does not render if textSize is null 1`] = `
 
 @media screen and (max-width:75em) {
   .c13 {
-    padding-left: 8rem;
     display: block;
   }
 }
@@ -868,6 +855,7 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
   top: 7rem;
   width: 100%;
   overflow: visible;
+  padding-left: 5rem;
   display: block;
   z-index: 30;
 }
@@ -927,6 +915,7 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
 
 .c8 {
   margin-left: auto;
+  margin-right: auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -935,7 +924,6 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: -5.2rem;
   position: relative;
   color: #5e6062;
   border: solid 0.1rem;
@@ -1062,7 +1050,6 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
   background-color: #fff;
   -webkit-transition: padding-left 300ms;
   transition: padding-left 300ms;
-  padding-left: 37.5rem;
   box-shadow: 0 0.2rem 0.2rem 0 rgba(0,0,0,0.14);
 }
 
@@ -1098,7 +1085,6 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
 }
 
 .c15 {
-  margin-left: auto;
   z-index: 3;
 }
 
@@ -1155,6 +1141,7 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
   height: 0.4rem;
   width: 12rem;
   margin: 0.8rem 0.7rem;
+  cursor: pointer;
 }
 
 .c20 .controls input[type="range"]::-webkit-slider-runnable-track,
@@ -1311,25 +1298,25 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
 }
 
 @media screen and (max-width:75em) {
-  .gPsjnW .c10 {
+  .fNEgfW .c10 {
     color: #5e6062;
   }
 }
 
 @media screen and (max-width:75em) {
-  .kXPpuK .c10 {
+  .WUYvv .c10 {
     color: #fff;
   }
 
-  .kXPpuK .c10:hover,
-  .kXPpuK .c10:focus {
+  .WUYvv .c10:hover,
+  .WUYvv .c10:focus {
     color: #fff;
     -webkit-transition: color 200ms;
     transition: color 200ms;
   }
 
-  .kXPpuK .c10:hover::before,
-  .kXPpuK .c10:focus::before {
+  .WUYvv .c10:hover::before,
+  .WUYvv .c10:focus::before {
     content: "";
     display: block;
     height: 100%;
@@ -1342,19 +1329,19 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
 }
 
 @media screen and (max-width:75em) {
-  .ulpVr .c10 {
+  .eLelrJ .c10 {
     color: #000;
   }
 
-  .ulpVr .c10:hover,
-  .ulpVr .c10:focus {
+  .eLelrJ .c10:hover,
+  .eLelrJ .c10:focus {
     color: #000;
     -webkit-transition: color 200ms;
     transition: color 200ms;
   }
 
-  .ulpVr .c10:hover::before,
-  .ulpVr .c10:focus::before {
+  .eLelrJ .c10:hover::before,
+  .eLelrJ .c10:focus::before {
     content: "";
     display: block;
     height: 100%;
@@ -1369,18 +1356,6 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
 @media screen and (max-width:50em) {
   .c9 {
     display: none;
-  }
-}
-
-@media screen and (max-width:90em) {
-  .c1 {
-    padding-left: calc(45.5rem - (100vw - 128rem) / 2);
-  }
-}
-
-@media screen and (max-width:80em) {
-  .c1 {
-    padding-left: 45.5rem;
   }
 }
 
@@ -1420,7 +1395,7 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
 }
 
 @media screen and (max-width:50em) {
-  .gjWAAG .c7 {
+  .fcMFyh .c7 {
     border: none;
     border-radius: 0;
     width: 45px;
@@ -1461,7 +1436,6 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
 
 @media screen and (max-width:75em) {
   .c22 {
-    padding-left: 8rem;
     display: block;
   }
 }

--- a/src/app/content/components/Topbar/styled.tsx
+++ b/src/app/content/components/Topbar/styled.tsx
@@ -16,19 +16,16 @@ import {
   bookBannerMobileMiniHeight,
   contentWrapperMaxWidth,
   mobileSearchContainerMargin,
-  sidebarDesktopWidth,
   sidebarTransitionTime,
-  toolbarButtonWidth,
+  textResizerIconWidth,
   toolbarHrHeight,
   toolbarIconColor,
   toolbarMobileSearchWrapperHeight,
   toolbarSearchInputHeight,
   toolbarSearchInputMobileHeight,
   topbarDesktopHeight,
-  topbarMobileHeight,
-  verticalNavbarMaxWidth
+  topbarMobileHeight
 } from '../constants';
-import { contentWrapperBreakpointStyles } from '../ContentPane';
 import { FilterDropdown } from '../popUp/Filters';
 import { toolbarIconStyles } from '../Toolbar/iconStyles';
 import { barPadding, buttonMinWidth, PlainButton } from '../Toolbar/styled';
@@ -63,6 +60,7 @@ export const TopBarWrapper = styled.div`
   top: ${bookBannerDesktopMiniHeight}rem;
   width: 100%;
   overflow: visible;
+  padding-left: ${textResizerIconWidth}rem;
   display: block;
   z-index: ${theme.zIndex.topbar}; /* stay above book content */
   ${theme.breakpoints.mobile(css`
@@ -181,9 +179,9 @@ export const CloseButtonNew = styled.button`
 // tslint:disable-next-line:variable-name
 export const SearchInputWrapper = styled.form`
   margin-left: auto;
+  margin-right: auto;
   display: flex;
   align-items: center;
-  margin-right: -${toolbarButtonWidth}rem;
   position: relative;
   color: ${toolbarIconColor.base};
   border: solid 0.1rem;
@@ -278,8 +276,6 @@ export const SearchPrintWrapper = isVerticalNavOpenConnector(styled.div`
   overflow: visible;
   background-color: ${theme.color.neutral.base};
   transition: padding-left ${sidebarTransitionTime}ms;
-  padding-left: ${sidebarDesktopWidth}rem;
-  ${contentWrapperBreakpointStyles}
   ${styleWhenSidebarClosed(css`
       padding-left: 0 !important;
   `)}
@@ -326,7 +322,6 @@ export const MobileSearchWrapper = styled.div`
   background-color: ${theme.color.neutral.base};
   ${shadow}
   ${theme.breakpoints.mobile(css`
-    padding-left: ${verticalNavbarMaxWidth}rem;
     display: block;
   `)}
   ${theme.breakpoints.mobileMedium(css`
@@ -370,7 +365,6 @@ export const SeachResultsTextButton = styled(PlainButton)`
 
 // tslint:disable-next-line:variable-name
 export const TextResizerDropdown = styled(FilterDropdown)`
-  margin-left: auto;
   z-index: 3;
 
   > button {

--- a/src/app/content/components/Topbar/styled.tsx
+++ b/src/app/content/components/Topbar/styled.tsx
@@ -463,6 +463,7 @@ export const TextResizerMenu = styled.div`
       height: 0.4rem;
       width: 12rem;
       margin: 0.8rem 0.7rem;
+      cursor: pointer;
     }
 
     input[type="range"]::-webkit-slider-runnable-track,

--- a/src/app/content/components/__snapshots__/AssignedTopBar.spec.tsx.snap
+++ b/src/app/content/components/__snapshots__/AssignedTopBar.spec.tsx.snap
@@ -58,7 +58,6 @@ exports[`AssignedTopBar renders 1`] = `
 }
 
 .c4 {
-  margin-left: auto;
   z-index: 3;
 }
 
@@ -76,6 +75,7 @@ exports[`AssignedTopBar renders 1`] = `
   top: 7rem;
   width: 100%;
   overflow: visible;
+  padding-left: 5rem;
   display: block;
   z-index: 30;
   box-shadow: 0 0.2rem 0.2rem 0 rgba(0,0,0,0.14);

--- a/src/app/content/components/__snapshots__/Content.spec.tsx.snap
+++ b/src/app/content/components/__snapshots__/Content.spec.tsx.snap
@@ -1452,6 +1452,7 @@ Array [
   top: 7rem;
   width: 100%;
   overflow: visible;
+  padding-left: 5rem;
   display: block;
   z-index: 30;
 }
@@ -1511,6 +1512,7 @@ Array [
 
 .c54 {
   margin-left: auto;
+  margin-right: auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1519,7 +1521,6 @@ Array [
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: -5.2rem;
   position: relative;
   color: #5e6062;
   border: solid 0.1rem;
@@ -1646,7 +1647,6 @@ Array [
   background-color: #fff;
   -webkit-transition: padding-left 300ms;
   transition: padding-left 300ms;
-  padding-left: 37.5rem;
   box-shadow: 0 0.2rem 0.2rem 0 rgba(0,0,0,0.14);
 }
 
@@ -1682,7 +1682,6 @@ Array [
 }
 
 .c60 {
-  margin-left: auto;
   z-index: 3;
 }
 
@@ -2822,18 +2821,6 @@ Array [
   }
 }
 
-@media screen and (max-width:90em) {
-  .c50 {
-    padding-left: calc(45.5rem - (100vw - 128rem) / 2);
-  }
-}
-
-@media screen and (max-width:80em) {
-  .c50 {
-    padding-left: 45.5rem;
-  }
-}
-
 @media screen and (max-width:75em) {
   .c50 {
     padding-left: 0 !important;
@@ -2903,7 +2890,6 @@ Array [
 
 @media screen and (max-width:75em) {
   .c65 {
-    padding-left: 8rem;
     display: block;
   }
 }
@@ -8673,6 +8659,7 @@ Array [
   top: 7rem;
   width: 100%;
   overflow: visible;
+  padding-left: 5rem;
   display: block;
   z-index: 30;
 }
@@ -8732,6 +8719,7 @@ Array [
 
 .c54 {
   margin-left: auto;
+  margin-right: auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8740,7 +8728,6 @@ Array [
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: -5.2rem;
   position: relative;
   color: #5e6062;
   border: solid 0.1rem;
@@ -8867,7 +8854,6 @@ Array [
   background-color: #fff;
   -webkit-transition: padding-left 300ms;
   transition: padding-left 300ms;
-  padding-left: 37.5rem;
   box-shadow: 0 0.2rem 0.2rem 0 rgba(0,0,0,0.14);
 }
 
@@ -8903,7 +8889,6 @@ Array [
 }
 
 .c60 {
-  margin-left: auto;
   z-index: 3;
 }
 
@@ -9981,18 +9966,6 @@ Array [
   }
 }
 
-@media screen and (max-width:90em) {
-  .c50 {
-    padding-left: calc(45.5rem - (100vw - 128rem) / 2);
-  }
-}
-
-@media screen and (max-width:80em) {
-  .c50 {
-    padding-left: 45.5rem;
-  }
-}
-
 @media screen and (max-width:75em) {
   .c50 {
     padding-left: 0 !important;
@@ -10062,7 +10035,6 @@ Array [
 
 @media screen and (max-width:75em) {
   .c65 {
-    padding-left: 8rem;
     display: block;
   }
 }

--- a/src/app/content/components/constants.ts
+++ b/src/app/content/components/constants.ts
@@ -18,6 +18,7 @@ export const searchResultsBarMobileWidth = 33.8;
 export const toolbarIconColor = theme.color.primary.gray;
 
 export const mobileSearchContainerMargin = 1;
+export const textResizerIconWidth = 5;
 export const toolbarWidth = 8;
 export const toolbarSearchInputHeight = 3.2;
 export const toolbarSearchInputMobileHeight = 3.2;


### PR DESCRIPTION
[CORE-1054]
1. On Safari, font resizer should allow clicks on the resizing controls without closing. It should close when you click outside the resize-control container.
2. It should (still) work the same way in Chrome.
3. Search bar and resize control button should be laid out the same as they are in production, at all screen widths.

[CORE-1054]: https://openstax.atlassian.net/browse/CORE-1054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ