### PR TITLE
CORE-1056 - Fix manage cookies style in flex footer

### DIFF
--- a/src/app/components/Footer/index.tsx
+++ b/src/app/components/Footer/index.tsx
@@ -307,9 +307,9 @@ const PortalColumn3 = () => (
         id='i18n:footer:column3:accessibility'
       />
       <FooterLinkMessage href='/license' id='i18n:footer:column3:license' />
-      <Styled.ManageCookiesLink>
+      <Styled.ManageCookiesFlexLink>
         <BareMessage id='i18n:footer:column3:manage-cookies' />
-      </Styled.ManageCookiesLink>
+      </Styled.ManageCookiesFlexLink>
     </LinkList>
   </Styled.Column3>
 );

--- a/src/app/components/Footer/styled.tsx
+++ b/src/app/components/Footer/styled.tsx
@@ -235,8 +235,7 @@ export const ManageCookiesLink = styled(RawCookiesLink)`
   }
 `;
 
-// tslint:disable-next-line:variable-name
-export const FooterButton = styled.button`
+const flexFooterLinkStyle = css`
   ${footerLinkStyle}
   font-size: inherit;
   cursor: pointer;
@@ -244,6 +243,16 @@ export const FooterButton = styled.button`
   border: none;
   background-color: transparent;
 `;
+
+// tslint:disable-next-line:variable-name
+export const FooterButton = styled.button`
+  ${flexFooterLinkStyle}
+`;
+
+// tslint:disable-next-line:variable-name
+export const ManageCookiesFlexLink = styled(RawCookiesLink)`
+  ${flexFooterLinkStyle}
+`
 
 // tslint:disable-next-line:variable-name
 export const ContactDialog = styled(Modal)`

--- a/src/app/components/Footer/styled.tsx
+++ b/src/app/components/Footer/styled.tsx
@@ -252,7 +252,7 @@ export const FooterButton = styled.button`
 // tslint:disable-next-line:variable-name
 export const ManageCookiesFlexLink = styled(RawCookiesLink)`
   ${flexFooterLinkStyle}
-`
+`;
 
 // tslint:disable-next-line:variable-name
 export const ContactDialog = styled(Modal)`


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1056

I made a mistake by not applying the same style in both places the first time. In my defense, this button does not appear in the dev version.

## Before
<img width="903" height="117" alt="Screenshot 2025-07-17 at 4 29 36 PM" src="https://github.com/user-attachments/assets/2a5f033f-1bdc-4ffc-9f76-efbb6537288a" />

## After
<img width="903" height="117" alt="Screenshot 2025-07-17 at 4 24 38 PM" src="https://github.com/user-attachments/assets/360effa4-5413-4778-bbc6-362bc023d625" />
