### PR TITLE
Phase 1.2: Container Components Migration

### DIFF
--- a/PLAIN_CSS_MIGRATION_LEARNINGS.md
+++ b/PLAIN_CSS_MIGRATION_LEARNINGS.md
@@ -257,6 +257,71 @@ Cross-reference the original styled-components code to ensure the media query lo
 
 ---
 
+## Redux Integration Patterns
+
+### Upgrade from connect() HOC to Hooks
+
+**Issue (Phase 1.2)**: When migrating components that use Redux's `connect()` HOC, the HOC passes a `dispatch` prop that can leak to DOM elements when using `...props` spreading.
+
+**Warning Signs**:
+- React warnings about invalid DOM props (e.g., "Warning: React does not recognize the `dispatch` prop on a DOM element")
+- TypeScript errors about unused parameters
+- Unexpected props appearing on DOM elements
+
+**Resolution**: Replace `connect()` HOC with Redux hooks (`useSelector`, `useDispatch`):
+
+**Before (connect HOC)**:
+```typescript
+import { connect } from 'react-redux';
+
+const Wrapper = ({ hasQuery, verticalNavOpen, children, ...props }) => (
+  <div {...props}> {/* dispatch leaks to DOM here */}
+    {children}
+  </div>
+);
+
+export default connect(
+  (state: AppState) => ({
+    hasQuery: !!selectSearch.query(state),
+    verticalNavOpen: contentSelectors.mobileMenuOpen(state),
+  })
+)(Wrapper);
+```
+
+**After (hooks)**:
+```typescript
+import { useSelector } from 'react-redux';
+
+// Named export for testing - accepts props directly
+export const Wrapper = ({ verticalNavOpen, children, ...props }) => (
+  <div {...props}>
+    {children}
+  </div>
+);
+
+// Default export with Redux hooks - selects state internally
+const WrapperConnected = ({ children, ...props }) => {
+  const verticalNavOpen = useSelector((state: AppState) =>
+    contentSelectors.mobileMenuOpen(state)
+  );
+
+  return <Wrapper verticalNavOpen={verticalNavOpen} {...props}>{children}</Wrapper>;
+};
+
+export default WrapperConnected;
+```
+
+**Benefits**:
+- ✅ No `dispatch` prop leaking to DOM elements
+- ✅ Cleaner separation of concerns (state selection vs presentation)
+- ✅ Easier to test (named export accepts props directly)
+- ✅ Modern React patterns (hooks are the recommended approach)
+- ✅ Better TypeScript inference
+
+**For Future Phases**: Whenever you edit a component that uses `connect()`, take the opportunity to upgrade it to hooks. This is especially important when migrating to plain CSS, as you're already touching the component structure.
+
+---
+
 ## Testing Requirements
 
 ### Test All Heading Levels
@@ -391,6 +456,7 @@ Use this checklist when migrating additional components from styled-components t
 - [ ] Extract shared constants into `.constants.ts` files (no side effects)
 - [ ] Create `.legacy.ts` files for backward-compatible styled-components exports
 - [ ] Use selective exports in index files to avoid conflicts
+- [ ] Upgrade Redux `connect()` to hooks (`useSelector`, `useDispatch`) when editing connected components
 
 ### Testing
 - [ ] Add snapshot tests for all component variations

--- a/PLAIN_CSS_MIGRATION_LEARNINGS.md
+++ b/PLAIN_CSS_MIGRATION_LEARNINGS.md
@@ -1,14 +1,15 @@
-# Phase 1.1: Typography Migration - Learnings & Best Practices
+# Plain CSS Migration - Learnings & Best Practices
 
-This document captures key learnings from the Phase 1.1 Typography Components Migration, documenting issues encountered and resolutions to help guide future migration phases.
+This document captures key learnings from the styled-components to plain CSS migration, documenting issues encountered and resolutions to help guide future migration phases.
 
 ## Table of Contents
 1. [Migration Strategy](#migration-strategy)
 2. [Module Structure & Dependencies](#module-structure--dependencies)
 3. [CSS Variables & Theming](#css-variables--theming)
-4. [Testing Requirements](#testing-requirements)
-5. [Code Organization](#code-organization)
-6. [Checklist for Future Phases](#checklist-for-future-phases)
+4. [Responsive Design & Media Queries](#responsive-design--media-queries)
+5. [Testing Requirements](#testing-requirements)
+6. [Code Organization](#code-organization)
+7. [Checklist for Future Phases](#checklist-for-future-phases)
 
 ---
 
@@ -161,6 +162,98 @@ style={{
 ```
 
 **For Future Phases**: Never duplicate constant values between TypeScript and CSS. Use the TypeScript → CSS variable binding pattern.
+
+---
+
+## Responsive Design & Media Queries
+
+### Understanding rem vs em in Media Queries
+
+**Issue (Phase 1.2)**: Initial breakpoint values were incorrect because raw `rem` values were used directly in media queries instead of converting to `em` units.
+
+**Background**: The rex-web codebase uses a custom base font size:
+- The `html` element has `font-size: 62.5%`, making `1rem = 10px` (62.5% of 16px default)
+- However, media queries use `em` units based on the browser's default font size (typically 16px)
+- This means `1rem = 10px` but `1em = 16px` in media query contexts
+
+**Resolution**: Always use the `remsToEms()` conversion function when converting layout dimensions from `rem` to `em` for media queries:
+
+```typescript
+// Conversion formula
+remsToEms = (rems) => rems * 10 / 16
+
+// Example
+contentWrapperMaxWidth = 128 // rem
+breakpoint = remsToEms(128) = 128 * 10/16 = 80 // em
+```
+
+**Common Mistakes**:
+```css
+/* ❌ Bad - using rem value directly as em */
+@media screen and (max-width: 128em) {
+  /* This is actually 2048px, not 1280px! */
+}
+
+/* ✅ Good - converted using remsToEms() */
+@media screen and (max-width: 80em) {
+  /* Correctly evaluates to 1280px (80 * 16) */
+}
+```
+
+**For Future Phases**: Always convert rem dimensions to em for media queries using the `remsToEms()` formula. Never use rem values directly as em values.
+
+### Document Hard-Coded Breakpoint Calculations
+
+**Issue (Phase 1.2)**: Media query breakpoints in CSS files are static values derived from TypeScript constants. If the constants change, the CSS breakpoints won't automatically update.
+
+**Resolution**: Add comprehensive inline documentation in CSS files explaining:
+1. The source constants from TypeScript
+2. The step-by-step calculation
+3. The conversion formula (rems * 10/16 = ems)
+4. References to exported constant names
+5. An explicit warning about maintenance
+
+**Example Documentation Pattern**:
+```css
+/* Responsive breakpoints for sidebar width adjustment
+ *
+ * IMPORTANT: These breakpoint values are derived from constants in constants.ts:
+ *
+ * 90em = remsToEms(contentWrapperMaxWidth + verticalNavbarMaxWidth * 2)
+ *      = remsToEms(128 + 8 * 2) = remsToEms(144) = 144 * 10/16 = 90em
+ *      (exported as contentWrapperAndNavWidthBreakpoint)
+ *
+ * 80em = remsToEms(contentWrapperMaxWidth)
+ *      = remsToEms(128) = 128 * 10/16 = 80em
+ *      (exported as contentWrapperWidthBreakpoint)
+ *
+ * If constants.ts values change, these breakpoints MUST be updated accordingly.
+ * The conversion formula is: rems * 10 / 16 = ems (because 1rem = 10px, 1em = 16px in media queries)
+ */
+@media screen and (max-width: 90em) {
+  /* ... */
+}
+
+@media screen and (max-width: 80em) {
+  /* ... */
+}
+```
+
+**Why Not CSS Variables?**: CSS variables cannot be used in media query breakpoints because the CSS specification requires them to be static values. The TypeScript exports are still maintained for use elsewhere in the codebase.
+
+**For Future Phases**: When using calculated breakpoints in CSS files, always add comprehensive documentation showing the derivation from TypeScript constants.
+
+### Verify Breakpoint Constants Match Theme
+
+**Issue (Phase 1.2)**: Easy to accidentally use incorrect breakpoint values when migrating from theme.breakpoints to plain CSS.
+
+**Resolution**: Always verify breakpoint values against the original theme definitions:
+- `theme.breakpoints.mobile()` → `@media screen and (max-width: 75em)`
+- `theme.breakpoints.mobileMedium()` → `@media screen and (max-width: 50em)`
+
+Cross-reference the original styled-components code to ensure the media query logic is identical.
+
+**For Future Phases**: Create a table mapping all theme.breakpoints values to their CSS equivalents and verify each migration against it.
 
 ---
 
@@ -333,7 +426,7 @@ Use this checklist when migrating additional components from styled-components t
 
 ## Summary
 
-The Phase 1.1 migration successfully migrated Typography components to plain CSS while maintaining backward compatibility. Key success factors:
+The styled-components to plain CSS migration has successfully migrated Typography (Phase 1.1) and Container/Layout (Phase 1.2) components while maintaining backward compatibility. Key success factors:
 
 1. **Hybrid Approach** - Incremental migration without breaking existing code
 2. **Clear Separation** - Legacy code isolated in `.legacy.ts` files
@@ -341,5 +434,12 @@ The Phase 1.1 migration successfully migrated Typography components to plain CSS
 4. **Module Hygiene** - Side-effect-free constants, no duplicate exports
 5. **CSS Best Practices** - Variables with fallbacks, single source of truth
 6. **Code Quality** - Eliminated duplication through base components
+7. **Responsive Design** - Proper rem/em conversion, documented breakpoint calculations
 
-These patterns and practices should serve as a foundation for future migration phases, helping to avoid the issues encountered during Phase 1.1 and streamlining the migration process.
+### Phase-Specific Highlights
+
+**Phase 1.1 (Typography)**: Established the hybrid migration pattern, module structure, and CSS variable binding approach.
+
+**Phase 1.2 (Container/Layout)**: Addressed responsive design complexities, particularly the rem/em conversion requirement for media queries and the importance of documenting hard-coded breakpoint values.
+
+These patterns and practices should serve as a foundation for future migration phases, helping to avoid the issues encountered and streamlining the migration process.

--- a/src/app/components/Layout.constants.ts
+++ b/src/app/components/Layout.constants.ts
@@ -1,0 +1,9 @@
+// Constants for Layout component padding
+// Single source of truth for padding values shared between new and legacy code
+
+import theme from '../theme';
+
+export const layoutPadding = {
+  desktop: theme.padding.page.desktop,
+  mobile: theme.padding.page.mobile,
+};

--- a/src/app/components/Layout.css
+++ b/src/app/components/Layout.css
@@ -1,0 +1,12 @@
+/* Layout component styles */
+
+.layout-body {
+  width: 100%;
+  padding: 0 var(--layout-padding-desktop, 3.2rem);
+}
+
+@media screen and (max-width: 75em) {
+  .layout-body {
+    padding: 0 var(--layout-padding-mobile, 1.6rem);
+  }
+}

--- a/src/app/components/Layout.legacy.ts
+++ b/src/app/components/Layout.legacy.ts
@@ -1,0 +1,13 @@
+// Legacy styled-components exports for backward compatibility
+// These will be removed in a future migration phase
+
+import { css } from 'styled-components/macro';
+import { layoutPadding } from './Layout.constants';
+import theme from '../theme';
+
+export const wrapperPadding = css`
+  padding: 0 ${layoutPadding.desktop}rem;
+  ${theme.breakpoints.mobile(css`
+    padding: 0 ${layoutPadding.mobile}rem;
+  `)}
+`;

--- a/src/app/components/Layout.tsx
+++ b/src/app/components/Layout.tsx
@@ -1,5 +1,6 @@
 import React, { SFC } from 'react';
-import styled, { createGlobalStyle, css } from 'styled-components/macro';
+import classNames from 'classnames';
+import { createGlobalStyle } from 'styled-components/macro';
 import ErrorBoundary from '../errors/components/ErrorBoundary';
 import ErrorModal from '../errors/components/ErrorModal';
 import theme from '../theme';
@@ -7,6 +8,8 @@ import AccessibilityButtonsWrapper from './AccessibilityButtonsWrapper';
 import NavBar from './NavBar';
 import OnEsc from './OnEsc';
 import PageTitleConfirmation from './PageTitleConfirmation';
+import { layoutPadding } from './Layout.constants';
+import './Layout.css';
 
 const MathJaxStyles = createGlobalStyle`
   mjx-help-background {
@@ -25,16 +28,26 @@ const Layout: SFC = ({ children }) => <AccessibilityButtonsWrapper>
   </ErrorBoundary>
 </AccessibilityButtonsWrapper>;
 
-export const wrapperPadding = css`
-  padding: 0 ${theme.padding.page.desktop}rem;
-  ${theme.breakpoints.mobile(css`
-    padding: 0 ${theme.padding.page.mobile}rem;
-  `)}
-`;
+// Export legacy styled-components fragment for backward compatibility
+export { wrapperPadding } from './Layout.legacy';
 
-export const LayoutBody = styled.div`
-  width: 100%;
-  ${wrapperPadding}
-`;
+export const LayoutBody = ({
+  children,
+  className,
+  style,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    {...props}
+    className={classNames('layout-body', className)}
+    style={{
+      '--layout-padding-desktop': `${layoutPadding.desktop}rem`,
+      '--layout-padding-mobile': `${layoutPadding.mobile}rem`,
+      ...style,
+    } as React.CSSProperties}
+  >
+    {children}
+  </div>
+);
 
 export default Layout;

--- a/src/app/components/MainContent.css
+++ b/src/app/components/MainContent.css
@@ -1,0 +1,12 @@
+/* MainContent component styles */
+
+.main-content-styles {
+  outline: none;
+}
+
+/* Compensates for a Firefox issue */
+.main-content-styles .os-problem-container .token,
+.main-content-styles .os-solution-container .token {
+  font-size-adjust: cap-height 1;
+  vertical-align: middle;
+}

--- a/src/app/components/MainContent.tsx
+++ b/src/app/components/MainContent.tsx
@@ -25,7 +25,8 @@ interface ContentStylesProps extends Omit<Props, 'className'> {
 
 const ContentStyles = React.forwardRef<HTMLElement, React.PropsWithChildren<ContentStylesProps>>(
   ({ textSize, className, style, children, ...props }, ref) => {
-    const textScale = textResizerValueMap.get(textSize);
+    // Use default value (0) if textSize is undefined, which maps to scale 1
+    const textScale = textResizerValueMap.get(textSize ?? 0);
 
     return (
       <DynamicContentStyles

--- a/src/app/components/MainContent.tsx
+++ b/src/app/components/MainContent.tsx
@@ -1,12 +1,13 @@
 import { HTMLDivElement } from '@openstax/types/lib.dom';
 import React from 'react';
-import styled from 'styled-components/macro';
+import classNames from 'classnames';
 import { TextResizerValue, textResizerValueMap } from '../content/constants';
 import { State } from '../content/types';
 import { MAIN_CONTENT_ID } from '../context/constants';
 import { Consumer } from '../context/SkipToContent';
 import { mergeRefs } from '../utils';
 import DynamicContentStyles from './DynamicContentStyles';
+import './MainContent.css';
 
 interface Props {
   book: State['book'];
@@ -14,37 +15,46 @@ interface Props {
   dangerouslySetInnerHTML?: { __html: string; };
   textSize?: TextResizerValue;
 }
-const ContentStyles = styled(({ textSize, ...props }) => <DynamicContentStyles {...props} />)`
-  outline: none;
-  ${(props: {textSize: TextResizerValue}) => `
-    --content-text-scale: ${textResizerValueMap.get(props.textSize)};
-  `}
 
-  /* Compensates for a Firefox issue */
-  .os-problem-container .token,
-  .os-solution-container .token {
-    font-size-adjust: cap-height 1;
-    vertical-align: middle;
-  }
-`;
+interface ContentStylesProps extends Omit<Props, 'className'> {
+  className?: string;
+  style?: React.CSSProperties;
+  id?: string;
+  tabIndex?: number;
+}
 
-const MainContent = React.forwardRef<HTMLDivElement, React.PropsWithChildren<Props>>(
-  ({book, children, className, ...props}, ref) => <Consumer>
-    {({registerMainContent}) => <main
-      ref={mergeRefs(ref, registerMainContent)}
-      className={className}
-      tabIndex={-1}
-    >
-      <ContentStyles
-        id={MAIN_CONTENT_ID}
-        book={book}
-        tabIndex={-1}
+const ContentStyles = React.forwardRef<HTMLElement, React.PropsWithChildren<ContentStylesProps>>(
+  ({ textSize, className, style, children, ...props }, ref) => {
+    const textScale = textResizerValueMap.get(textSize);
+
+    return (
+      <DynamicContentStyles
         {...props}
+        ref={ref}
+        className={classNames('main-content-styles', className)}
+        style={{
+          '--content-text-scale': textScale,
+          ...style,
+        } as React.CSSProperties}
       >
         {children}
-      </ContentStyles>
-    </main>}
-  </Consumer>
+      </DynamicContentStyles>
+    );
+  }
+);
+
+const MainContent = React.forwardRef<HTMLDivElement, React.PropsWithChildren<Props>>(
+  ({ book, children, className, ...props }, ref) => (
+    <Consumer>
+      {({ registerMainContent }) => (
+        <main ref={mergeRefs(ref, registerMainContent)} className={className} tabIndex={-1}>
+          <ContentStyles id={MAIN_CONTENT_ID} book={book} tabIndex={-1} {...props}>
+            {children}
+          </ContentStyles>
+        </main>
+      )}
+    </Consumer>
+  )
 );
 
 export default MainContent;

--- a/src/app/components/MainContent.tsx
+++ b/src/app/components/MainContent.tsx
@@ -1,7 +1,7 @@
 import { HTMLDivElement } from '@openstax/types/lib.dom';
 import React from 'react';
 import classNames from 'classnames';
-import { TextResizerValue, textResizerValueMap } from '../content/constants';
+import { TextResizerValue, textResizerValueMap, textResizerDefaultValue } from '../content/constants';
 import { State } from '../content/types';
 import { MAIN_CONTENT_ID } from '../context/constants';
 import { Consumer } from '../context/SkipToContent';
@@ -24,9 +24,8 @@ interface ContentStylesProps extends Omit<Props, 'className'> {
 }
 
 const ContentStyles = React.forwardRef<HTMLElement, React.PropsWithChildren<ContentStylesProps>>(
-  ({ textSize, className, style, children, ...props }, ref) => {
-    // Use default value (0) if textSize is undefined, which maps to scale 1
-    const textScale = textResizerValueMap.get(textSize ?? 0);
+  ({ textSize=textResizerDefaultValue, className, style, children, ...props }, ref) => {
+    const textScale = textResizerValueMap.get(textSize);
 
     return (
       <DynamicContentStyles

--- a/src/app/content/__snapshots__/routes.spec.tsx.snap
+++ b/src/app/content/__snapshots__/routes.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`assigned route route renders renders a component 1`] = `
-.c21 {
+.c20 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
@@ -75,42 +75,31 @@ exports[`assigned route route renders renders a component 1`] = `
   padding: 1.4rem;
 }
 
-.c23 {
+.c22 {
   height: 1.7rem;
   width: 1.7rem;
 }
 
-.c26 {
+.c25 {
   height: 1.7rem;
   width: 1.7rem;
 }
 
-.c18 {
+.c17 {
   list-style: none;
   cursor: pointer;
 }
 
-.c18::before {
+.c17::before {
   display: none;
 }
 
-.c18::-moz-list-bullet {
+.c17::-moz-list-bullet {
   list-style-type: none;
 }
 
-.c18::-webkit-details-marker {
+.c17::-webkit-details-marker {
   display: none;
-}
-
-.c15 {
-  outline: none;
-  --content-text-scale: 1;
-}
-
-.c15 .os-problem-container .token,
-.c15 .os-solution-container .token {
-  font-size-adjust: cap-height 1;
-  vertical-align: middle;
 }
 
 .c14 {
@@ -476,21 +465,21 @@ exports[`assigned route route renders renders a component 1`] = `
   margin-left: 1.6rem;
 }
 
-.c24 {
+.c23 {
   margin-left: -0.3rem;
 }
 
-.c27 {
+.c26 {
   margin-left: -0.3rem;
 }
 
-.c20 {
+.c19 {
   font-weight: 500;
   list-style: none;
 }
 
-.c20,
-.c20 span {
+.c19,
+.c19 span {
   color: #424242;
   font-size: 1.6rem;
   line-height: 2.5rem;
@@ -500,33 +489,33 @@ exports[`assigned route route renders renders a component 1`] = `
   text-decoration: none;
 }
 
-.c20 a,
-.c20 span a {
+.c19 a,
+.c19 span a {
   color: #027EB5;
   cursor: pointer;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c20 a:hover,
-.c20 span a:hover {
+.c19 a:hover,
+.c19 span a:hover {
   color: #0064A0;
 }
 
-.c20:hover,
-.c20 span:hover,
-.c20:focus,
-.c20 span:focus {
+.c19:hover,
+.c19 span:hover,
+.c19:focus,
+.c19 span:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0064A0;
 }
 
-.c28 blockquote {
+.c27 blockquote {
   margin-left: 0;
 }
 
-.c16 {
+.c15 {
   color: #424242;
   font-size: 1.6rem;
   line-height: 2.5rem;
@@ -537,30 +526,30 @@ exports[`assigned route route renders renders a component 1`] = `
   padding-top: 1.8rem;
 }
 
-.c16[open] > summary .c22 {
+.c15[open] > summary .c21 {
   display: none;
 }
 
-.c16:not([open]) > summary .c25 {
+.c15:not([open]) > summary .c24 {
   display: none;
 }
 
-.c16 a {
+.c15 a {
   color: #027EB5;
   cursor: pointer;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c16 a:hover {
+.c15 a:hover {
   color: #0064A0;
 }
 
-.c16 > .c19 {
+.c15 > .c18 {
   margin-bottom: 1.8rem;
 }
 
-.c16 li {
+.c15 li {
   margin-bottom: 1rem;
   overflow: visible;
 }
@@ -760,38 +749,38 @@ exports[`assigned route route renders renders a component 1`] = `
 }
 
 @media screen {
-  .c20 {
+  .c19 {
     max-width: 82.5rem;
     margin: 0 auto;
   }
 }
 
 @media screen {
-  .c28 {
+  .c27 {
     max-width: 82.5rem;
     margin: 0 auto;
   }
 }
 
 @media screen and (max-width:75em) {
-  .c16 {
+  .c15 {
     padding: 0 1.6rem;
   }
 }
 
 @media screen and (max-width:75em) {
-  .c16 {
+  .c15 {
     min-height: 4rem;
     padding-top: 0.8rem;
   }
 
-  .c16 > .c17 {
+  .c15 > .c16 {
     margin-bottom: 0.8rem;
   }
 }
 
 @media print {
-  .c16 {
+  .c15 {
     display: none;
   }
 }
@@ -948,7 +937,7 @@ exports[`assigned route route renders renders a component 1`] = `
         tabIndex={-1}
       >
         <div
-          className="c15"
+          className="main-content-styles"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<br>  <div xmlns:m=\\"http://www.w3.org/1998/Math/MathML\\" xmlns:ns2=\\"urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0\\" class=\\"introduction\\" data-cnxml-to-html-ver=\\"1.3.2\\" data-type=\\"page\\" id=\\"1d1fd537-77fb-4eac-8a8a-60bbaa747b6d\\"><p id=\\"p1\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi ex erat, lacinia vitae mattis id, commodo vitae est. Nam quis arcu quis enim congue aliquet. Vivamus dictum rhoncus tortor, malesuada placerat tortor imperdiet ac. Fusce ac viverra nisi. Aliquam ut tempor diam. Cras rhoncus sodales massa vitae porttitor. Integer pharetra lorem a ante sollicitudin condimentum. Aliquam imperdiet erat et tellus mattis finibus. Sed nisl lectus, ultricies et ante ut, porttitor varius sem. Interdum et malesuada fames ac ante ipsum primis in faucibus. Fusce tempus interdum ante, nec placerat felis facilisis quis. Nunc nec malesuada nisi. Cras eu iaculis felis. Sed id maximus enim, sit amet sodales sapien. Proin pulvinar sem risus, nec ultricies odio viverra a. Aliquam feugiat euismod dapibus.</p><section id=\\"section1\\"><h2 data-type=\\"document-title\\" id=\\"100_copy_1\\"><span class=\\"os-number\\">1.1</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">A Section, Probably</span></h2><p id=\\"p2\\">Morbi lobortis mattis velit, <math display=\\"inline\\"><semantics><mrow><mrow><mrow><mrow><mrow><mrow><mi>W</mi><mo stretchy=\\"false\\">=</mo><mrow><msub><mtext>KE</mtext><mrow><mn>f</mn></mrow></msub><mo stretchy=\\"false\\">+</mo><msub><mtext>PE</mtext><mrow><mn>g</mn></mrow></msub></mrow></mrow><mo stretchy=\\"false\\">=</mo><mfrac><mrow><mn>1</mn></mrow><mrow><mn>2</mn></mrow></mfrac><msup><msub><mi fontstyle=\\"italic\\">mv</mi><mn>f</mn></msub><mn>2</mn></msup><mo stretchy=\\"false\\">+</mo><mrow><mtext fontstyle=\\"italic\\">mgh</mtext></mrow></mrow></mrow></mrow><mrow></mrow></mrow></mrow><annotation-xml encoding=\\"MathML-Content\\"><semantics><mrow><mrow><mrow><mrow><mrow><mi>W</mi><mo stretchy=\\"false\\">=</mo><mrow><msub><mtext>KE</mtext><mrow><mn>f</mn></mrow></msub><mo stretchy=\\"false\\">+</mo><msub><mtext>PE</mtext><mrow><mn>g</mn></mrow></msub></mrow></mrow><mo stretchy=\\"false\\">=</mo><mfrac><mrow><mn>1</mn></mrow><mrow><mn>2</mn></mrow></mfrac><msup><msub><mi fontstyle=\\"italic\\">mv</mi><mn>f</mn></msub><mn>2</mn></msup><mo stretchy=\\"false\\">+</mo><mrow><mtext fontstyle=\\"italic\\">mgh</mtext></mrow></mrow></mrow></mrow><mrow></mrow></mrow><annotation encoding=\\"StarMath 5.0\\"> size 12{W=\\"KE\\" rSub { size 8{f} } +\\"PE\\" rSub { size 8{g} } = {  { size 8{1} }  over  { size 8{2} } }  ital \\"mv\\" rSub { size 8{f}   rSup { size 8{2} } } + ital \\"mgh\\"} {}</annotation></semantics></annotation-xml></semantics></math> dapibus convallis est mollis sed. Sed ullamcorper est tortor, at ultricies felis tincidunt ut. Mauris interdum nunc et convallis pharetra. Nulla ac erat nulla. Vivamus a ornare leo. Quisque luctus dui eget auctor tristique. Sed vel est eget lorem volutpat mattis non et nisi. Aliquam ultricies ultrices velit, id fringilla ex suscipit in. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris consequat blandit felis, non finibus neque dignissim sit amet. Integer laoreet dapibus quam eget pulvinar. Aenean lobortis, arcu dignissim euismod ornare, eros est tincidunt urna, nec auctor odio quam eget tortor. Praesent sit amet metus a metus varius tincidunt. Pellentesque convallis sit amet erat eget malesuada. Proin pretium est euismod risus facilisis dignissim. Interdum et malesuada fames ac ante ipsum primis in faucibus.</p><p id=\\"p3\\">Integer maximus augue vitae orci vehicula tincidunt. Integer auctor ante odio, nec porta nisi pellentesque id. Donec porttitor velit vel turpis sagittis molestie. Sed eu rhoncus orci. Donec feugiat tristique posuere. Fusce consequat, nisi vitae porttitor ornare, augue velit sodales augue, ac facilisis turpis orci vitae lectus. Mauris mauris urna, dictum a dui et, imperdiet commodo justo. Pellentesque scelerisque dui sed libero porta, sit amet rhoncus ex dictum. Interdum et malesuada fames ac ante ipsum primis in faucibus.</p><div data-type=\\"equation\\" id=\\"fs-id2746082\\"><math display=\\"block\\"><semantics><mrow><mrow><mrow><mrow><mi>P</mi><mo stretchy=\\"false\\">=</mo><mfrac><mi>W</mi><mi>t</mi></mfrac></mrow></mrow><mrow></mrow></mrow></mrow><annotation-xml encoding=\\"MathML-Content\\"><semantics><mrow><mrow><mrow><mi>P</mi><mo stretchy=\\"false\\">=</mo><mfrac><mi>W</mi><mi>t</mi></mfrac></mrow></mrow><mrow></mrow></mrow><annotation encoding=\\"StarMath 5.0\\"> size 12{P= {  {W}  over  {t} } } {}</annotation></semantics></annotation-xml></semantics></math><div class=\\"os-equation-number\\"><span class=\\"os-number\\">1.01</span></div></div><p id=\\"p4\\">Donec congue tortor sed magna ullamcorper mollis. Suspendisse eu tincidunt augue, et pulvinar purus. Fusce gravida quam lorem, sed pharetra libero bibendum et. Etiam facilisis ex vel nisi egestas, non consequat mi malesuada. Donec scelerisque magna sem, ut ornare massa rhoncus sed. In ultricies tellus porttitor enim elementum, ut mollis nisl euismod. Pellentesque eu lobortis neque. Phasellus eget luctus velit, in eleifend lectus. Pellentesque leo odio, cursus eget feugiat eu, finibus in nibh. In nec urna justo. Donec ut nisi eleifend, auctor lacus quis, hendrerit sem. Pellentesque sagittis nunc a molestie finibus. Donec pulvinar nibh elit, nec ornare nibh egestas quis. Curabitur luctus euismod lobortis.</p><div class=\\"os-figure\\" id=\\"figureid\\"><figure data-id=\\"figureid\\" class=\\"ui-has-child-figcaption\\"><div data-alt=\\"\\" data-type=\\"media\\" id=\\"Phet_module_25.2\\"> <iframe title=\\"interactive simulation\\" height=\\"371.4\\" src=\\"/specials/version/radio-waves/#sim-radio-waves\\" width=\\"660\\" loading=\\"lazy\\"></iframe></div><figcaption class=\\"os-caption-container\\"><span class=\\"os-title-label\\">Figure </span><span class=\\"os-number\\">1.0</span><span class=\\"os-divider\\"> </span></figcaption></figure></div>  <p id=\\"p5\\">Maecenas vehicula nec quam vitae sodales. Vestibulum bibendum accumsan mauris. Nunc rhoncus libero odio, in ullamcorper massa ornare convallis. Nullam metus tortor, aliquam a ultrices et, rhoncus in risus. Nunc vel turpis erat. Cras semper sagittis odio, eu mattis nulla faucibus quis. Aliquam egestas nunc elit, eget condimentum lectus congue et. Curabitur non gravida lorem. Integer mi nunc, commodo vitae augue vel, bibendum pretium magna. Sed ut nibh venenatis ipsum tempus mollis pretium eget est. Aliquam commodo quam ipsum, at fermentum enim tristique eget. Mauris imperdiet dapibus maximus. Donec tristique varius lacinia. Pellentesque pharetra nunc eu nisi ullamcorper placerat. Suspendisse potenti.</p><p id=\\"p6\\">Integer fringilla blandit dolor ut mattis. Nam commodo ex at blandit sodales. Nullam suscipit, nunc eu mollis sagittis, purus arcu tincidunt ligula, vitae pharetra metus tortor id ex. Donec malesuada aliquet ligula id mollis. Maecenas scelerisque maximus sollicitudin. Quisque sagittis dolor at ligula congue, quis rhoncus mi porttitor. Quisque lobortis ut ante sed convallis. Integer luctus cursus molestie.</p><p id=\\"p7\\">Morbi a purus a elit dapibus fermentum. Sed varius ex quis tortor tincidunt posuere. Mauris luctus risus id aliquet mollis. Phasellus ornare leo a arcu imperdiet dictum. Praesent accumsan venenatis urna, sed egestas sem pharetra a. Sed vulputate sit amet nisl a aliquet. Interdum et malesuada fames ac ante ipsum primis in faucibus. Mauris facilisis augue vitae est maximus pharetra in ac elit. Pellentesque viverra purus non ligula tempor convallis.</p><p id=\\"p8\\">Pellentesque lectus ante, malesuada ut ornare vitae, euismod non urna. Morbi varius eros eget felis accumsan vehicula. In diam ex, finibus rhoncus dapibus non, lacinia in lacus. Nullam pretium mollis laoreet. Ut interdum dui sit amet elementum dignissim. Etiam in nibh vitae ligula fringilla aliquet quis vel ex. Nullam quis elit libero. In aliquet laoreet arcu at posuere. Duis consectetur et dolor non accumsan. Fusce enim est, dignissim sed mauris at, ornare cursus ligula. Nullam tincidunt eu purus vel lacinia. Praesent varius, arcu sed facilisis elementum, orci metus vestibulum nisl, sed sodales urna eros ullamcorper turpis. Donec mollis ac massa ac elementum. Nulla maximus purus sed orci efficitur, ut porta mauris elementum.</p><p id=\\"p9\\">Vestibulum blandit enim quis sapien ultrices pretium. Cras dapibus ornare fringilla. Duis ut laoreet dolor. Proin ullamcorper molestie dui eu vestibulum. Nullam convallis mollis mauris nec accumsan. Proin egestas enim non nisl suscipit, ut feugiat felis pharetra. In faucibus fringilla ipsum vel sollicitudin. Maecenas blandit augue odio, ac mattis justo feugiat sit amet. Etiam nec molestie eros. Sed gravida velit libero, at pretium diam venenatis sit amet. Donec tellus leo, faucibus eu sapien nec, mollis efficitur lorem. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p></section><dl id=\\"test-pair-page1\\"><dt>test term</dt><dd>test definition with <math>math element</math></dd></dl></div><button type=\\"button\\" aria-label=\\"Click to enlarge image of A photo is shown of the Crab Nebula.\\" class=\\"image-button-wrapper\\"><img alt=\\"A photo is shown of the Crab Nebula.\\" data-media-type=\\"image/jpeg\\" id=\\"89491\\" src=\\"/apps/image-cdn/v1/f=webp/apps/archive/codeversion/resources/c7cc4c5e00a4bc07cb74f29cac2fb3c6cd6d53b5\\" data-original-src=\\"/apps/archive/codeversion/resources/c7cc4c5e00a4bc07cb74f29cac2fb3c6cd6d53b5\\"></button><a href=\\"../../../books/book-slug-1/pages/test-page-1#hash\\" target=\\"_blank\\">hashlink</a><a href=\\".\\" target=\\"_blank\\">Current link</a>",
@@ -956,23 +945,28 @@ exports[`assigned route route renders renders a component 1`] = `
           }
           data-dynamic-style={false}
           id="main-content"
+          style={
+            Object {
+              "--content-text-scale": 1,
+            }
+          }
           tabIndex={-1}
         />
       </main>
     </div>
   </div>
   <details
-    className="c16"
+    className="c15"
     data-analytics-region="attribution"
     data-testid="attribution-details"
   >
     <summary
       aria-label="Citation/Attribution"
-      className="c17 c18 c19 c20"
+      className="c16 c17 c18 c19"
     >
       <svg
         aria-hidden="true"
-        className="c21 c22 c23 c24"
+        className="c20 c21 c22 c23"
         fill="currentColor"
         focusable="false"
         viewBox="0 0 192 512"
@@ -985,7 +979,7 @@ exports[`assigned route route renders renders a component 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        className="c21 c25 c26 c27"
+        className="c20 c24 c25 c26"
         fill="currentColor"
         focusable="false"
         viewBox="0 0 320 512"
@@ -1004,7 +998,7 @@ exports[`assigned route route renders renders a component 1`] = `
       </span>
     </summary>
     <div
-      className="c28"
+      className="c27"
       dangerouslySetInnerHTML={
         Object {
           "__html": "

--- a/src/app/content/components/ContentPane.css
+++ b/src/app/content/components/ContentPane.css
@@ -1,0 +1,58 @@
+/* ContentPane component styles */
+
+.content-pane-wrapper {
+  grid-column: 1 / -1;
+  grid-row: 1;
+  justify-self: center;
+  width: 100%;
+  overflow: visible; /* so sidebar position: sticky works */
+  margin: 0 auto;
+  max-width: var(--content-wrapper-max-width, 82.5rem);
+}
+
+@media screen {
+  .content-pane-wrapper {
+    background-color: var(--main-content-background, #fff);
+    padding-left: var(--sidebar-desktop-width, 37.5rem);
+    transition: padding-left var(--sidebar-transition-time, 300ms) ease-in-out;
+  }
+}
+
+/* Responsive breakpoints for sidebar width adjustment */
+@media screen and (max-width: 104em) {
+  .content-pane-wrapper {
+    padding-left: calc(var(--sidebar-desktop-with-toolbar-width, 45.5rem) - (100vw - var(--content-wrapper-max-width, 82.5rem)) / 2);
+  }
+}
+
+@media screen and (max-width: 82.5em) {
+  .content-pane-wrapper {
+    padding-left: var(--sidebar-desktop-with-toolbar-width, 45.5rem);
+  }
+}
+
+@media screen and (max-width: 75em) {
+  .content-pane-wrapper {
+    grid-column-start: 2;
+    padding-left: 0;
+  }
+}
+
+@media screen and (max-width: 62.5em) {
+  .content-pane-wrapper {
+    grid-column: 1 / -1;
+  }
+}
+
+/* Sidebar closed states */
+@media screen and (max-width: 75em) {
+  .content-pane-wrapper--sidebar-closed-mobile {
+    padding-left: 0 !important;
+  }
+}
+
+@media screen {
+  .content-pane-wrapper--sidebar-closed-desktop {
+    padding-left: 0 !important;
+  }
+}

--- a/src/app/content/components/ContentPane.css
+++ b/src/app/content/components/ContentPane.css
@@ -18,7 +18,21 @@
   }
 }
 
-/* Responsive breakpoints for sidebar width adjustment */
+/* Responsive breakpoints for sidebar width adjustment
+ *
+ * IMPORTANT: These breakpoint values are derived from constants in constants.ts:
+ *
+ * 90em = remsToEms(contentWrapperMaxWidth + verticalNavbarMaxWidth * 2)
+ *      = remsToEms(128 + 8 * 2) = remsToEms(144) = 144 * 10/16 = 90em
+ *      (exported as contentWrapperAndNavWidthBreakpoint)
+ *
+ * 80em = remsToEms(contentWrapperMaxWidth)
+ *      = remsToEms(128) = 128 * 10/16 = 80em
+ *      (exported as contentWrapperWidthBreakpoint)
+ *
+ * If constants.ts values change, these breakpoints MUST be updated accordingly.
+ * The conversion formula is: rems * 10 / 16 = ems (because 1rem = 10px, 1em = 16px in media queries)
+ */
 @media screen and (max-width: 90em) {
   .content-pane-wrapper {
     padding-left: calc(var(--sidebar-desktop-with-toolbar-width, 45.5rem) - (100vw - var(--content-wrapper-max-width, 128rem)) / 2);

--- a/src/app/content/components/ContentPane.css
+++ b/src/app/content/components/ContentPane.css
@@ -7,7 +7,7 @@
   width: 100%;
   overflow: visible; /* so sidebar position: sticky works */
   margin: 0 auto;
-  max-width: var(--content-wrapper-max-width, 82.5rem);
+  max-width: var(--content-wrapper-max-width, 128rem);
 }
 
 @media screen {
@@ -19,13 +19,13 @@
 }
 
 /* Responsive breakpoints for sidebar width adjustment */
-@media screen and (max-width: 104em) {
+@media screen and (max-width: 90em) {
   .content-pane-wrapper {
-    padding-left: calc(var(--sidebar-desktop-with-toolbar-width, 45.5rem) - (100vw - var(--content-wrapper-max-width, 82.5rem)) / 2);
+    padding-left: calc(var(--sidebar-desktop-with-toolbar-width, 45.5rem) - (100vw - var(--content-wrapper-max-width, 128rem)) / 2);
   }
 }
 
-@media screen and (max-width: 82.5em) {
+@media screen and (max-width: 80em) {
   .content-pane-wrapper {
     padding-left: var(--sidebar-desktop-with-toolbar-width, 45.5rem);
   }
@@ -38,7 +38,7 @@
   }
 }
 
-@media screen and (max-width: 62.5em) {
+@media screen and (max-width: 50em) {
   .content-pane-wrapper {
     grid-column: 1 / -1;
   }

--- a/src/app/content/components/ContentPane.tsx
+++ b/src/app/content/components/ContentPane.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
-import styled, { css } from 'styled-components/macro';
 import ScrollLock from '../../components/ScrollLock';
 import theme from '../../theme';
 import { Dispatch } from '../../types';
@@ -15,49 +15,12 @@ import {
   sidebarTransitionTime,
   verticalNavbarMaxWidth,
 } from './constants';
-import { isVerticalNavOpenConnector, styleWhenSidebarClosed } from './utils/sidebar';
+import { isVerticalNavOpenConnector } from './utils/sidebar';
+import './ContentPane.css';
 
 export const contentWrapperWidthBreakpoint = '(max-width: ' + remsToEms(contentWrapperMaxWidth) + 'em)';
 export const contentWrapperAndNavWidthBreakpoint =
   '(max-width: ' + remsToEms(contentWrapperMaxWidth + verticalNavbarMaxWidth * 2) + 'em)';
-const contentWrapperBreakpointStyles = `
-  @media screen and ${contentWrapperAndNavWidthBreakpoint} {
-    padding-left: calc(${sidebarDesktopWithToolbarWidth}rem - (100vw - ${contentWrapperMaxWidth}rem) / 2);
-  }
-
-  @media screen and ${contentWrapperWidthBreakpoint} {
-    padding-left: ${sidebarDesktopWithToolbarWidth}rem;
-  }
-`;
-const Wrapper = styled.div<{verticalNavOpen: State['tocOpen']}>`
-  grid-column: 1 / -1;
-  grid-row: 1;
-  justify-self: center;
-  width: 100%;
-  overflow: visible; /* so sidebar position: sticky works */
-  margin: 0 auto;
-  max-width: ${contentWrapperMaxWidth}rem;
-  ${theme.breakpoints.mobile(css`
-    grid-column-start: 2;
-  `)}
-  ${theme.breakpoints.mobileMedium(css`
-    grid-column: 1 / -1;
-  `)}
-
-  @media screen {
-    background-color: ${mainContentBackground};
-    padding-left: ${sidebarDesktopWidth}rem;
-    transition: padding-left ${sidebarTransitionTime}ms ease-in-out;
-    ${contentWrapperBreakpointStyles}
-    ${theme.breakpoints.mobile(css`
-      padding-left: 0;
-    `)}
-
-    ${styleWhenSidebarClosed(css`
-      padding-left: 0 !important;
-    `)}
-  }
-`;
 
 interface Props {
   isDesktopSearchOpen: boolean;
@@ -65,21 +28,43 @@ interface Props {
   onClick: () => void;
 }
 
-const ContentPane = ({ isDesktopSearchOpen, isVerticalNavOpen, onClick, children }: React.PropsWithChildren<Props>) =>
-  <Wrapper
-    isVerticalNavOpen={isVerticalNavOpen}
-    isDesktopSearchOpen={isDesktopSearchOpen}
-    data-testid='centered-content-row'
-  >
-      {isVerticalNavOpen &&
+const ContentPane = ({
+  isDesktopSearchOpen,
+  isVerticalNavOpen,
+  onClick,
+  children,
+}: React.PropsWithChildren<Props>) => {
+  // Determine sidebar closed state classes
+  const sidebarClosedMobile = isVerticalNavOpen === null;
+  const sidebarClosedDesktop = isDesktopSearchOpen === false && isVerticalNavOpen === false;
+
+  return (
+    <div
+      className={classNames('content-pane-wrapper', {
+        'content-pane-wrapper--sidebar-closed-mobile': sidebarClosedMobile,
+        'content-pane-wrapper--sidebar-closed-desktop': sidebarClosedDesktop,
+      })}
+      data-testid="centered-content-row"
+      style={{
+        '--content-wrapper-max-width': `${contentWrapperMaxWidth}rem`,
+        '--main-content-background': mainContentBackground,
+        '--sidebar-desktop-width': `${sidebarDesktopWidth}rem`,
+        '--sidebar-desktop-with-toolbar-width': `${sidebarDesktopWithToolbarWidth}rem`,
+        '--sidebar-transition-time': `${sidebarTransitionTime}ms`,
+      } as React.CSSProperties}
+    >
+      {isVerticalNavOpen && (
         <ScrollLock
           onClick={onClick}
           mediumScreensOnly={true}
           overlay={true}
           zIndex={theme.zIndex.overlay}
-      />}
-    {children}
-  </Wrapper>;
+        />
+      )}
+      {children}
+    </div>
+  );
+};
 
 const dispatchConnector = connect(
   () => ({}),

--- a/src/app/content/components/Wrapper.css
+++ b/src/app/content/components/Wrapper.css
@@ -1,0 +1,26 @@
+/* Wrapper component styles */
+
+.content-wrapper {
+  position: relative; /* for sidebar overlay */
+  overflow: visible; /* so sidebar position: sticky works */
+}
+
+@media screen and (max-width: 75em) {
+  .content-wrapper {
+    margin-left: 0;
+  }
+}
+
+.content-layout-body {
+  width: 100%;
+  max-width: var(--content-max-width, 104rem);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 8rem auto auto;
+}
+
+@media screen and (max-width: 62.5em) {
+  .content-layout-body {
+    grid-template-columns: 100%;
+  }
+}

--- a/src/app/content/components/Wrapper.css
+++ b/src/app/content/components/Wrapper.css
@@ -13,13 +13,13 @@
 
 .content-layout-body {
   width: 100%;
-  max-width: var(--content-max-width, 104rem);
+  max-width: var(--content-max-width, 144rem);
   margin: 0 auto;
   display: grid;
   grid-template-columns: 8rem auto auto;
 }
 
-@media screen and (max-width: 62.5em) {
+@media screen and (max-width: 50em) {
   .content-layout-body {
     grid-template-columns: 100%;
   }

--- a/src/app/content/components/Wrapper.spec.tsx
+++ b/src/app/content/components/Wrapper.spec.tsx
@@ -9,7 +9,7 @@ describe('wrapper', () => {
   });
 
   it('matches snapshot with search open', () => {
-    const tree = renderer.create(<Wrapper hasQuery verticalNavOpen />).toJSON();
+    const tree = renderer.create(<Wrapper verticalNavOpen />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/src/app/content/components/Wrapper.tsx
+++ b/src/app/content/components/Wrapper.tsx
@@ -10,8 +10,8 @@ import './Wrapper.css';
 export { wrapperPadding } from '../../components/Layout';
 
 interface WrapperProps {
-  hasQuery: boolean;
-  verticalNavOpen: boolean;
+  hasQuery?: boolean;
+  verticalNavOpen?: boolean;
   className?: string;
 }
 

--- a/src/app/content/components/Wrapper.tsx
+++ b/src/app/content/components/Wrapper.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import styled, { css } from 'styled-components/macro';
 import ScrollLock from '../../components/ScrollLock';
-import theme from '../../theme';
 import { AppState } from '../../types';
 import * as selectSearch from '../search/selectors';
 import * as contentSelectors from '../selectors';
 import { contentWrapperMaxWidth, verticalNavbarMaxWidth } from './constants';
+import './Wrapper.css';
 
 export { wrapperPadding } from '../../components/Layout';
 
@@ -16,33 +15,40 @@ interface WrapperProps {
   className?: string;
 }
 
-export const Wrapper = styled(
-  ({hasQuery, verticalNavOpen, children, ...props}: React.PropsWithChildren<WrapperProps>) =>
-    <ContentLayoutBody {...props}>
-      {verticalNavOpen && <ScrollLock overlay={false} mediumScreensOnly={true} />}
+const ContentLayoutBody = ({
+  children,
+  className,
+  style,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => {
+  const maxWidth = contentWrapperMaxWidth + verticalNavbarMaxWidth * 2;
+
+  return (
+    <div
+      {...props}
+      className={className}
+      style={{
+        '--content-max-width': `${maxWidth}rem`,
+        ...style,
+      } as React.CSSProperties}
+    >
       {children}
-    </ContentLayoutBody>
-)`
-  position: relative; /* for sidebar overlay */
-  overflow: visible; /* so sidebar position: sticky works */
+    </div>
+  );
+};
 
-  @media screen {
-    ${theme.breakpoints.mobile(css`
-      margin-left: 0;
-    `)}
-  }
-`;
-
-const ContentLayoutBody = styled.div`
-  width: 100%;
-  max-width: ${contentWrapperMaxWidth + verticalNavbarMaxWidth * 2}rem;
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: 8rem auto auto;
-  ${theme.breakpoints.mobileMedium(css`
-    grid-template-columns: 100%;
-  `)}
-`;
+export const Wrapper = ({
+  hasQuery,
+  verticalNavOpen,
+  children,
+  className,
+  ...props
+}: React.PropsWithChildren<WrapperProps>) => (
+  <ContentLayoutBody {...props} className={`content-wrapper ${className || ''}`}>
+    {verticalNavOpen && <ScrollLock overlay={false} mediumScreensOnly={true} />}
+    <div className="content-layout-body">{children}</div>
+  </ContentLayoutBody>
+);
 
 export default connect(
   (state: AppState) => ({

--- a/src/app/content/components/Wrapper.tsx
+++ b/src/app/content/components/Wrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import classNames from 'classnames';
 import ScrollLock from '../../components/ScrollLock';
 import { AppState } from '../../types';
@@ -38,6 +38,7 @@ const ContentLayoutBody = ({
   );
 };
 
+// Export named component for testing
 export const Wrapper = ({
   hasQuery,
   verticalNavOpen,
@@ -51,9 +52,27 @@ export const Wrapper = ({
   </ContentLayoutBody>
 );
 
-export default connect(
-  (state: AppState) => ({
-    hasQuery: !!selectSearch.query(state),
-    verticalNavOpen: contentSelectors.mobileMenuOpen(state) || selectSearch.searchResultsOpen(state),
-  })
-)(Wrapper);
+// Default export with Redux hooks
+const WrapperConnected = ({
+  children,
+  className,
+  ...props
+}: React.PropsWithChildren<Omit<WrapperProps, 'hasQuery' | 'verticalNavOpen'>>) => {
+  const hasQuery = useSelector((state: AppState) => !!selectSearch.query(state));
+  const verticalNavOpen = useSelector((state: AppState) =>
+    contentSelectors.mobileMenuOpen(state) || selectSearch.searchResultsOpen(state)
+  );
+
+  return (
+    <Wrapper
+      {...props}
+      hasQuery={hasQuery}
+      verticalNavOpen={verticalNavOpen}
+      className={className}
+    >
+      {children}
+    </Wrapper>
+  );
+};
+
+export default WrapperConnected;

--- a/src/app/content/components/Wrapper.tsx
+++ b/src/app/content/components/Wrapper.tsx
@@ -11,7 +11,6 @@ import './Wrapper.css';
 export { wrapperPadding } from '../../components/Layout';
 
 interface WrapperProps {
-  hasQuery?: boolean;
   verticalNavOpen?: boolean;
   className?: string;
 }
@@ -40,7 +39,6 @@ const ContentLayoutBody = ({
 
 // Export named component for testing
 export const Wrapper = ({
-  hasQuery,
   verticalNavOpen,
   children,
   className,
@@ -57,8 +55,7 @@ const WrapperConnected = ({
   children,
   className,
   ...props
-}: React.PropsWithChildren<Omit<WrapperProps, 'hasQuery' | 'verticalNavOpen'>>) => {
-  const hasQuery = useSelector((state: AppState) => !!selectSearch.query(state));
+}: React.PropsWithChildren<Omit<WrapperProps, 'verticalNavOpen'>>) => {
   const verticalNavOpen = useSelector((state: AppState) =>
     contentSelectors.mobileMenuOpen(state) || selectSearch.searchResultsOpen(state)
   );
@@ -66,7 +63,6 @@ const WrapperConnected = ({
   return (
     <Wrapper
       {...props}
-      hasQuery={hasQuery}
       verticalNavOpen={verticalNavOpen}
       className={className}
     >

--- a/src/app/content/components/Wrapper.tsx
+++ b/src/app/content/components/Wrapper.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 import ScrollLock from '../../components/ScrollLock';
 import { AppState } from '../../types';
 import * as selectSearch from '../search/selectors';
@@ -44,7 +45,7 @@ export const Wrapper = ({
   className,
   ...props
 }: React.PropsWithChildren<WrapperProps>) => (
-  <ContentLayoutBody {...props} className={`content-wrapper ${className || ''}`}>
+  <ContentLayoutBody {...props} className={classNames('content-wrapper', className)}>
     {verticalNavOpen && <ScrollLock overlay={false} mediumScreensOnly={true} />}
     <div className="content-layout-body">{children}</div>
   </ContentLayoutBody>

--- a/src/app/content/components/__snapshots__/Wrapper.spec.tsx.snap
+++ b/src/app/content/components/__snapshots__/Wrapper.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`wrapper matches snapshot 1`] = `
 <div
-  className="content-wrapper "
+  className="content-wrapper"
   style={
     Object {
       "--content-max-width": "144rem",
@@ -17,7 +17,7 @@ exports[`wrapper matches snapshot 1`] = `
 
 exports[`wrapper matches snapshot with search open 1`] = `
 <div
-  className="content-wrapper "
+  className="content-wrapper"
   style={
     Object {
       "--content-max-width": "144rem",

--- a/src/app/content/components/__snapshots__/Wrapper.spec.tsx.snap
+++ b/src/app/content/components/__snapshots__/Wrapper.spec.tsx.snap
@@ -1,51 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`wrapper matches snapshot 1`] = `
-.c1 {
-  position: relative;
-  overflow: visible;
-}
-
-.c0 {
-  width: 100%;
-  max-width: 144rem;
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: 8rem auto auto;
-}
-
-@media screen and (max-width:50em) {
-  .c0 {
-    grid-template-columns: 100%;
-  }
-}
-
 <div
-  className="c0 c1"
-/>
+  className="content-wrapper "
+  style={
+    Object {
+      "--content-max-width": "144rem",
+    }
+  }
+>
+  <div
+    className="content-layout-body"
+  />
+</div>
 `;
 
 exports[`wrapper matches snapshot with search open 1`] = `
-.c1 {
-  position: relative;
-  overflow: visible;
-}
-
-.c0 {
-  width: 100%;
-  max-width: 144rem;
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: 8rem auto auto;
-}
-
-@media screen and (max-width:50em) {
-  .c0 {
-    grid-template-columns: 100%;
-  }
-}
-
 <div
-  className="c0 c1"
-/>
+  className="content-wrapper "
+  style={
+    Object {
+      "--content-max-width": "144rem",
+    }
+  }
+>
+  <div
+    className="content-layout-body"
+  />
+</div>
 `;

--- a/src/app/developer/components/__snapshots__/Home.spec.tsx.snap
+++ b/src/app/developer/components/__snapshots__/Home.spec.tsx.snap
@@ -332,21 +332,19 @@ Array [
 }
 
 .c0 {
-  width: 100%;
-  padding: 0 3.2rem;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-@media screen and (max-width:75em) {
-  .c0 {
-    padding: 0 1.6rem;
-  }
-}
-
 <div
-    className="c0"
+    className="layout-body c0"
+    style={
+      Object {
+        "--layout-padding-desktop": "3.2rem",
+        "--layout-padding-mobile": "1.6rem",
+      }
+    }
   >
     <div
       className="c1"


### PR DESCRIPTION
## Summary

This PR migrates Phase 1.2 container and layout components from styled-components to plain CSS as specified in [CORE-1692](https://openstax.atlassian.net/browse/CORE-1692).

### Components Migrated

- ✅ **Layout** (src/app/components/Layout.tsx)
  - Created `Layout.css` with `.layout-body` styles
  - Created `Layout.constants.ts` for shared padding values
  - Created `Layout.legacy.ts` for backward-compatible `wrapperPadding` export
  - Converted `LayoutBody` to plain React component with CSS variables

- ✅ **Wrapper** (src/app/content/components/Wrapper.tsx)
  - Created `Wrapper.css` with `.content-wrapper` and `.content-layout-body` styles
  - Removed styled-components, using plain className
  - Preserved Redux connection and ScrollLock functionality

- ✅ **ContentPane** (src/app/content/components/ContentPane.tsx)
  - Created `ContentPane.css` with responsive breakpoints
  - Implemented sidebar closed states with conditional classes
  - Used classNames library for dynamic class management
  - Kept exported breakpoint constants for backward compatibility

- ✅ **MainContent** (src/app/components/MainContent.tsx)
  - Created `MainContent.css` with Firefox-specific token styles
  - Converted `ContentStyles` from styled to plain React component
  - Binds `--content-text-scale` CSS variable from textSize prop
  - Preserved ref forwarding and Consumer integration

## Migration Approach

Following the hybrid approach from Phase 1.1:

- Theme values bound as CSS variables at component level
- CSS variables set **before** `...style` for override capability
- Responsive breakpoints converted to standard `@media` queries (using proper rem-to-em conversion)
- Legacy exports preserved in `.legacy.ts` files for backward compatibility
- Constants extracted to `.constants.ts` files for sharing

## Testing

The following tests need to pass:

- [ ] `yarn test:unit` - Unit tests and snapshots
- [ ] `yarn test:screenshots` - Visual regression tests
- [ ] Manual testing of responsive breakpoints
- [ ] Manual testing of sidebar open/closed states
- [ ] Manual testing of mobile and desktop layouts

## Manual Testing Guide

While we expect no visual differences, the following areas are most likely to show layout changes if there are issues:

### Responsive Breakpoints
The migration involved converting styled-components breakpoints to CSS media queries with proper rem/em conversion. Test these viewport widths:

- **1440px (90em)** - `contentWrapperAndNavWidthBreakpoint`
  - ContentPane sidebar padding switches to calculated offset
  - Test with sidebar open and closed
  
- **1280px (80em)** - `contentWrapperWidthBreakpoint`
  - ContentPane sidebar padding becomes fixed width
  - Wrapper layout adjustments
  
- **1200px (75em)** - `theme.breakpoints.mobile`
  - Mobile layout activates
  - Sidebar becomes overlay instead of side-by-side
  - ContentPane grid layout changes
  
- **800px (50em)** - `theme.breakpoints.mobileMedium`
  - ContentPane padding adjustments for smaller screens

### Layout Components
- **Page wrapper and content area** - Check overall page layout, maximum widths, and centering
- **Sidebar interactions** - Toggle sidebar open/closed and verify smooth transitions
- **Content pane** - Check padding and margins, especially near responsive breakpoints
- **Main content area** - Verify text scaling with different textSize values

### Specific Scenarios to Test
1. **Text resizer functionality** - Change text size and verify `--content-text-scale` CSS variable applies correctly
2. **Sidebar state transitions** - Open/close sidebar and check padding animations (300ms ease-in-out)
3. **Mobile menu** - Test navigation on mobile viewport sizes
4. **Search overlay** - Open search and verify it doesn't break layout
5. **Firefox browser** - Check token styles render correctly (Firefox-specific CSS was migrated)

### Areas of Lower Risk
These components had straightforward migrations with minimal conditional logic:
- Layout body padding (consistent across all pages)
- MainContent text scaling (simple CSS variable binding)

## Follow-up Work

Items for future phases:

- Remove `wrapperPadding` legacy export after migrating all consumers (RedoPadding.tsx, Attribution.tsx)
- Migrate nested styled components in Content.tsx (Background, OuterWrapper)
- Consider migrating DynamicContentStyles to remove styled-components dependency

## Related Tickets

- Follows up on: [CORE-1691](https://openstax.atlassian.net/browse/CORE-1691) - Phase 1.1: Typography Components Migration
- Implements: [CORE-1692](https://openstax.atlassian.net/browse/CORE-1692) - Phase 1.2: Container Components Migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-1692]: https://openstax.atlassian.net/browse/CORE-1692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-1691]: https://openstax.atlassian.net/browse/CORE-1691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
