### PR TITLE
scroll to target without waiting for images to load

### DIFF
--- a/src/app/content/components/Page.spec.tsx
+++ b/src/app/content/components/Page.spec.tsx
@@ -1308,13 +1308,15 @@ describe('Page', () => {
 
     await Promise.resolve();
     await Promise.resolve();
+    // deferred scroll execution (scrollToTarget uses setImmediate)
+    await new Promise((resolve) => setImmediate(resolve));
 
     const target = root.querySelector('[id="somehash"]');
     expect(target).toBeTruthy();
     expect(scrollTo).toHaveBeenCalledWith(target);
   });
 
-  it('scrolls to selected content on initial load', () => {
+  it('scrolls to selected content on initial load', async() => {
     if (!document) {
       return expect(document).toBeTruthy();
     }
@@ -1334,6 +1336,8 @@ describe('Page', () => {
     archiveLoader.mockPage(book, someHashPage, 'unused?2');
 
     const {root} = renderDomHelper();
+    // deferred scroll execution (scrollToTarget uses setImmediate)
+    await new Promise((resolve) => setImmediate(resolve));
 
     const target = root.querySelector('[id="somehash"]');
 
@@ -1371,8 +1375,8 @@ describe('Page', () => {
     await Promise.resolve();
     // previous processing
     await Promise.resolve();
-    // images loaded
-    await Promise.resolve();
+    // deferred scroll execution (scrollToTarget uses setImmediate)
+    await new Promise((resolve) => setImmediate(resolve));
 
     const target = root.querySelector('[id="somehash"]');
 

--- a/src/app/content/components/Page.spec.tsx
+++ b/src/app/content/components/Page.spec.tsx
@@ -1271,7 +1271,7 @@ describe('Page', () => {
     expect(spy).toHaveBeenCalledWith(0, 0);
   });
 
-  it('waits for images to load before scrolling to a target element', async() => {
+  it('does not wait for images to load before scrolling to a target element', async() => {
     if (!document) {
       return expect(document).toBeTruthy();
     }
@@ -1309,18 +1309,12 @@ describe('Page', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(scrollTo).not.toHaveBeenCalled();
-
-    resolveImageLoaded();
-    await Promise.resolve();
-
     const target = root.querySelector('[id="somehash"]');
-
     expect(target).toBeTruthy();
     expect(scrollTo).toHaveBeenCalledWith(target);
   });
 
-  it('does not scroll to selected content on initial load', () => {
+  it('scrolls to selected content on initial load', () => {
     if (!document) {
       return expect(document).toBeTruthy();
     }
@@ -1344,7 +1338,7 @@ describe('Page', () => {
     const target = root.querySelector('[id="somehash"]');
 
     expect(target).toBeTruthy();
-    expect(scrollTo).not.toHaveBeenCalled();
+    expect(scrollTo).toHaveBeenCalled();
   });
 
   it('scrolls to selected content on update', async() => {

--- a/src/app/content/components/Page/scrollToTopOrHashManager.ts
+++ b/src/app/content/components/Page/scrollToTopOrHashManager.ts
@@ -19,7 +19,7 @@ const scrollToTarget = (container: HTMLElement | null, hash: string) => {
   const target = getScrollTarget(container, hash);
 
   if (target) {
-    scrollTo(target);
+    setImmediate(() => scrollTo(target));
   }
 };
 

--- a/src/app/content/components/Page/scrollToTopOrHashManager.ts
+++ b/src/app/content/components/Page/scrollToTopOrHashManager.ts
@@ -6,7 +6,6 @@ import { assertWindow, memoizeStateToProps } from '../../../utils';
 import { isSearchScrollTarget } from '../../search/guards';
 import { selectedResult } from '../../search/selectors';
 import * as select from '../../selectors';
-import allImagesLoaded from '../utils/allImagesLoaded';
 
 export const mapStateToScrollToTopOrHashProp = memoizeStateToProps((state: AppState) => ({
   hash: selectNavigation.hash(state),
@@ -19,10 +18,8 @@ type ScrollTargetProp = ReturnType<typeof mapStateToScrollToTopOrHashProp>;
 const scrollToTarget = (container: HTMLElement | null, hash: string) => {
   const target = getScrollTarget(container, hash);
 
-  if (target && container) {
-    allImagesLoaded(container).then(
-      () => scrollTo(target)
-    );
+  if (target) {
+    scrollTo(target);
   }
 };
 


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1099

Now that we lazy load images, waiting for the `allImagesLoaded` promise to resolve causes a scroll bug. The images have a set width and height so we can remove the check and scroll immediately without worrying about layout shifting.