### PR TITLE
Core-1308: Highlight markers have textContent

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@craco/craco": "<7",
     "@formatjs/intl-pluralrules": "^5.2.3",
     "@openstax/event-capture-client": "^2.0.2",
-    "@openstax/highlighter": "https://github.com/openstax/highlighter#1.16.3",
+    "@openstax/highlighter": "https://github.com/openstax/highlighter#1.16.4b",
     "@openstax/open-search-client": "0.1.0-build.7",
     "@openstax/ts-utils": "1.19.0",
     "@openstax/ui-components": "openstax/ui-components#1.14.0",

--- a/src/app/content/__snapshots__/routes.spec.tsx.snap
+++ b/src/app/content/__snapshots__/routes.spec.tsx.snap
@@ -550,6 +550,19 @@ Array [
   transform: rotate(90deg);
 }
 
+.c4 [data-for-screenreaders="true"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .c4 .os-figure,
 .c4 .os-figure:last-child {
   margin-bottom: 5px;
@@ -729,20 +742,6 @@ Array [
 
   .c4 .search-highlight[aria-current] .search-highlight {
     background-color: unset;
-  }
-
-  .c4 .search-highlight [data-for-screenreaders="true"]::before {
-    content: attr(data-message);
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    -webkit-clip: rect(0,0,0,0);
-    clip: rect(0,0,0,0);
-    white-space: nowrap;
-    border: 0;
   }
 }
 

--- a/src/app/content/components/Page/PageContent.tsx
+++ b/src/app/content/components/Page/PageContent.tsx
@@ -181,12 +181,11 @@ export default styled(MainContent)`
           background-color: unset;
         }
       }
-
-      [data-for-screenreaders="true"]::before {
-        content: attr(data-message);
-        ${hiddenButAccessible}
-      }
     }
+  }
+
+  [data-for-screenreaders="true"] {
+    ${hiddenButAccessible}
   }
 
   .os-figure,

--- a/src/app/content/components/__snapshots__/Content.spec.tsx.snap
+++ b/src/app/content/components/__snapshots__/Content.spec.tsx.snap
@@ -976,6 +976,19 @@ Array [
   transform: rotate(90deg);
 }
 
+.c73 [data-for-screenreaders="true"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .c73 .os-figure,
 .c73 .os-figure:last-child {
   margin-bottom: 5px;
@@ -2386,20 +2399,6 @@ Array [
 
   .c73 .search-highlight[aria-current] .search-highlight {
     background-color: unset;
-  }
-
-  .c73 .search-highlight [data-for-screenreaders="true"]::before {
-    content: attr(data-message);
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    -webkit-clip: rect(0,0,0,0);
-    clip: rect(0,0,0,0);
-    white-space: nowrap;
-    border: 0;
   }
 }
 
@@ -8288,6 +8287,19 @@ Array [
   transform: rotate(90deg);
 }
 
+.c73 [data-for-screenreaders="true"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .c73 .os-figure,
 .c73 .os-figure:last-child {
   margin-bottom: 5px;
@@ -9545,20 +9557,6 @@ Array [
 
   .c73 .search-highlight[aria-current] .search-highlight {
     background-color: unset;
-  }
-
-  .c73 .search-highlight [data-for-screenreaders="true"]::before {
-    content: attr(data-message);
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    -webkit-clip: rect(0,0,0,0);
-    clip: rect(0,0,0,0);
-    white-space: nowrap;
-    border: 0;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5259,9 +5259,9 @@
   dependencies:
     uuid "^8.3.2"
 
-"@openstax/highlighter@https://github.com/openstax/highlighter#1.16.3":
-  version "1.16.3"
-  resolved "https://github.com/openstax/highlighter#500e0bc4331267c2b565c04c5856eefc3415acf5"
+"@openstax/highlighter@https://github.com/openstax/highlighter#1.16.4b":
+  version "1.16.4"
+  resolved "https://github.com/openstax/highlighter#702b3c1241106505240df188b3113b92d29dca5b"
   dependencies:
     "@openstax/highlights-client" "0.2.3"
     change-case "^4.0.0"


### PR DESCRIPTION
[CORE-1308]
Uses [version of Highlighter](https://github.com/openstax/highlighter/pull/89) that puts textContent in the screenreader spans and makes those markers hidden-but-accessible.

[CORE-1308]: https://openstax.atlassian.net/browse/CORE-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ