### PR TITLE
CORE-1541: Trap tab navigation in My Highlights dialog

### DIFF
--- a/src/app/content/highlights/components/HighlightsPopUp.spec.tsx
+++ b/src/app/content/highlights/components/HighlightsPopUp.spec.tsx
@@ -275,8 +275,10 @@ describe('MyHighlights button and PopUp', () => {
       </TestContainer>);
 
       setTimeout(() => {
-        const modal = document.querySelector('[data-testid="highlights-popup-wrapper"]');
-        assertNotNull(modal, 'modal should exist');
+        const modal = assertNotNull(
+          document.querySelector('[data-testid="highlights-popup-wrapper"]'),
+          'modal should exist'
+        );
 
         const focusableElements = Array.from(
           modal.querySelectorAll<HTMLElement>(
@@ -317,8 +319,10 @@ describe('MyHighlights button and PopUp', () => {
       </TestContainer>);
 
       setTimeout(() => {
-        const modal = document.querySelector('[data-testid="highlights-popup-wrapper"]');
-        assertNotNull(modal, 'modal should exist');
+        const modal = assertNotNull(
+          document.querySelector('[data-testid="highlights-popup-wrapper"]'),
+          'modal should exist'
+        );
 
         const focusableElements = Array.from(
           modal.querySelectorAll<HTMLElement>(

--- a/src/app/content/highlights/components/HighlightsPopUp.spec.tsx
+++ b/src/app/content/highlights/components/HighlightsPopUp.spec.tsx
@@ -264,6 +264,92 @@ describe('MyHighlights button and PopUp', () => {
     }, 10);
   });
 
+  describe('tab navigation trapping', () => {
+    it('wraps focus from last to first element when Tab is pressed', (done) => {
+      const document = utils.assertDocument();
+      store.dispatch(openMyHighlights());
+      store.dispatch(receiveUser(user));
+
+      renderToDom(<TestContainer services={services} store={store}>
+        <HighlightsPopUp />
+      </TestContainer>);
+
+      setTimeout(() => {
+        const modal = document.querySelector('[data-testid="highlights-popup-wrapper"]');
+        assertNotNull(modal, 'modal should exist');
+
+        const focusableElements = Array.from(
+          modal.querySelectorAll<HTMLElement>(
+            'button, input, select, textarea, [href], [tabindex]:not([tabindex="-1"])'
+          )
+        ).filter(el => !el.hasAttribute('disabled'));
+
+        expect(focusableElements.length).toBeGreaterThan(0);
+
+        const lastElement = focusableElements[focusableElements.length - 1];
+        const firstElement = focusableElements[0];
+
+        lastElement.focus();
+        expect(document.activeElement).toBe(lastElement);
+
+        // Simulate Tab key press on the last element
+        dispatchKeyDownEvent({
+          element: modal as HTMLElement,
+          key: 'Tab',
+          shiftKey: false,
+          target: lastElement,
+        });
+
+        setTimeout(() => {
+          expect(document.activeElement).toBe(firstElement);
+          done();
+        }, 10);
+      }, 10);
+    });
+
+    it('wraps focus from first to last element when Shift+Tab is pressed', (done) => {
+      const document = utils.assertDocument();
+      store.dispatch(openMyHighlights());
+      store.dispatch(receiveUser(user));
+
+      renderToDom(<TestContainer services={services} store={store}>
+        <HighlightsPopUp />
+      </TestContainer>);
+
+      setTimeout(() => {
+        const modal = document.querySelector('[data-testid="highlights-popup-wrapper"]');
+        assertNotNull(modal, 'modal should exist');
+
+        const focusableElements = Array.from(
+          modal.querySelectorAll<HTMLElement>(
+            'button, input, select, textarea, [href], [tabindex]:not([tabindex="-1"])'
+          )
+        ).filter(el => !el.hasAttribute('disabled'));
+
+        expect(focusableElements.length).toBeGreaterThan(0);
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        firstElement.focus();
+        expect(document.activeElement).toBe(firstElement);
+
+        // Simulate Shift+Tab key press on the first element
+        dispatchKeyDownEvent({
+          element: modal as HTMLElement,
+          key: 'Tab',
+          shiftKey: true,
+          target: firstElement,
+        });
+
+        setTimeout(() => {
+          expect(document.activeElement).toBe(lastElement);
+          done();
+        }, 10);
+      }, 10);
+    });
+  });
+
   describe('with unsaved highlights', () => {
 
     beforeEach(() => {

--- a/src/app/content/highlights/components/HighlightsPopUp.tsx
+++ b/src/app/content/highlights/components/HighlightsPopUp.tsx
@@ -9,7 +9,7 @@ import notLoggedImage2Retina from '../../../../assets/My_Highlights_page_empty_2
 import { useAnalyticsEvent } from '../../../../helpers/analytics';
 import * as authSelect from '../../../auth/selectors';
 import { User } from '../../../auth/types';
-import { useOnEsc } from '../../../reactUtils';
+import { useOnEsc, useTrapTabNavigation } from '../../../reactUtils';
 import theme from '../../../theme';
 import { AppState, Dispatch } from '../../../types';
 import { useModalFocusManagementUnmounting } from '../../hooks/useModalFocusManagement';
@@ -109,6 +109,7 @@ const HighlightsPopUp = ({ closeMyHighlights, ...props }: Omit<Props, 'myHighlig
   const { closeButtonRef } = useModalFocusManagementUnmounting('highlights');
 
   useOnEsc(true, closeAndTrack('esc'));
+  useTrapTabNavigation(popUpRef);
 
   return <Modal
     ref={popUpRef}


### PR DESCRIPTION
## Summary

This PR fixes tab navigation trapping in the My Highlights dialog to prevent keyboard users from accessing elements behind the modal.

**Jira Ticket:** [CORE-1541](https://openstax.atlassian.net/browse/CORE-1541)

## Problem

The My Highlights dialog was missing tab navigation trapping, allowing keyboard and screen reader users to tab out of the modal and access content behind it. This creates accessibility issues:
- Keyboard users have difficulty determining their position in the page
- Unintended access to controls behind the dialog
- Violates WCAG 2.1 Level A success criteria 1.1.1

## Solution

Added the `useTrapTabNavigation` hook to the `HighlightsPopUp` component, following the same pattern used in other modal popups (`StudyGuidesPopUp` and `PracticeQuestionsPopup`).

## Changes

**File:** `src/app/content/highlights/components/HighlightsPopUp.tsx`
- Added `useTrapTabNavigation` to imports from `reactUtils`
- Called `useTrapTabNavigation(popUpRef)` to enable tab trapping

## Expected Behavior

After this fix:
- Tabbing forward from the last focusable element wraps to the first element
- Shift+tabbing backward from the first focusable element wraps to the last element
- Focus never escapes the dialog to access elements behind it

## Test Plan

1. Open the My Highlights dialog
2. Use keyboard tab navigation to move through all focusable elements
3. Verify that pressing Tab on the last element wraps to the first element
4. Verify that pressing Shift+Tab on the first element wraps to the last element
5. Verify that focus never escapes to elements behind the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-1541]: https://openstax.atlassian.net/browse/CORE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ