### PR TITLE
Fix validateLinks params in book scripts

### DIFF
--- a/concourse/book-scan/script.bash
+++ b/concourse/book-scan/script.bash
@@ -8,4 +8,4 @@ cd rex-web
 
 yarn install --network-timeout 60000
 
-node script/entry.js domVisitor errorsExist --osWebUrl="https://openstax.org" --rootUrl="https://$cloudfront_environment" --queryString="validateLinks"
+node script/entry.js domVisitor errorsExist --osWebUrl="https://openstax.org" --rootUrl="https://$cloudfront_environment"

--- a/script/validate-modified-books.bash
+++ b/script/validate-modified-books.bash
@@ -13,7 +13,7 @@ while read -r row; do
     --bookId="$book_id" \
     --bookVersion="$book_version" \
     --rootUrl="$BASE_URL" \
-    --queryString="validateLinks" \
+    --queryString="validateLinks=true" \
     || code=1
 
   if [ "$is_new" == false ]; then

--- a/src/app/navigation/selectors.ts
+++ b/src/app/navigation/selectors.ts
@@ -46,6 +46,7 @@ export const systemQueryParameters = createSelector(
     archive: navQuery.archive,
     'content-style': navQuery['content-style'],
     osWeb: navQuery.osWeb,
+    validateLinks: navQuery.validateLinks,
   })
 );
 


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1466

This PR fixes the validateLinks param in validate-modified-books, and makes it persist on link navigation. This should work with the current config, as validate-modified-books runs against a review environment, which uses the development config. This param is needed if one of the modified books is retired, otherwise an error would be thrown. As a side-effect, broken link checks will cause warnings instead of failing the build, which I'm not sure is a good thing (but maybe there's a reason this behavior was added that I don't know at the moment).

It also removes the queryString from the book-scan (which usually runs against sandbox envs, which use the prod config). It doesn't seem to be necessary for the book scan anyway. (The book scan already skips retired books)

It seems the main tradeoff is that the script won't fail for retired books, but on the other hand invalid links will only be warnings and won't cause validate-modified-books to fail.

If anyone thinks we should instead remove the more lenient link check behavior when UNLIMITED_CONTENT is enabled, or do something completely different, I'm all ears.