### PR TITLE
Core 1366 Fix contrast of PQ progress bar unfinished items

### DIFF
--- a/src/app/content/practiceQuestions/components/ProgressBar/ProgressBarItem.tsx
+++ b/src/app/content/practiceQuestions/components/ProgressBar/ProgressBarItem.tsx
@@ -57,7 +57,7 @@ const StyledActiveItem = styled(StyledItem)`
 
 // tslint:disable-next-line: variable-name
 const StyledDisabledItem = styled(StyledItem)`
-  color: #c1c1c1;
+  color: #6e6e6e;
   background-color: #f1f1f1;
   border-color: #f1f1f1;
 `;

--- a/src/app/content/practiceQuestions/components/ProgressBar/__snapshots__/index.spec.tsx.snap
+++ b/src/app/content/practiceQuestions/components/ProgressBar/__snapshots__/index.spec.tsx.snap
@@ -119,7 +119,7 @@ exports[`ProgressBar displays properly 1`] = `
   color: #fff;
   margin: 0 0.4rem;
   font-weight: bold;
-  color: #c1c1c1;
+  color: #6e6e6e;
   background-color: #f1f1f1;
   border-color: #f1f1f1;
 }


### PR DESCRIPTION
[CORE-1366]
Both progress bar changes on Practice Questions

[CORE-1366]: https://openstax.atlassian.net/browse/CORE-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ