### PR TITLE
Core-1503: Use updated ui-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@openstax/highlighter": "https://github.com/openstax/highlighter#1.16.4b",
     "@openstax/open-search-client": "0.1.0-build.7",
     "@openstax/ts-utils": "1.19.0",
-    "@openstax/ui-components": "openstax/ui-components#1.20.0",
+    "@openstax/ui-components": "openstax/ui-components#1.21.1",
     "@sentry/integrations": "^7.54.0",
     "@sentry/react": "^7.54.0",
     "classnames": "2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5305,9 +5305,9 @@
   resolved "https://registry.yarnpkg.com/@openstax/types/-/types-3.1.0.tgz#364a73e321127dfb1cfa36adccdae8e21a0805dc"
   integrity sha512-vy9nFdfw/nRX7iYjpl1CPxHwr8dIog+WVlDQr+EeD31HQ9uQX4I+cNV7jmvx1oiMIofSdrM+OBbmPC9qzAJK+w==
 
-"@openstax/ui-components@openstax/ui-components#1.20.0":
-  version "1.20.0"
-  resolved "https://codeload.github.com/openstax/ui-components/tar.gz/b2567a4283743099ab7f96f2b072eb81e0ad5436"
+"@openstax/ui-components@openstax/ui-components#1.21.1":
+  version "1.21.0"
+  resolved "https://codeload.github.com/openstax/ui-components/tar.gz/dc52d5faedfa98498d89578302ceed0fbe90b2a1"
   dependencies:
     "@sentry/react" "^7.120.3"
     classnames "^2.3.1"


### PR DESCRIPTION
[CORE-1503]
### Before merging
This refers to a tag of unmerged commits on ui-components.

- [x]  That PR should be merged 
- [x]  A new official ui-components tag should be created
- [x]  This PR should be updated to use the new tag

[CORE-1503]: https://openstax.atlassian.net/browse/CORE-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ