### PR TITLE
Core 1316 highlight close issues

### DIFF
--- a/src/app/content/highlights/components/CardWrapper.tsx
+++ b/src/app/content/highlights/components/CardWrapper.tsx
@@ -167,10 +167,14 @@ function CardsForHighlights({
 
   // First time, Esc closes it to the instructions; second Esc disappears it
   const hideCard = () => {
-    if (!focusedHighlight?.elements.length) {
+    if (!focusedHighlight) {
       return;
     }
-    focusedHighlight?.focus();
+    if (focusedHighlight.elements.length) {
+      focusedHighlight.focus();
+    } else {
+      window?.getSelection()?.removeAllRanges();
+    }
     if (shouldFocusCard) {
       setShouldFocusCard(false);
     } else {

--- a/src/app/reactUtils.spec.tsx
+++ b/src/app/reactUtils.spec.tsx
@@ -84,6 +84,19 @@ describe('onFocusInOrOutHandler focusout', () => {
 
     expect(cb).not.toHaveBeenCalled();
   });
+  it('noops when relatedTarget is null', () => {
+    const window = assertWindow();
+    const cb = jest.fn();
+    utils.onFocusInOrOutHandler(ref, true, cb, 'focusout')();
+
+    const focusOutEvent = window.document.createEvent('FocusEvent');
+    // no relatedTarget
+    focusOutEvent.initEvent('focusout', true, false);
+
+    childElement.dispatchEvent(focusOutEvent);
+
+    expect(cb).not.toHaveBeenCalled();
+  });
 });
 
 describe('onFocusInOrOutHandler focusin', () => {

--- a/src/app/reactUtils.ts
+++ b/src/app/reactUtils.ts
@@ -120,7 +120,7 @@ export const onFocusInOrOutHandler = (
 
   const handler = (event: FocusEvent) => {
     const target = type === 'focusout'
-      ? event.relatedTarget
+      ? (event.relatedTarget ?? event.target)
       : event.target;
 
     if (


### PR DESCRIPTION
[CORE-1316]
Two fixes:

1. When text is selected and the highlight instructions box appears, Escape was not dismissing it. Now it does (and unselects the text, because that's the only way to keep the highlight instruction box from reappearing).
2. Clicking in the note textarea would sometimes dismiss the edit window. Adjusted the onFocusInOrOutHandler to stop that. The only other thing using useFocusLost is dropdown menus, and they still work correctly.

[CORE-1316]: https://openstax.atlassian.net/browse/CORE-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ