### PR TITLE
CORE-1548: Fix key term aria-label to include visible text at start

### DIFF
--- a/src/app/content/search/components/SearchResultsSidebar/SearchResultHits.tsx
+++ b/src/app/content/search/components/SearchResultsSidebar/SearchResultHits.tsx
@@ -56,7 +56,18 @@ function useKeyTermPair({
   return pair;
 }
 
-function uniqueSearchLabel(index: number, title: string, highlight: string) {
+function uniqueSearchLabel(
+  index: number,
+  title: string,
+  highlight: string,
+  isKeyTerm: boolean,
+  keyTermName?: string
+) {
+  if (isKeyTerm && keyTermName) {
+    // For key terms: "[Term]: [definition] (Result N in Key Terms)"
+    return `${stripHtml(keyTermName)}: ${stripHtml(highlight)} (Result ${index + 1} in ${stripHtml(title)})`;
+  }
+  // For regular search results: keep existing format
   return `Result ${index + 1} in ${stripHtml(title)}: ${stripHtml(highlight)}`;
 }
 
@@ -94,7 +105,7 @@ const OneSearchResultHit = ({
           scrollTarget={target}
           queryParams={queryParams}
           onClick={() => onClick(thisResult)}
-          aria-label={uniqueSearchLabel(index, page.title, highlight)}
+          aria-label={uniqueSearchLabel(index, page.title, highlight, isKeyTermHit(hit), pair?.term)}
           ref={isSelected ? activeSectionRef : undefined}
         >
           {isKeyTermHit(hit) ? (

--- a/src/app/content/search/components/SearchResultsSidebar/SearchResultHits.tsx
+++ b/src/app/content/search/components/SearchResultsSidebar/SearchResultHits.tsx
@@ -63,12 +63,12 @@ function uniqueSearchLabel(
   isKeyTerm: boolean,
   keyTermName?: string
 ) {
+  const extraText = `(Result ${index + 1} in ${stripHtml(title)})`;
+
   if (isKeyTerm && keyTermName) {
-    // For key terms: "[Term]: [definition] (Result N in Key Terms)"
-    return `${stripHtml(keyTermName)}: ${stripHtml(highlight)} (Result ${index + 1} in ${stripHtml(title)})`;
+    return `${stripHtml(keyTermName)}: ${stripHtml(highlight)} ${extraText}`;
   }
-  // For regular search results: keep existing format
-  return `Result ${index + 1} in ${stripHtml(title)}: ${stripHtml(highlight)}`;
+  return `${stripHtml(highlight)} ${extraText}`;
 }
 
 const OneSearchResultHit = ({
@@ -121,7 +121,7 @@ const OneSearchResultHit = ({
         </Styled.SectionContentPreview>
       );
     },
-    [activeSectionRef, book, getPage, hit, onClick, queryParams, selectedResult, testId]
+    [activeSectionRef, book, getPage, hit, onClick, queryParams, selectedResult, testId, pair?.term]
   );
 
   // inefficient data structure for search results should be addressed in the future

--- a/src/app/content/search/components/SearchResultsSidebar/__snapshots__/index.spec.tsx.snap
+++ b/src/app/content/search/components/SearchResultsSidebar/__snapshots__/index.spec.tsx.snap
@@ -876,7 +876,7 @@ exports[`SearchResultsSidebar matches snapshot with related key terms 1`] = `
       </h3>
       <a
         aria-current={true}
-        aria-label="Result 1 in Test Page 1: test definition with …"
+        aria-label="test term: test definition with … (Result 1 in Test Page 1)"
         className="c15 c16"
         data-testid="related-key-term-result"
         href="books/book-slug-1/pages/test-page-1?target=%7B%22index%22%3A0%2C%22type%22%3A%22search%22%7D#test-pair-page1"
@@ -901,7 +901,7 @@ exports[`SearchResultsSidebar matches snapshot with related key terms 1`] = `
       </a>
       <a
         aria-current={false}
-        aria-label="Result 1 in Test Page 6 with special characters in url: test definition"
+        aria-label="test term: test definition (Result 1 in Test Page 6 with special characters in url)"
         className="c15 c19"
         data-testid="related-key-term-result"
         href="books/book-slug-1/pages/10-test-page-6-f%C3%ADsica?target=%7B%22index%22%3A0%2C%22type%22%3A%22search%22%7D#test-pair-page6"
@@ -1006,7 +1006,7 @@ exports[`SearchResultsSidebar matches snapshot with related key terms 1`] = `
               </div>
               <a
                 aria-current={false}
-                aria-label="Result 1 in Test Page 7: cool highlight bruh"
+                aria-label="cool highlight bruh (Result 1 in Test Page 7)"
                 className="c15 c19"
                 data-testid="search-result"
                 href="books/book-slug-1/pages/12-test-page-7?target=%7B%22index%22%3A0%2C%22type%22%3A%22search%22%7D#fs-id1544727"
@@ -1587,7 +1587,7 @@ exports[`SearchResultsSidebar matches snapshot with results 1`] = `
         </div>
         <a
           aria-current={true}
-          aria-label="Result 1 in Test Page 1: cool highlight bruh"
+          aria-label="cool highlight bruh (Result 1 in Test Page 1)"
           className="c18 c19"
           data-testid="search-result"
           href="books/book-slug-1/pages/test-page-1?query=cool%20search&target=%7B%22index%22%3A0%2C%22type%22%3A%22search%22%7D#fs-id1544727"
@@ -1679,7 +1679,7 @@ exports[`SearchResultsSidebar matches snapshot with results 1`] = `
               </div>
               <a
                 aria-current={false}
-                aria-label="Result 1 in Test Page 6 with special characters in url: cool highlight bruh"
+                aria-label="cool highlight bruh (Result 1 in Test Page 6 with special characters in url)"
                 className="c18 c33"
                 data-testid="search-result"
                 href="books/book-slug-1/pages/10-test-page-6-f%C3%ADsica?query=cool%20search&target=%7B%22index%22%3A0%2C%22type%22%3A%22search%22%7D#fs-id1544727"
@@ -1773,7 +1773,7 @@ exports[`SearchResultsSidebar matches snapshot with results 1`] = `
               </div>
               <a
                 aria-current={false}
-                aria-label="Result 1 in Test Page 7: cool highlight bruh"
+                aria-label="cool highlight bruh (Result 1 in Test Page 7)"
                 className="c18 c33"
                 data-testid="search-result"
                 href="books/book-slug-1/pages/12-test-page-7?query=cool%20search&target=%7B%22index%22%3A0%2C%22type%22%3A%22search%22%7D#fs-id1544727"


### PR DESCRIPTION
## Summary

This PR fixes the key term search result aria-labels to comply with both WCAG 2.5.3 (Label in Name) and WCAG 2.4.4 (Link Purpose).

Fixes: [CORE-1548](https://openstax.atlassian.net/browse/CORE-1548)
Related: [CORE-799](https://openstax.atlassian.net/browse/CORE-799)

## The Problem

We had two conflicting WCAG requirements:
- **WCAG 2.4.4 (Level A)**: Links must have unique, meaningful names (addressed in CORE-799)
- **WCAG 2.5.3 (Level A)**: Accessible name must START with the visible label text (this issue)

**Current aria-label**: `"Result 1 in Key Terms: rotational analog of linear momentum..."`  
**Visible text**: `"Angular momentum..."`

The visible text wasn't at the start of the aria-label, preventing speech input users from saying "click Angular momentum" to activate the link.

## The Solution

Reorder the aria-label to put the key term FIRST, then add the disambiguating context:

**New aria-label format**: `"[Key Term]: [definition] (Result [N] in Key Terms)"`  
**Example**: `"Angular momentum: rotational analog of linear momentum... (Result 1 in Key Terms)"`

## Why This Works

✅ **WCAG 2.5.3 Compliance**: The visible text "Angular momentum" now appears at the START of the aria-label  
✅ **WCAG 2.4.4 Compliance**: The "(Result 1 in Key Terms)" suffix still provides unique context  
✅ **Better UX**: Screen reader users hear the key term first, then definition, then location context

## Changes Made

- Modified `uniqueSearchLabel` function in `SearchResultHits.tsx` to handle key terms specially
- Updated call site to pass `isKeyTerm` flag and `keyTermName` when available
- Regular search results maintain their existing format (unchanged)

## Testing

The test snapshots will need to be updated to reflect the new aria-label format for key term results. CI will handle running tests and we can update snapshots as needed.

**Manual Testing Steps**:
1. Search for "angular momentum" on a physics textbook
2. Inspect key term results in Chrome DevTools
3. Verify aria-label starts with the key term name
4. Test with screen reader to verify announcement is clear
5. Verify multiple results have unique aria-labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-1548]: https://openstax.atlassian.net/browse/CORE-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-799]: https://openstax.atlassian.net/browse/CORE-799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ