### PR TITLE
Phase 3.3: Define theme colors at root level

### DIFF
--- a/PLAIN_CSS_MIGRATION_GUIDE.md
+++ b/PLAIN_CSS_MIGRATION_GUIDE.md
@@ -212,6 +212,84 @@ export function Button({ children, ...props }) {
 }
 ```
 
+### Pattern 2.5: Using Root-Level CSS Variables for Static Theme Colors
+
+For static theme colors that don't require dynamic property access (like `theme.color.text.*`, `theme.color.neutral.*`, `theme.color.disabled.*`), use root-level CSS variables defined in `src/index.css` instead of binding them at the component level.
+
+**Benefits:**
+- Reduces code duplication across components
+- Improves maintainability by centralizing static color definitions
+- Establishes clear patterns for future migrations
+- Still maintains theme.ts as single source of truth
+
+**When to use root-level variables:**
+- Static colors that never change based on props
+- Colors used across multiple components
+- Colors from `theme.color.text.*`, `theme.color.neutral.*`, `theme.color.disabled.*`, and `theme.color.primary.gray.*`
+
+**When to use component-level bindings:**
+- Book-specific theme colors requiring dynamic property access (`theme.color.primary[bookTheme]`)
+- Colors with runtime computations (highlight colors using Color library)
+- Any color that changes based on props or state
+
+**Example:**
+
+```typescript
+// ❌ Before: Component-level binding for static color
+import theme from '../theme';
+
+export function Card({ className, style, ...props }) {
+  return (
+    <div
+      className="modal-card"
+      style={{
+        '--text-color': theme.color.text.default,  // Static, repeated across components
+        ...style,
+      } as React.CSSProperties}
+    />
+  );
+}
+```
+
+```typescript
+// ✅ After: Use root-level CSS variable
+export function Card({ className, style, ...props }) {
+  return (
+    <div
+      className="modal-card"
+      style={style}  // No need to bind static colors
+    />
+  );
+}
+```
+
+```css
+/* Component.css */
+.modal-card {
+  color: var(--color-text-default);  /* References root-level variable */
+  background: var(--color-neutral-base);
+}
+```
+
+**Naming Convention:**
+
+Root-level CSS variables follow the pattern: `--color-{category}-{property}`
+
+- `theme.color.text.default` → `--color-text-default`
+- `theme.color.neutral.pageBackground` → `--color-neutral-page-background`
+- `theme.color.primary.gray.base` → `--color-primary-gray-base`
+- `theme.color.disabled.foreground` → `--color-disabled-foreground`
+
+Note: camelCase properties in theme.ts become kebab-case in CSS variable names.
+
+**Available Root-Level Variables:**
+
+See `src/index.css` for the complete list of available root-level CSS variables. These include:
+- Text colors: `--color-text-black`, `--color-text-default`, `--color-text-label`, `--color-text-white`
+- Neutral colors: `--color-neutral-base`, `--color-neutral-darker`, `--color-neutral-darkest`, `--color-neutral-page-background`, etc.
+- Disabled colors: `--color-disabled-base`, `--color-disabled-foreground`
+- Primary gray colors: `--color-primary-gray-base`, `--color-primary-gray-darker`, etc.
+
 ### Pattern 3: Component with Dynamic Theme Access
 
 For components that need **runtime theme lookups** (this is the key pattern!):

--- a/PLAIN_CSS_MIGRATION_GUIDE.md
+++ b/PLAIN_CSS_MIGRATION_GUIDE.md
@@ -220,8 +220,9 @@ For static theme colors that don't require dynamic property access (like `theme.
 - Reduces code duplication across components
 - Improves maintainability by centralizing static color definitions
 - Establishes clear patterns for future migrations
-- Still maintains theme.ts as single source of truth
+- Keeps a documented mapping from `src/app/theme.ts` into shared CSS variables
 
+**Important:** The root-level variables in `src/index.css` are copied from `src/app/theme.ts`; they are not automatically generated or verified by the process described in this guide. When updating these values, keep `src/index.css` and `src/app/theme.ts` in sync manually.
 **When to use root-level variables:**
 - Static colors that never change based on props
 - Colors used across multiple components

--- a/src/app/components/Modal/Modal.css
+++ b/src/app/components/Modal/Modal.css
@@ -34,7 +34,7 @@
   /* bodyCopyRegularStyle - font-size: 1.6rem, line-height: 2.5rem, color from theme */
   font-size: 1.6rem;
   line-height: 2.5rem;
-  color: var(--text-color, #424242);
+  color: var(--color-text-default);
 }
 
 /* Link styling inside modal card - mirrors bodyCopyRegularStyle link behavior */
@@ -54,8 +54,8 @@
   align-items: center;
   margin-bottom: 1.5rem; /* modalPadding * 0.5 = 3.0 * 0.5 */
   padding: 1.5rem 3rem; /* modalPadding * 0.5, modalPadding */
-  background: var(--header-bg, #f1f1f1);
-  border-bottom: solid 0.1rem var(--header-border, #fafafa);
+  background: var(--color-neutral-page-background);
+  border-bottom: solid 0.1rem var(--color-neutral-darker);
   justify-content: space-between;
 }
 
@@ -67,7 +67,7 @@
   letter-spacing: -0.02rem;
   padding: 1rem 0 1rem 0;
   margin: 0;
-  color: var(--text-color, #424242);
+  color: var(--color-text-default);
 
   /* Additional heading styles */
   display: flex;
@@ -89,7 +89,7 @@
   line-height: 3rem;
   letter-spacing: -0.02rem;
   margin: 0;
-  color: var(--text-color, #424242);
+  color: var(--color-text-default);
 
   /* Additional styles from BodyHeading */
   font-weight: 400;

--- a/src/app/components/Modal/Modal.css
+++ b/src/app/components/Modal/Modal.css
@@ -54,8 +54,8 @@
   align-items: center;
   margin-bottom: 1.5rem; /* modalPadding * 0.5 = 3.0 * 0.5 */
   padding: 1.5rem 3rem; /* modalPadding * 0.5, modalPadding */
-  background: var(--color-neutral-page-background);
-  border-bottom: solid 0.1rem var(--color-neutral-darker);
+  background: var(--color-neutral-page-background, '#f1f1f1');
+  border-bottom: solid 0.1rem var(--color-neutral-darker, '#fafafa');
   justify-content: space-between;
 }
 

--- a/src/app/components/Modal/Modal.css
+++ b/src/app/components/Modal/Modal.css
@@ -54,8 +54,8 @@
   align-items: center;
   margin-bottom: 1.5rem; /* modalPadding * 0.5 = 3.0 * 0.5 */
   padding: 1.5rem 3rem; /* modalPadding * 0.5, modalPadding */
-  background: var(--color-neutral-page-background, '#f1f1f1');
-  border-bottom: solid 0.1rem var(--color-neutral-darker, '#fafafa');
+  background: var(--color-neutral-page-background, #f1f1f1);
+  border-bottom: solid 0.1rem var(--color-neutral-darker, #fafafa);
   justify-content: space-between;
 }
 

--- a/src/app/components/Modal/Modal.tsx
+++ b/src/app/components/Modal/Modal.tsx
@@ -54,7 +54,6 @@ export function Card(
       {...props}
       className={classNames('modal-card', className)}
       style={{
-        '--text-color': theme.color.text.default,
         '--link-color': linkColor,
         '--link-hover-color': linkHover,
         ...style,
@@ -71,11 +70,7 @@ export function Header(
     <header
       {...props}
       className={classNames('modal-header', className)}
-      style={{
-        '--header-bg': theme.color.neutral.pageBackground,
-        '--header-border': theme.color.neutral.darker,
-        ...style,
-      } as React.CSSProperties}
+      style={style}
     />
   );
 }
@@ -89,10 +84,7 @@ export function Heading(
     <h1
       {...props}
       className={classNames('modal-heading', className)}
-      style={{
-        '--text-color': theme.color.text.default,
-        ...style,
-      } as React.CSSProperties}
+      style={style}
     >
       {children}
     </h1>
@@ -108,10 +100,7 @@ export function BodyHeading(
     <h3
       {...props}
       className={classNames('modal-body-heading', className)}
-      style={{
-        '--text-color': theme.color.text.default,
-        ...style,
-      } as React.CSSProperties}
+      style={style}
     >
       {children}
     </h3>

--- a/src/app/components/Modal/__snapshots__/Modal.spec.tsx.snap
+++ b/src/app/components/Modal/__snapshots__/Modal.spec.tsx.snap
@@ -18,26 +18,14 @@ exports[`Modal matches snapshot 1`] = `
         Object {
           "--link-color": "#027EB5",
           "--link-hover-color": "#0064A0",
-          "--text-color": "#424242",
         }
       }
     >
       <header
         className="modal-header"
-        style={
-          Object {
-            "--header-bg": "#f1f1f1",
-            "--header-border": "#fafafa",
-          }
-        }
       >
         <h1
           className="modal-heading"
-          style={
-            Object {
-              "--text-color": "#424242",
-            }
-          }
         >
           Discard unsaved changes?
         </h1>
@@ -108,26 +96,14 @@ exports[`Modal matches snapshot with children 1`] = `
         Object {
           "--link-color": "#027EB5",
           "--link-hover-color": "#0064A0",
-          "--text-color": "#424242",
         }
       }
     >
       <header
         className="modal-header"
-        style={
-          Object {
-            "--header-bg": "#f1f1f1",
-            "--header-border": "#fafafa",
-          }
-        }
       >
         <h1
           className="modal-heading"
-          style={
-            Object {
-              "--text-color": "#424242",
-            }
-          }
         >
           Discard unsaved changes?
         </h1>

--- a/src/app/content/highlights/components/__snapshots__/ConfirmationModal.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/ConfirmationModal.spec.tsx.snap
@@ -25,26 +25,14 @@ exports[`ConfirmationModal matches snapshot 1`] = `
         Object {
           "--link-color": "#027EB5",
           "--link-hover-color": "#0064A0",
-          "--text-color": "#424242",
         }
       }
     >
       <header
         className="modal-header"
-        style={
-          Object {
-            "--header-bg": "#f1f1f1",
-            "--header-border": "#fafafa",
-          }
-        }
       >
         <h1
           className="modal-heading"
-          style={
-            Object {
-              "--text-color": "#424242",
-            }
-          }
         >
           Discard unsaved changes?
         </h1>
@@ -94,11 +82,6 @@ exports[`ConfirmationModal matches snapshot 1`] = `
       >
         <h3
           className="modal-body-heading "
-          style={
-            Object {
-              "--text-color": "#424242",
-            }
-          }
         >
           You have an unsaved note on this page.
         </h3>

--- a/src/app/errors/components/__snapshots__/ErrorModal.spec.tsx.snap
+++ b/src/app/errors/components/__snapshots__/ErrorModal.spec.tsx.snap
@@ -18,26 +18,14 @@ exports[`ErrorModal matches snapshot 1`] = `
         Object {
           "--link-color": "#027EB5",
           "--link-hover-color": "#0064A0",
-          "--text-color": "#424242",
         }
       }
     >
       <header
         className="modal-header"
-        style={
-          Object {
-            "--header-bg": "#f1f1f1",
-            "--header-border": "#fafafa",
-          }
-        }
       >
         <h1
           className="modal-heading"
-          style={
-            Object {
-              "--text-color": "#424242",
-            }
-          }
         >
           Error
         </h1>
@@ -88,11 +76,6 @@ exports[`ErrorModal matches snapshot 1`] = `
         <h3
           className="modal-body-heading "
           id="modal-title"
-          style={
-            Object {
-              "--text-color": "#424242",
-            }
-          }
         >
           Uh-oh, there's been a glitch
         </h3>
@@ -168,26 +151,14 @@ exports[`ErrorModal matches snapshots with recorded error ids 1`] = `
         Object {
           "--link-color": "#027EB5",
           "--link-hover-color": "#0064A0",
-          "--text-color": "#424242",
         }
       }
     >
       <header
         className="modal-header"
-        style={
-          Object {
-            "--header-bg": "#f1f1f1",
-            "--header-border": "#fafafa",
-          }
-        }
       >
         <h1
           className="modal-heading"
-          style={
-            Object {
-              "--text-color": "#424242",
-            }
-          }
         >
           Error
         </h1>
@@ -238,11 +209,6 @@ exports[`ErrorModal matches snapshots with recorded error ids 1`] = `
         <h3
           className="modal-body-heading "
           id="modal-title"
-          style={
-            Object {
-              "--text-color": "#424242",
-            }
-          }
         >
           Uh-oh, there's been a glitch
         </h3>

--- a/src/index.css
+++ b/src/index.css
@@ -209,3 +209,42 @@ noscript {
   font-weight: 900;
   font-style: italic;
 }
+
+/*
+ * Root-level CSS variables for static theme colors.
+ * These values are derived from theme.ts and provide a centralized place
+ * for static colors that don't require dynamic property access.
+ *
+ * Dynamic colors (e.g., book themes) should continue using component-level
+ * bindings as per the hybrid approach documented in PLAIN_CSS_MIGRATION_GUIDE.md
+ */
+:root {
+  /* Text colors from theme.color.text */
+  --color-text-black: #000;
+  --color-text-default: #424242;
+  --color-text-label: #6f6f6f;
+  --color-text-white: #fff;
+
+  /* Neutral colors from theme.color.neutral */
+  --color-neutral-base: #fff;
+  --color-neutral-darker: #fafafa;
+  --color-neutral-darkest: #e5e5e5;
+  --color-neutral-foreground: #424242;
+  --color-neutral-form-background: #f5f5f5;
+  --color-neutral-form-border: #d5d5d5;
+  --color-neutral-page-background: #f1f1f1;
+
+  /* Disabled colors from theme.color.disabled */
+  --color-disabled-base: #f1f1f1;
+  --color-disabled-foreground: #c1c1c1;
+
+  /* Primary gray colors from theme.color.primary.gray */
+  --color-primary-gray-base: #5e6062;
+  --color-primary-gray-darker: #424242;
+  --color-primary-gray-foreground: #fff;
+  --color-primary-gray-foreground-hover: #424242;
+  --color-primary-gray-light: #767676;
+  --color-primary-gray-medium: #888888;
+  --color-primary-gray-lighter: #c5c5c5;
+  --color-primary-gray-lightest: #ededed;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -244,7 +244,7 @@ noscript {
   --color-primary-gray-foreground: #fff;
   --color-primary-gray-foreground-hover: #424242;
   --color-primary-gray-light: #767676;
-  --color-primary-gray-medium: #888888;
+  --color-primary-gray-medium: #888;
   --color-primary-gray-lighter: #c5c5c5;
   --color-primary-gray-lightest: #ededed;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -212,8 +212,13 @@ noscript {
 
 /*
  * Root-level CSS variables for static theme colors.
- * These values are derived from theme.ts and provide a centralized place
- * for static colors that don't require dynamic property access.
+ *
+ * Source of truth: src/app/theme.ts
+ *
+ * These variables intentionally mirror a static subset of the theme values so
+ * plain CSS can use them without dynamic property access. If any corresponding
+ * color value changes in src/app/theme.ts, this block must be updated in the
+ * same change to keep the duplicated values in sync.
  *
  * Dynamic colors (e.g., book themes) should continue using component-level
  * bindings as per the hybrid approach documented in PLAIN_CSS_MIGRATION_GUIDE.md


### PR DESCRIPTION
## Summary

Establishes a standard pattern for theme color usage by defining CSS variables at the `:root` level instead of binding them inline at the component level. This improves maintainability, reduces duplication, and establishes a clear pattern for future theme color usage.

## Changes Made

### 1. Added Root-Level CSS Variables (`src/index.css`)
- Defined static theme colors at `:root` level following the naming convention `--color-{category}-{property}`
- Includes text, neutral, disabled, and primary gray colors
- Values sourced from `theme.ts` to maintain single source of truth

### 2. Updated Modal Components
- **Modal.tsx**: Removed inline style bindings for static colors (`--text-color`, `--header-bg`, `--header-border`)
- **Modal.css**: Updated to reference root-level variables:
  - `var(--text-color)` → `var(--color-text-default)`
  - `var(--header-bg)` → `var(--color-neutral-page-background)`
  - `var(--header-border)` → `var(--color-neutral-darker)`

### 3. Updated Migration Guide
- Added **Pattern 2.5** documenting when to use root-level vs component-level CSS variables
- Established naming conventions for root-level variables
- Provided clear examples and decision criteria

## Benefits
- ✅ Reduces code duplication across components
- ✅ Improves maintainability
- ✅ Establishes clear patterns for future migrations
- ✅ Maintains hybrid approach (theme.ts as source of truth)

## Technical Notes
- Dynamic colors (book themes, highlights) continue using component-level bindings as per hybrid approach
- `theme.ts` remains unchanged as the single source of truth
- No visual changes expected (variables resolve to same values)

## Testing Focus

Manual testers should verify:
- ✅ Modal components render correctly with no visual changes
- ✅ Modal text colors match expected theme colors
- ✅ Modal header background and border colors are correct
- ✅ All existing Modal functionality works (open, close, interactions)

## Related Issues

Implements: [CORE-1840](https://openstax.atlassian.net/browse/CORE-1840) - Phase 3.3: Define theme colors at root level
Part of: Plain CSS migration effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-1840]: https://openstax.atlassian.net/browse/CORE-1840