### PR TITLE
Fix: Toast notification z-index above modal overlay [CORE-1848]

### DIFF
--- a/src/app/content/components/ConfirmationToast.tsx
+++ b/src/app/content/components/ConfirmationToast.tsx
@@ -9,7 +9,7 @@ const HiddenLiveRegion = styled.div`
 
 const ElevatedToastContainer = styled(ToastContainer)`
   &&& {
-    z-index: ${theme.zIndex.navbar + 1};
+    z-index: ${theme.zIndex.nudgeOverlay + 1};
   }
 `;
 

--- a/src/app/content/highlights/components/__snapshots__/EditCard.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/EditCard.spec.tsx.snap
@@ -16,7 +16,7 @@ Array [
 }
 
 .c1.c1.c1 {
-  z-index: 71;
+  z-index: 131;
 }
 
 <div
@@ -202,7 +202,7 @@ Array [
 }
 
 .c1.c1.c1 {
-  z-index: 71;
+  z-index: 131;
 }
 
 <div


### PR DESCRIPTION
## Summary

Fixes the z-index layering issue where the "Highlight removed" confirmation toast appears behind the My Highlights modal overlay, making it obscured and difficult to see.

## Changes

- Updated `ConfirmationToast.tsx` to use `theme.zIndex.nudgeOverlay + 1` (131) instead of `theme.zIndex.navbar + 1` (71)
- This ensures the toast appears above all modals including the My Highlights modal (z-index 110)

## Testing

1. Open a textbook in REX
2. Create a highlight
3. Open the My Highlights and Notes modal
4. Delete the highlight
5. Verify the "Highlight removed" toast appears above the dark overlay and is fully visible

## Before/After

**Before:** Toast z-index was 71, modal overlay was 110 → toast appeared behind overlay
**After:** Toast z-index is 131, modal overlay is 110 → toast appears above overlay

## Related

- Jira: [CORE-1848](https://openstax.atlassian.net/browse/CORE-1848)
- See the detailed implementation plan in the Jira ticket description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-1848]: https://openstax.atlassian.net/browse/CORE-1848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ