### PR TITLE
Fix sticky positioning regression for BookBanner and Topbar

### DIFF
--- a/src/app/components/Dropdown.css
+++ b/src/app/components/Dropdown.css
@@ -1,5 +1,12 @@
 /* Dropdown component styles */
 
+/* Base dropdown container styles */
+.dropdown-hidden,
+.dropdown-transparent {
+  position: relative; /* needed for absolute positioning of dropdown menu */
+  overflow: visible;
+}
+
 /* Keyframe animation for dropdown fade-in */
 @keyframes dropdown-fade-in {
   0% {

--- a/src/app/components/Dropdown.tsx
+++ b/src/app/components/Dropdown.tsx
@@ -102,7 +102,7 @@ const TabHiddenDropDown = React.forwardRef<HTMLElement, TabHiddenProps>((
     if (toggleElement.current) { toggleElement.current.focus(); }
   });
 
-  return <div className={className} ref={mergeRefs(ref, container)}>
+  return <div className={classNames('dropdown-hidden', className)} ref={mergeRefs(ref, container)}>
     <DropdownToggle
       ref={toggleElement}
       component={toggle}
@@ -248,7 +248,6 @@ const DropdownBase = React.forwardRef<HTMLElement, DropdownProps>(({transparentT
 
 const Dropdown = styled(DropdownBase)<DropdownProps>`
   overflow: visible;
-  position: relative;
 `;
 
 export default Dropdown;


### PR DESCRIPTION
## Summary

Fixes a regression in sticky positioning behavior for BookBanner and Topbar on mobile, introduced in PR #2837 (Phase 2.4: Dropdown System Migration).

**Issue:** When scrolling down, the BookBanner and Topbar scroll out of view as expected, but when scrolling back up, they incorrectly snap back to their sticky position instead of scrolling smoothly.

**Root Cause:** The Dropdown component wrapper had `position: relative` applied via styled-components, which created a containing block that interfered with `position: sticky` behavior in ancestor elements.

**Solution:** Moved `position: relative` from the styled-components wrapper to the CSS file with appropriate class selectors (`.dropdown-hidden` and `.dropdown-transparent`). This maintains dropdown menu positioning functionality while allowing parent elements to maintain their sticky positioning behavior.

## Changes

- **src/app/components/Dropdown.tsx**
  - Removed `position: relative` from the styled-components wrapper
  - Added `dropdown-hidden` className to TabHiddenDropDown root element

- **src/app/components/Dropdown.css**
  - Added `position: relative` and `overflow: visible` to `.dropdown-hidden` and `.dropdown-transparent` selectors

## Testing

Manual testing should verify:
1. BookBanner and Topbar stick correctly on mobile when scrolling
2. Dropdown menus still position correctly relative to their triggers
3. All dropdown functionality (open/close, keyboard navigation) still works

## Related

- Fixes regression from: #2837
- Related Jira ticket: [CORE-1698](https://openstax.atlassian.net/browse/CORE-1698)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-1698]: https://openstax.atlassian.net/browse/CORE-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ