### PR TITLE
Core-1566: use aria-current="page" instead of aria-label="Current Page"

### DIFF
--- a/script/domVisitor.ts
+++ b/script/domVisitor.ts
@@ -124,7 +124,7 @@ async function visitPages(
 
               linkElt.click();
             }, linkSelector);
-            await page.waitForSelector(`${linkSelector}[aria-label*="Current Page"]`);
+            await page.waitForSelector(`${linkSelector}[aria-current="page"]`);
           } else {
             await page.goto(decodeURI(`${rootUrl}${pageUrl}${appendQueryString}`));
           }

--- a/src/app/content/components/TableOfContents/index.spec.tsx
+++ b/src/app/content/components/TableOfContents/index.spec.tsx
@@ -3,7 +3,7 @@ import { unmountComponentAtNode } from 'react-dom';
 import { act as reactDomAct } from 'react-dom/test-utils';
 import renderer from 'react-test-renderer';
 import { HTMLElement } from '@openstax/types/lib.dom';
-import ConnectedTableOfContents, { TableOfContents, maybeAriaLabel } from '.';
+import ConnectedTableOfContents, { TableOfContents, maybeAriaAttributes } from '.';
 import createTestStore from '../../../../test/createTestStore';
 import { book as archiveBook, page, shortPage } from '../../../../test/mocks/archiveLoader';
 import { mockCmsBook } from '../../../../test/mocks/osWebLoader';
@@ -417,7 +417,7 @@ describe('TableOfContents', () => {
   });
 });
 
-describe('maybeAriaLabel', () => {
+describe('maybeAriaAttributes', () => {
   const mockPage = {
     id: 'some-id',
     title: '<span class="os-number">1</span><span class="os-divider"> </span><span class="os-text">chapter 1</span>',
@@ -426,13 +426,13 @@ describe('maybeAriaLabel', () => {
     },
   } as any;
 
-  it('returns aria-label when active is true', () => {
-    const result = maybeAriaLabel(mockPage, true);
+  it('returns aria-current="page" when active is true', () => {
+    const result = maybeAriaAttributes(mockPage, true);
     expect(result).toEqual({ 'aria-current': 'page' });
   });
 
   it('returns empty object when active is false', () => {
-    const result = maybeAriaLabel(mockPage, false);
+    const result = maybeAriaAttributes(mockPage, false);
     expect(result).toEqual({});
   });
 });

--- a/src/app/content/components/TableOfContents/index.spec.tsx
+++ b/src/app/content/components/TableOfContents/index.spec.tsx
@@ -435,4 +435,20 @@ describe('maybeAriaAttributes', () => {
     const result = maybeAriaAttributes(mockPage, false);
     expect(result).toEqual({});
   });
+
+  it('returns aria-current and disambiguating aria-label when title has no number but parent has number', () => {
+    const pageWithParentNumber = {
+      ...mockPage,
+      title: 'Chapter summary', // no number in the title itself
+      parent: {
+        title: '<span class="os-number">1</span><span class="os-divider"> </span><span class="os-text">chapter 1</span>',
+      },
+    } as any;
+
+    const result = maybeAriaAttributes(pageWithParentNumber, true);
+
+    expect(result['aria-current']).toBe('page');
+    expect(typeof result['aria-label']).toBe('string');
+    expect(result['aria-label']).not.toMatch(/Current Page/i);
+  });
 });

--- a/src/app/content/components/TableOfContents/index.spec.tsx
+++ b/src/app/content/components/TableOfContents/index.spec.tsx
@@ -428,7 +428,7 @@ describe('maybeAriaLabel', () => {
 
   it('returns aria-label when active is true', () => {
     const result = maybeAriaLabel(mockPage, true);
-    expect(result).toEqual({ 'aria-label': 'Current Page' });
+    expect(result).toEqual({ 'aria-current': 'page' });
   });
 
   it('returns empty object when active is false', () => {

--- a/src/app/content/components/TableOfContents/index.tsx
+++ b/src/app/content/components/TableOfContents/index.tsx
@@ -175,17 +175,17 @@ function ArchiveTreeComponent({
   );
 }
 
-export function maybeAriaLabel(page: LinkedArchiveTreeSection, active?: boolean) {
+export function maybeAriaAttributes(page: LinkedArchiveTreeSection, active?: boolean) {
   const [num, titleText] = splitTitleParts(page.title);
-  const currentPageAriaLabel = { 'aria-current': 'page' };
+  const currentPageIndicator = { 'aria-current': 'page' };
   if (num) {
-    return active ? currentPageAriaLabel : {};
+    return active ? currentPageIndicator : {};
   }
 
   const [parentNum, parentTitleText] = splitTitleParts(page.parent.title);
 
   if (!parentNum || titleText.includes(parentTitleText)) {
-    return active ? currentPageAriaLabel : {};
+    return active ? currentPageIndicator : {};
   }
 
   const activeAriaLabel = active ? '- Current Page' : '';
@@ -234,7 +234,7 @@ function TocLeaf({
           book={book}
           page={item}
           dangerouslySetInnerHTML={{ __html: item.title }}
-          {...maybeAriaLabel(item, active)}
+          {...maybeAriaAttributes(item, active)}
         />
       </Styled.NavItem>
     </Styled.StyledTreeItem>

--- a/src/app/content/components/TableOfContents/index.tsx
+++ b/src/app/content/components/TableOfContents/index.tsx
@@ -175,7 +175,10 @@ function ArchiveTreeComponent({
   );
 }
 
-export function maybeAriaAttributes(page: LinkedArchiveTreeSection, active?: boolean) {
+export function maybeAriaAttributes(page: LinkedArchiveTreeSection, active?: boolean): {
+  'aria-current'?: string;
+  'aria-label'?: string;
+} {
   const [num, titleText] = splitTitleParts(page.title);
   const currentPageIndicator = { 'aria-current': 'page' };
   if (num) {
@@ -188,9 +191,10 @@ export function maybeAriaAttributes(page: LinkedArchiveTreeSection, active?: boo
     return active ? currentPageIndicator : {};
   }
 
-  const activeAriaLabel = active ? '- Current Page' : '';
-
-  return { 'aria-label': `${titleText} - Chapter ${parentNum} ${activeAriaLabel}` };
+  return {
+    'aria-label': `${titleText} - Chapter ${parentNum}`,
+    ...(active ? currentPageIndicator : {}),
+  };
 }
 
 function TocLeaf({

--- a/src/app/content/components/TableOfContents/index.tsx
+++ b/src/app/content/components/TableOfContents/index.tsx
@@ -177,7 +177,7 @@ function ArchiveTreeComponent({
 
 export function maybeAriaLabel(page: LinkedArchiveTreeSection, active?: boolean) {
   const [num, titleText] = splitTitleParts(page.title);
-  const currentPageAriaLabel = { 'aria-label': 'Current Page' };
+  const currentPageAriaLabel = { 'aria-current': 'page' };
   if (num) {
     return active ? currentPageAriaLabel : {};
   }

--- a/src/app/content/components/TableOfContents/styled/index.tsx
+++ b/src/app/content/components/TableOfContents/styled/index.tsx
@@ -17,7 +17,7 @@ export { ExpandIcon, CollapseIcon } from '../../../../components/Details';
     (result, char) => (result[char] = ((element.innerText = char) && element.getBoundingClientRect().width)) && result,
     {}
   )
-)(element = document.querySelector('[data-testid=toc] [aria-label="Current Page"] a')
+)(element = document.querySelector('[data-testid=toc] a[aria-current="page"]')
   .appendChild(document.createElement('span'))
 );
  */
@@ -47,7 +47,7 @@ export const ContentLink = styled(ContentLinkComponent)`
   margin-left: ${iconSize}rem;
   text-decoration: none;
 
-  &[aria-label$="Current Page"] {
+  &[aria-current="page"] {
     font-weight: 600;
   }
 

--- a/src/app/content/content.browserspec.ts
+++ b/src/app/content/content.browserspec.ts
@@ -124,7 +124,7 @@ const clickTocLink = (href: string) => page.evaluate(async(href) => {
 const getSelectedTocSection = () => page.evaluate(() => {
   const toc = document && document.querySelector('[data-testid="toc"]');
 
-  const a = toc && toc.querySelector('a[aria-current$="page"]');
+  const a = toc && toc.querySelector('a[aria-current="page"]');
   const href = a && a.attributes.getNamedItem('href');
 
   return href && href.value;

--- a/src/app/content/content.browserspec.ts
+++ b/src/app/content/content.browserspec.ts
@@ -124,7 +124,7 @@ const clickTocLink = (href: string) => page.evaluate(async(href) => {
 const getSelectedTocSection = () => page.evaluate(() => {
   const toc = document && document.querySelector('[data-testid="toc"]');
 
-  const a = toc && toc.querySelector('a[aria-label$="Current Page"]');
+  const a = toc && toc.querySelector('a[aria-current$="page"]');
   const href = a && a.attributes.getNamedItem('href');
 
   return href && href.value;


### PR DESCRIPTION
[CORE-1566] Claude said to push back on the use of treegrid -- it's correct. It also noted this weird use of aria-label which is better replaced with aria-current. So I did.

[CORE-1566]: https://openstax.atlassian.net/browse/CORE-1566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ