### PR TITLE
Core-1561: Fix hover color contrast

### DIFF
--- a/src/app/content/keyboardShortcuts/components/__snapshots__/KeyboardShortcutsPopup.spec.tsx.snap
+++ b/src/app/content/keyboardShortcuts/components/__snapshots__/KeyboardShortcutsPopup.spec.tsx.snap
@@ -111,7 +111,7 @@ exports[`KeyboardShortcuts renders keyboard shortcuts modal if it is open 1`] = 
 }
 
 .c6:hover {
-  color: #424242;
+  color: #888888;
 }
 
 .c7 {

--- a/src/app/content/practiceQuestions/components/__snapshots__/PracticeQuestionsPopup.spec.tsx.snap
+++ b/src/app/content/practiceQuestions/components/__snapshots__/PracticeQuestionsPopup.spec.tsx.snap
@@ -125,7 +125,7 @@ exports[`PracticeQuestions renders practice questions modal if it is open 1`] = 
 }
 
 .c5:hover {
-  color: #424242;
+  color: #888888;
 }
 
 .c15 {

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -41,6 +41,7 @@ const greyColors = {
   foreground: textColors.white,
   foregroundHover: '#424242',
   light: '#767676', // lightest allowed for text on white background
+  medium: '#888888', // suitable for darkening white on a dark background
   lighter: '#c5c5c5',
   lightest: '#ededed',
 };
@@ -71,45 +72,45 @@ const color = {
     'blue': {
       base: '#002468',
       foreground: textColors.white,
-      foregroundHover: greyColors.darker,
+      foregroundHover: greyColors.medium,
     },
     'deep-green': {
       base: '#067056',
       foreground: textColors.white,
-      foregroundHover: greyColors.darker,
+      foregroundHover: greyColors.lighter,
     },
     'gray': greyColors,
     'green': {
       base: '#63a524',
       foreground: textColors.black,
-      foregroundHover: greyColors.light,
+      foregroundHover: greyColors.darker,
     },
     'light-blue': {
       base: '#0DC0DC',
       foreground: textColors.black,
-      foregroundHover: greyColors.light,
+      foregroundHover: greyColors.darker,
     },
     'midnight': {
       base: '#003e52',
       foreground: textColors.white,
-      foregroundHover: greyColors.darker,
+      foregroundHover: greyColors.medium,
     },
     'orange': {
       base: '#d4450c',
       darker: '#be3c08',
       darkest: '#b03808',
       foreground: textColors.white,
-      foregroundHover: greyColors.darker,
+      foregroundHover: greyColors.lightest,
     },
     'raise-green': {
       base: '#0a5b50',
       foreground: textColors.white,
-      foregroundHover: greyColors.darker,
+      foregroundHover: greyColors.lighter,
     },
     'red': {
       base: '#C22032',
       foreground: textColors.white,
-      foregroundHover: greyColors.darker,
+      foregroundHover: greyColors.lighter,
     },
     'yellow': {
       base: '#f4d019',


### PR DESCRIPTION
[CORE-1561]
Ensure that each foregroundHover color (used for the close icon in dialogs) has contrast of at least 3.0 against the base color

[CORE-1561]: https://openstax.atlassian.net/browse/CORE-1561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ