### PR TITLE
CORE-1574 Disable build failure due to verify-production-urls

### DIFF
--- a/concourse/verify-production-urls/script.bash
+++ b/concourse/verify-production-urls/script.bash
@@ -35,7 +35,7 @@ missing_files=$(diff_file_lists "$current_files" "$new_release_files")
 
 if [ -n "$missing_files" ]; then
   printf "MISSING PATHS:\n%s\n" "$missing_files"
-  exit 1
+  #exit 1
+else
+  echo 'all current release files also present in the new release'
 fi
-
-echo 'all current release files also present in the new release'

--- a/script/prerender/cfn.yml
+++ b/script/prerender/cfn.yml
@@ -196,7 +196,7 @@ Resources:
                 BaselinePerformanceFactors:
                   Cpu:
                     References:
-                      - InstanceFamily: r6a
+                      - InstanceFamily: r5
                 MemoryGiBPerVCpu:
                   Min: 4
                   Max: 8


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1574

- Disable build failure due to verify-production-urls 
- Also allow m5, r5 instances once more (to try to avoid lack of spot capacity)