### PR TITLE
Rex prerendering optimizations

### DIFF
--- a/script/prerender/cfn.yml
+++ b/script/prerender/cfn.yml
@@ -184,12 +184,32 @@ Resources:
             LaunchTemplateId: !Ref LaunchTemplate
             Version: !GetAtt LaunchTemplate.LatestVersionNumber
           Overrides:
-            - SubnetId: !Sub
+            - InstanceRequirements:
+                AcceleratorCount:
+                  Max: 0
+                BaselinePerformanceFactors:
+                  Cpu:
+                    References:
+                      - InstanceFamily: c5
+                MemoryGiBPerVCpu:
+                  Min: 1
+                  Max: 2
+                MemoryMiB:
+                  Max: 262144
+                  Min: 2048
+                VCpuCount:
+                  Min: 2
+              SubnetId: !Sub
                 - ${Subnet1}, ${Subnet2}, ${Subnet3}
                 - Subnet1: !ImportValue RexPrerenderWorkersSubnet1ID
                   Subnet2: !ImportValue RexPrerenderWorkersSubnet2ID
                   Subnet3: !ImportValue RexPrerenderWorkersSubnet3ID
       ReplaceUnhealthyInstances: true
+      SpotOptions:
+        AllocationStrategy: priceCapacityOptimized
+        FleetSpotCapacityRebalance:
+          ReplacementStrategy: launch-before-terminate
+          TerminationDelay: 120
       TagSpecifications:
         - ResourceType: fleet
           Tags:
@@ -197,7 +217,8 @@ Resources:
               Value: !Sub ${AWS::StackName}-fleet
       TargetCapacitySpecification:
         DefaultTargetCapacityType: spot
-        TotalTargetCapacity: 8
+        TargetCapacityUnitType: memory-mib
+        TotalTargetCapacity: 262144
       TerminateInstancesWithExpiration: true
       ValidUntil: !Ref ValidUntil
 

--- a/script/prerender/cfn.yml
+++ b/script/prerender/cfn.yml
@@ -207,9 +207,10 @@ Resources:
       ReplaceUnhealthyInstances: true
       SpotOptions:
         AllocationStrategy: priceCapacityOptimized
-        FleetSpotCapacityRebalance:
-          ReplacementStrategy: launch-before-terminate
-          TerminationDelay: 120
+        MaintenanceStrategies:
+          CapacityRebalance:
+            ReplacementStrategy: launch-before-terminate
+            TerminationDelay: 120
       TagSpecifications:
         - ResourceType: fleet
           Tags:

--- a/script/prerender/fleet.ts
+++ b/script/prerender/fleet.ts
@@ -460,7 +460,7 @@ async function finishRendering(stats: Stats) {
 }
 
 async function manage() {
-  let deleteWorkersStackPromise: ReturnType<typeof deleteWorkersStack> | undefined = undefined;
+  let deleteWorkersStackPromise: ReturnType<typeof deleteWorkersStack> | undefined;
   const workersStackName = await createWorkersStack();
 
   try {

--- a/script/prerender/fleet.ts
+++ b/script/prerender/fleet.ts
@@ -63,7 +63,7 @@ const MAX_ATTEMPTS = 5;
 const PRERENDER_TIMEOUT_SECONDS = 3600;
 
 // Abort the build if the workers stack is not created/deleted within this many seconds
-const WORKERS_STACK_CREATE_TIMEOUT_SECONDS = 300;
+const WORKERS_STACK_CREATE_TIMEOUT_SECONDS = 600;
 const WORKERS_STACK_DELETE_TIMEOUT_SECONDS = WORKERS_STACK_CREATE_TIMEOUT_SECONDS;
 
 // Docker does not accept forward slashes in the image tag

--- a/script/prerender/fleet.ts
+++ b/script/prerender/fleet.ts
@@ -460,15 +460,17 @@ async function finishRendering(stats: Stats) {
 }
 
 async function manage() {
+  let deleteWorkersStackPromise: ReturnType<typeof deleteWorkersStack> | undefined = undefined;
   const workersStackName = await createWorkersStack();
 
   try {
     const { workQueueUrl, deadLetterQueueUrl } = await getQueueUrls(workersStackName);
     const stats = await queueWork(workQueueUrl);
     await waitUntilWorkDone(workQueueUrl, deadLetterQueueUrl, stats);
+    deleteWorkersStackPromise = deleteWorkersStack(workersStackName);
     await finishRendering(stats);
   } finally {
-    await deleteWorkersStack(workersStackName);
+    await (deleteWorkersStackPromise ?? deleteWorkersStack(workersStackName));
   }
 }
 


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-771

- In order to make it easier for us to get spot instances for Rex prerendering, instead of requesting a specific spot instance class, request:
  - At least c5 instance family CPU performance
  - At least 2 vCPU
  - From 1GB to 2GB of ram per vCPU
  - 256GB ram total (each container uses 1GB)
  - No accelerators (GPU etc)
  - Grab the cheapest instances from the spot pools that actually have available capacity
  - Launch new instances if current spot instances get terminated

- Begin deleting prerendering workers stack while generating Rex redirects
   This is a small optimization to begin deleting the Rex prerendering workers stack while generating redirects (which don't use the workers).