### PR TITLE
Core-1545: Remove unnecessary padding from SearchResultsHeader

### DIFF
--- a/src/app/content/search/components/SearchResultsSidebar/__snapshots__/index.spec.tsx.snap
+++ b/src/app/content/search/components/SearchResultsSidebar/__snapshots__/index.spec.tsx.snap
@@ -397,7 +397,6 @@ exports[`SearchResultsSidebar matches snapshot with related key terms 1`] = `
 .c3 {
   font-size: 1.8rem;
   margin-left: 16px;
-  padding: 1rem 0;
   color: #5e6062;
   font-weight: bold;
 }
@@ -1160,7 +1159,6 @@ exports[`SearchResultsSidebar matches snapshot with results 1`] = `
 .c3 {
   font-size: 1.8rem;
   margin-left: 16px;
-  padding: 1rem 0;
   color: #5e6062;
   font-weight: bold;
 }

--- a/src/app/content/search/components/SearchResultsSidebar/styled.tsx
+++ b/src/app/content/search/components/SearchResultsSidebar/styled.tsx
@@ -176,7 +176,6 @@ export const SearchResultsHeader = styled.div`
 export const SearchResultsHeaderTitle = styled.h2`
   font-size: 1.8rem;
   margin-left: 16px;
-  padding: 1rem 0;
   color: ${theme.color.primary.gray.base};
   font-weight: bold;
 `;


### PR DESCRIPTION
[CORE-1545]
This was a result of restructuring the header (for an accessibility change -- moving the close button outside the header). Some no-longer-needed padding was pushing the header into view in mobile.

Images before and after

<img width="325" height="278" alt="image" src="https://github.com/user-attachments/assets/e15104c2-02b2-470c-8f70-44f35d75389e" />
<img width="297" height="256" alt="image" src="https://github.com/user-attachments/assets/950b135b-20dc-4f01-a20b-4b6dc1e97658" />


[CORE-1545]: https://openstax.atlassian.net/browse/CORE-1545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ