### PR TITLE
[CORE-1834] Phase 5.3: Highlights Edit Mode Components Migration

### DIFF
--- a/src/app/content/__snapshots__/routes.spec.tsx.snap
+++ b/src/app/content/__snapshots__/routes.spec.tsx.snap
@@ -35,6 +35,21 @@ exports[`assigned route route renders renders a component 1`] = `
   justify-content: flex-end;
 }
 
+.c1 {
+  box-shadow: 0 0.2rem 0.2rem 0 rgba(0,0,0,0.14);
+  background-color: #fff;
+  color: #424242;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 5rem;
+}
+
+.c1.c1 {
+  top: 0;
+}
+
 .c15 {
   height: 1.7rem;
   width: 1.7rem;
@@ -60,21 +75,6 @@ exports[`assigned route route renders renders a component 1`] = `
 
 .c11::-webkit-details-marker {
   display: none;
-}
-
-.c1 {
-  box-shadow: 0 0.2rem 0.2rem 0 rgba(0,0,0,0.14);
-  background-color: #fff;
-  color: #424242;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 5rem;
-}
-
-.c1.c1 {
-  top: 0;
 }
 
 .c2 {

--- a/src/app/content/components/popUp/__snapshots__/ColorFilter.spec.tsx.snap
+++ b/src/app/content/components/popUp/__snapshots__/ColorFilter.spec.tsx.snap
@@ -164,7 +164,6 @@ exports[`ColorFilter matches snapshot 1`] = `
         style={
           Object {
             "--focus-border-color": "#8f7700",
-            "--focus-outline-color": "var(--focus-outline-color)",
             "--focused-color": "#fed200",
             "--passive-color": "#ffff8a",
           }
@@ -223,7 +222,6 @@ exports[`ColorFilter matches snapshot 1`] = `
         style={
           Object {
             "--focus-border-color": "#4e6f01",
-            "--focus-outline-color": "var(--focus-outline-color)",
             "--focused-color": "#92d101",
             "--passive-color": "#def99f",
           }
@@ -282,7 +280,6 @@ exports[`ColorFilter matches snapshot 1`] = `
         style={
           Object {
             "--focus-border-color": "#006880",
-            "--focus-outline-color": "var(--focus-outline-color)",
             "--focused-color": "#00c3ed",
             "--passive-color": "#c8f5ff",
           }
@@ -341,7 +338,6 @@ exports[`ColorFilter matches snapshot 1`] = `
         style={
           Object {
             "--focus-border-color": "#141a3e",
-            "--focus-outline-color": "var(--focus-outline-color)",
             "--focused-color": "#545ec8",
             "--passive-color": "#cbcfff",
           }
@@ -400,7 +396,6 @@ exports[`ColorFilter matches snapshot 1`] = `
         style={
           Object {
             "--focus-border-color": "#560131",
-            "--focus-outline-color": "var(--focus-outline-color)",
             "--focused-color": "#de017e",
             "--passive-color": "#ffc5e1",
           }

--- a/src/app/content/components/popUp/__snapshots__/ColorFilter.spec.tsx.snap
+++ b/src/app/content/components/popUp/__snapshots__/ColorFilter.spec.tsx.snap
@@ -26,265 +26,6 @@ exports[`ColorFilter matches snapshot 1`] = `
   padding: 0 1rem;
 }
 
-.c9 {
-  display: none;
-}
-
-.c11 {
-  display: none;
-  position: absolute;
-  height: 2rem;
-  width: 2rem;
-  background-color: transparent;
-  z-index: -1;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-}
-
-.c12 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #fed200;
-}
-
-.c15 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #92d101;
-}
-
-.c17 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #00c3ed;
-}
-
-.c19 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #545ec8;
-}
-
-.c21 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #de017e;
-}
-
-.c7 {
-  position: relative;
-  background-color: #ffff8a;
-  border: 1px solid #8f7700;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c7 .c8 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c7 input:focus + .c10 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c14 {
-  position: relative;
-  background-color: #def99f;
-  border: 1px solid #4e6f01;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c14 .c8 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c14 input:focus + .c10 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c16 {
-  position: relative;
-  background-color: #c8f5ff;
-  border: 1px solid #006880;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c16 .c8 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c16 input:focus + .c10 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c18 {
-  position: relative;
-  background-color: #cbcfff;
-  border: 1px solid #141a3e;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c18 .c8 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c18 input:focus + .c10 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c20 {
-  position: relative;
-  background-color: #ffc5e1;
-  border: 1px solid #560131;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c20 .c8 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c20 input:focus + .c10 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
 .c4 {
   padding: 0;
   border: none;
@@ -304,7 +45,7 @@ exports[`ColorFilter matches snapshot 1`] = `
   border: 0;
 }
 
-.c13 {
+.c7 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -418,11 +159,20 @@ exports[`ColorFilter matches snapshot 1`] = `
         </svg>
       </span>
       <div
-        className="c6 c7"
+        className="color-indicator c6 "
+        data-size="small"
+        style={
+          Object {
+            "--focus-border-color": "#8f7700",
+            "--focus-outline-color": "var(--focus-outline-color)",
+            "--focused-color": "#fed200",
+            "--passive-color": "#ffff8a",
+          }
+        }
       >
         <svg
           aria-hidden="true"
-          className="c8 c9"
+          className="color-indicator-check "
           viewBox="0 0 512 512"
         >
           <path
@@ -431,32 +181,14 @@ exports[`ColorFilter matches snapshot 1`] = `
           />
         </svg>
         <span
-          className="c10 c11"
-          size="small"
-          style={
-            Object {
-              "focusBorder": "#8f7700",
-              "focused": "#fed200",
-              "label": "yellow",
-              "passive": "#ffff8a",
-            }
-          }
+          className="color-indicator-focus"
         />
         <span
-          className="c12"
-          size="small"
-          style={
-            Object {
-              "focusBorder": "#8f7700",
-              "focused": "#fed200",
-              "label": "yellow",
-              "passive": "#ffff8a",
-            }
-          }
+          className="color-indicator-ring"
         />
       </div>
       <span
-        className="c13"
+        className="c7"
       >
         yellow
       </span>
@@ -486,11 +218,20 @@ exports[`ColorFilter matches snapshot 1`] = `
         </svg>
       </span>
       <div
-        className="c6 c14"
+        className="color-indicator c6 "
+        data-size="small"
+        style={
+          Object {
+            "--focus-border-color": "#4e6f01",
+            "--focus-outline-color": "var(--focus-outline-color)",
+            "--focused-color": "#92d101",
+            "--passive-color": "#def99f",
+          }
+        }
       >
         <svg
           aria-hidden="true"
-          className="c8 c9"
+          className="color-indicator-check "
           viewBox="0 0 512 512"
         >
           <path
@@ -499,32 +240,14 @@ exports[`ColorFilter matches snapshot 1`] = `
           />
         </svg>
         <span
-          className="c10 c11"
-          size="small"
-          style={
-            Object {
-              "focusBorder": "#4e6f01",
-              "focused": "#92d101",
-              "label": "green",
-              "passive": "#def99f",
-            }
-          }
+          className="color-indicator-focus"
         />
         <span
-          className="c15"
-          size="small"
-          style={
-            Object {
-              "focusBorder": "#4e6f01",
-              "focused": "#92d101",
-              "label": "green",
-              "passive": "#def99f",
-            }
-          }
+          className="color-indicator-ring"
         />
       </div>
       <span
-        className="c13"
+        className="c7"
       >
         green
       </span>
@@ -554,11 +277,20 @@ exports[`ColorFilter matches snapshot 1`] = `
         </svg>
       </span>
       <div
-        className="c6 c16"
+        className="color-indicator c6 "
+        data-size="small"
+        style={
+          Object {
+            "--focus-border-color": "#006880",
+            "--focus-outline-color": "var(--focus-outline-color)",
+            "--focused-color": "#00c3ed",
+            "--passive-color": "#c8f5ff",
+          }
+        }
       >
         <svg
           aria-hidden="true"
-          className="c8 c9"
+          className="color-indicator-check "
           viewBox="0 0 512 512"
         >
           <path
@@ -567,32 +299,14 @@ exports[`ColorFilter matches snapshot 1`] = `
           />
         </svg>
         <span
-          className="c10 c11"
-          size="small"
-          style={
-            Object {
-              "focusBorder": "#006880",
-              "focused": "#00c3ed",
-              "label": "blue",
-              "passive": "#c8f5ff",
-            }
-          }
+          className="color-indicator-focus"
         />
         <span
-          className="c17"
-          size="small"
-          style={
-            Object {
-              "focusBorder": "#006880",
-              "focused": "#00c3ed",
-              "label": "blue",
-              "passive": "#c8f5ff",
-            }
-          }
+          className="color-indicator-ring"
         />
       </div>
       <span
-        className="c13"
+        className="c7"
       >
         blue
       </span>
@@ -622,11 +336,20 @@ exports[`ColorFilter matches snapshot 1`] = `
         </svg>
       </span>
       <div
-        className="c6 c18"
+        className="color-indicator c6 "
+        data-size="small"
+        style={
+          Object {
+            "--focus-border-color": "#141a3e",
+            "--focus-outline-color": "var(--focus-outline-color)",
+            "--focused-color": "#545ec8",
+            "--passive-color": "#cbcfff",
+          }
+        }
       >
         <svg
           aria-hidden="true"
-          className="c8 c9"
+          className="color-indicator-check "
           viewBox="0 0 512 512"
         >
           <path
@@ -635,32 +358,14 @@ exports[`ColorFilter matches snapshot 1`] = `
           />
         </svg>
         <span
-          className="c10 c11"
-          size="small"
-          style={
-            Object {
-              "focusBorder": "#141a3e",
-              "focused": "#545ec8",
-              "label": "purple",
-              "passive": "#cbcfff",
-            }
-          }
+          className="color-indicator-focus"
         />
         <span
-          className="c19"
-          size="small"
-          style={
-            Object {
-              "focusBorder": "#141a3e",
-              "focused": "#545ec8",
-              "label": "purple",
-              "passive": "#cbcfff",
-            }
-          }
+          className="color-indicator-ring"
         />
       </div>
       <span
-        className="c13"
+        className="c7"
       >
         purple
       </span>
@@ -690,11 +395,20 @@ exports[`ColorFilter matches snapshot 1`] = `
         </svg>
       </span>
       <div
-        className="c6 c20"
+        className="color-indicator c6 "
+        data-size="small"
+        style={
+          Object {
+            "--focus-border-color": "#560131",
+            "--focus-outline-color": "var(--focus-outline-color)",
+            "--focused-color": "#de017e",
+            "--passive-color": "#ffc5e1",
+          }
+        }
       >
         <svg
           aria-hidden="true"
-          className="c8 c9"
+          className="color-indicator-check "
           viewBox="0 0 512 512"
         >
           <path
@@ -703,32 +417,14 @@ exports[`ColorFilter matches snapshot 1`] = `
           />
         </svg>
         <span
-          className="c10 c11"
-          size="small"
-          style={
-            Object {
-              "focusBorder": "#560131",
-              "focused": "#de017e",
-              "label": "pink",
-              "passive": "#ffc5e1",
-            }
-          }
+          className="color-indicator-focus"
         />
         <span
-          className="c21"
-          size="small"
-          style={
-            Object {
-              "focusBorder": "#560131",
-              "focused": "#de017e",
-              "label": "pink",
-              "passive": "#ffc5e1",
-            }
-          }
+          className="color-indicator-ring"
         />
       </div>
       <span
-        className="c13"
+        className="c7"
       >
         pink
       </span>

--- a/src/app/content/highlights/components/ColorIndicator.css
+++ b/src/app/content/highlights/components/ColorIndicator.css
@@ -67,7 +67,7 @@
 
 .color-indicator input:focus + .color-indicator-focus {
   display: block;
-  outline: 0.2rem solid var(--focus-outline-color);
+  outline: 0.2rem solid var(--focus-outline-color, #007297);
   outline-offset: 0.1rem;
   z-index: 1;
 }

--- a/src/app/content/highlights/components/ColorIndicator.css
+++ b/src/app/content/highlights/components/ColorIndicator.css
@@ -67,8 +67,10 @@
 
 .color-indicator input:focus + .color-indicator-focus {
   display: block;
-  outline: 0.2rem solid var(--focus-outline-color, #007297);
-  outline-offset: 0.1rem;
+
+  /* Browser default outline for focus items (from theme.ts defaultFocusOutline) */
+  outline: 0.2rem auto Highlight;
+  outline: 0.2rem auto -webkit-focus-ring-color;
   z-index: 1;
 }
 

--- a/src/app/content/highlights/components/ColorIndicator.css
+++ b/src/app/content/highlights/components/ColorIndicator.css
@@ -1,0 +1,113 @@
+/* ColorIndicator styles */
+
+/* Base color indicator */
+.color-indicator {
+  position: relative;
+  height: 2.4rem;
+  width: 2.4rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 2rem;
+  overflow: visible;
+  background-color: var(--passive-color);
+  border: 1px solid var(--focus-border-color);
+}
+
+.color-indicator[data-size="small"] {
+  height: 1.6rem;
+  width: 1.6rem;
+}
+
+.color-indicator[data-shape="square"] {
+  border-radius: 0;
+}
+
+/* Check icon */
+.color-indicator-check {
+  height: 1.6rem;
+  width: 1.6rem;
+  display: none;
+}
+
+.color-indicator[data-size="small"] .color-indicator-check {
+  height: 1rem;
+  width: 1rem;
+}
+
+.color-indicator[data-checked="true"] .color-indicator-check {
+  color: var(--focused-color);
+  stroke: var(--focus-border-color);
+  stroke-width: 5%;
+  display: block;
+}
+
+/* Focused style ring */
+.color-indicator-focus {
+  display: none;
+  position: absolute;
+  height: 2.8rem;
+  width: 2.8rem;
+  background-color: transparent;
+  z-index: -1;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+}
+
+.color-indicator[data-size="small"] .color-indicator-focus {
+  height: 2rem;
+  width: 2rem;
+}
+
+.color-indicator[data-shape="square"] .color-indicator-focus {
+  border-radius: 0;
+}
+
+.color-indicator input:focus + .color-indicator-focus {
+  display: block;
+  outline: 0.2rem solid var(--focus-outline-color);
+  outline-offset: 0.1rem;
+  z-index: 1;
+}
+
+/* Color ring */
+.color-indicator-ring {
+  height: 2.2rem;
+  width: 2.2rem;
+  background-color: transparent;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 1px solid var(--focused-color);
+}
+
+.color-indicator[data-size="small"] .color-indicator-ring {
+  height: 1.4rem;
+  width: 1.4rem;
+}
+
+.color-indicator[data-shape="square"] .color-indicator-ring {
+  border-radius: 0;
+}
+
+/* Trash button */
+.trash-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.trash-button img {
+  height: 1.9rem;
+  width: 1.9rem;
+}
+
+.trash-button[data-size="small"] img {
+  height: 1.1rem;
+  width: 1.1rem;
+}

--- a/src/app/content/highlights/components/ColorIndicator.tsx
+++ b/src/app/content/highlights/components/ColorIndicator.tsx
@@ -52,7 +52,6 @@ function ColorIndicator<T extends React.ComponentType | undefined>(props: React.
     '--passive-color': style.passive,
     '--focused-color': style.focused,
     '--focus-border-color': style.focusBorder,
-    '--focus-outline-color': 'var(--focus-outline-color)',
   } as React.CSSProperties;
   const content = (
     <>

--- a/src/app/content/highlights/components/ColorIndicator.tsx
+++ b/src/app/content/highlights/components/ColorIndicator.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import styled, { css } from 'styled-components/macro';
 import { isDefined } from '../../../guards';
 import { highlightStyles } from '../../constants';
-import { defaultFocusOutline } from '../../../theme';
 import { useIntl } from 'react-intl';
 import trashIcon from '../../../../assets/trash-347.svg';
+import './ColorIndicator.css';
 
 interface IconProps extends React.SVGAttributes<SVGSVGElement> {
   className?: string;
@@ -13,13 +12,11 @@ interface IconProps extends React.SVGAttributes<SVGSVGElement> {
 /**
  * Check icon component.
  * SVG path from Font Awesome Free (https://fontawesome.com - MIT License)
- *
- * Note: Wrapped with styled() to enable styled-components component selector references
  */
-function CheckBase({ className, ...props }: IconProps) {
+function Check({ className, ...props }: IconProps) {
   return (
     <svg
-      className={className}
+      className={`color-indicator-check ${className || ''}`}
       viewBox="0 0 512 512"
       aria-hidden="true"
       {...props}
@@ -31,8 +28,6 @@ function CheckBase({ className, ...props }: IconProps) {
     </svg>
   );
 }
-
-const Check = styled(CheckBase)``;
 
 interface StyleProps {
   style: typeof highlightStyles[number];
@@ -48,120 +43,79 @@ interface Props<T extends React.ComponentType | undefined = React.ComponentType>
     never;
 }
 
-const CheckIcon = styled(Check)`
-  display: none;
-`;
+function ColorIndicator<T extends React.ComponentType | undefined>(props: React.PropsWithChildren<Props<T>>) {
+  const {children, style, checked, size, component, shape, className, ...otherProps} = props;
 
-const FocusedStyle = styled.span`
-  display: none;
-  position: absolute;
-  height: ${(props: StyleProps) => indicatorSize(props) + 0.4}rem;
-  width: ${(props: StyleProps) => indicatorSize(props) + 0.4}rem;
-  background-color: transparent;
-  z-index: -1;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  ${(props: StyleProps) => (props.shape === 'circle' || props.shape === undefined) && css`
-    border-radius: 50%;
-  `}
-`;
+  const indicatorStyle = {
+    '--passive-color': style.passive,
+    '--focused-color': style.focused,
+    '--focus-border-color': style.focusBorder,
+    '--focus-outline-color': 'var(--focus-outline-color)',
+  } as React.CSSProperties;
 
-const ColorRing = styled.span`
-  height: ${(props: StyleProps) => indicatorSize(props) - 0.2}rem;
-  width: ${(props: StyleProps) => indicatorSize(props) - 0.2}rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  ${(props: StyleProps) => (props.shape === 'circle' || props.shape === undefined) && css`
-    border-radius: 50%;
-  `}
-  border: 1px solid ${(props: {style: typeof highlightStyles[number]}) => props.style.focused};
-`;
+  const content = (
+    <>
+      <Check />
+      {children}
+      <span className="color-indicator-focus" />
+      <span className="color-indicator-ring" />
+    </>
+  );
 
-function Hoc<T extends React.ComponentType | undefined>(props: React.PropsWithChildren<Props<T>>) {
-  const {children, style, checked, size, component, ...otherProps} = props;
-  const focusedProps: StyleProps = { style, size, shape: props.shape };
+  const indicatorClasses = `color-indicator ${className || ''}`;
 
   if (isDefined(component)) {
     return React.cloneElement(
       component,
-      props,
-      <CheckIcon key='check' />,
-      children,
-      <FocusedStyle {...focusedProps} />,
-      <ColorRing {...focusedProps} />
+      {
+        ...otherProps,
+        className: indicatorClasses,
+        style: indicatorStyle,
+        'data-size': size,
+        'data-shape': shape,
+        'data-checked': checked,
+      },
+      content
     );
   }
-  return <div {...otherProps}>
-    <CheckIcon />
-    {children}
-    <FocusedStyle {...focusedProps} />
-    <ColorRing {...focusedProps} />
-  </div>;
+
+  return (
+    <div
+      {...otherProps}
+      className={indicatorClasses}
+      style={indicatorStyle}
+      data-size={size}
+      data-shape={shape}
+      data-checked={checked}
+    >
+      {content}
+    </div>
+  );
 }
 
-const indicatorSize = (props: {size?: 'small'}) => props.size === 'small' ? 1.6 : 2.4;
-const checkSize = (props: {size?: 'small'}) => props.size === 'small' ? 1 : 1.6;
-
-const ColorIndicator = styled(Hoc)`
-  position: relative;
-  background-color: ${(props: {style: typeof highlightStyles[number]}) => props.style.passive};
-  border: 1px solid ${(props: {style: typeof highlightStyles[number]}) => props.style.focusBorder};
-  height: ${(props: Props) => indicatorSize(props)}rem;
-  width: ${(props: Props) => indicatorSize(props)}rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  ${(props: Props) => (props.shape === 'circle' || props.shape === undefined) && css`
-    border-radius: 2rem;
-  `}
-  overflow: visible;
-
-  ${CheckIcon} {
-    height: ${(props: Props) => checkSize(props)}rem;
-    width: ${(props: Props) => checkSize(props)}rem;
-    ${(props: Props) => props.checked && css`
-      color: ${props.style.focused};
-      stroke: ${props.style.focusBorder};
-      stroke-width: 5%;
-      display: block;
-    `}
-  }
-
-  input:focus + ${FocusedStyle} {
-    display: block;
-    ${defaultFocusOutline}
-    z-index: 1;
-  }
-`;
-
-function TB({
+export function TrashButton({
   onClick,
+  size,
   className,
+  ...props
 }: {
   onClick: React.MouseEventHandler<HTMLButtonElement>;
-  className: string;
+  size?: 'small';
+  className?: string;
+  'data-testid'?: string;
 }) {
   return (
     <button
       type='button'
-      className={className}
+      className={`trash-button ${className || ''}`}
       aria-label={useIntl().formatMessage({id: 'i18n:a11y:keyboard-shortcuts:deselect-highlight-color'})}
       onClick={onClick}
+      data-size={size}
+      {...props}
     >
       <img src={trashIcon} alt='' />
     </button>
   );
 }
-
-export const TrashButton = styled(TB)`
-  img {
-    height: ${(props: Props) => indicatorSize(props) - 0.5}rem;
-    width: ${(props: Props) => indicatorSize(props) - 0.5}rem;
-  }
-`;
 
 export default ColorIndicator;

--- a/src/app/content/highlights/components/ColorIndicator.tsx
+++ b/src/app/content/highlights/components/ColorIndicator.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import styled from 'styled-components/macro';
 import { isDefined } from '../../../guards';
 import { highlightStyles } from '../../constants';
 import { useIntl } from 'react-intl';
+import classNames from 'classnames';
 import trashIcon from '../../../../assets/trash-347.svg';
-import './ColorIndicator.css';
+// CSS is imported in src/app/index.tsx
 
 interface IconProps extends React.SVGAttributes<SVGSVGElement> {
   className?: string;
@@ -35,7 +37,8 @@ interface StyleProps {
   shape?: 'square' | 'circle';
 }
 
-interface Props<T extends React.ComponentType | undefined = React.ComponentType> extends StyleProps {
+interface Props<T extends React.ComponentType | undefined = React.ComponentType>
+extends StyleProps, Omit<React.HTMLAttributes<HTMLElement>, 'style'> {
   className?: string;
   checked?: boolean;
   component?: T extends undefined ? undefined :
@@ -45,14 +48,12 @@ interface Props<T extends React.ComponentType | undefined = React.ComponentType>
 
 function ColorIndicator<T extends React.ComponentType | undefined>(props: React.PropsWithChildren<Props<T>>) {
   const {children, style, checked, size, component, shape, className, ...otherProps} = props;
-
   const indicatorStyle = {
     '--passive-color': style.passive,
     '--focused-color': style.focused,
     '--focus-border-color': style.focusBorder,
     '--focus-outline-color': 'var(--focus-outline-color)',
   } as React.CSSProperties;
-
   const content = (
     <>
       <Check />
@@ -62,21 +63,19 @@ function ColorIndicator<T extends React.ComponentType | undefined>(props: React.
     </>
   );
 
-  const indicatorClasses = `color-indicator ${className || ''}`;
+  const indicatorClasses = classNames('color-indicator', className);
 
   if (isDefined(component)) {
-    return React.cloneElement(
-      component,
-      {
-        ...otherProps,
-        className: indicatorClasses,
-        style: indicatorStyle,
-        'data-size': size,
-        'data-shape': shape,
-        'data-checked': checked,
-      },
-      content
-    );
+    const extraProps: Record<string, unknown> = {
+      ...otherProps,
+      className: indicatorClasses,
+      style: indicatorStyle,
+      'data-size': size,
+      'data-shape': shape,
+      'data-checked': checked,
+    };
+
+    return React.cloneElement(component, extraProps, content);
   }
 
   return (
@@ -118,4 +117,7 @@ export function TrashButton({
   );
 }
 
-export default ColorIndicator;
+// Export a styled wrapper with no styles to maintain compatibility with styled-components selectors
+// This allows ColorIndicator to be used as a CSS selector (e.g., ${ColorIndicator}) in other
+// styled-components while the actual styling is handled by ColorIndicator.css
+export default styled(ColorIndicator)``;

--- a/src/app/content/highlights/components/Confirmation.css
+++ b/src/app/content/highlights/components/Confirmation.css
@@ -1,0 +1,27 @@
+/* Confirmation overlay styles */
+.confirmation-overlay {
+  background: rgba(0, 0, 0, 0.9);
+  outline: none;
+  border-radius: 0.4rem;
+  box-shadow: 0 0.2rem 0.4rem rgba(0, 0, 0, 0.2);
+  transition: background 200ms;
+  display: flex;
+  flex-direction: column;
+  padding: 1.6rem;
+  overflow: visible;
+  min-height: 100%;
+  min-width: 100%;
+  position: static;
+  width: min-content;
+}
+
+.confirmation-overlay label {
+  font-size: 1.4rem;
+  line-height: 2rem;
+  letter-spacing: -0.056rem;
+  font-weight: 700;
+  flex: 1;
+  color: var(--text-white);
+  margin-bottom: 1rem;
+  overflow: visible;
+}

--- a/src/app/content/highlights/components/Confirmation.css
+++ b/src/app/content/highlights/components/Confirmation.css
@@ -3,7 +3,7 @@
   background: rgba(0, 0, 0, 0.9);
   outline: none;
   border-radius: 0.4rem;
-  box-shadow: 0 0.2rem 0.4rem rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.14), 0 2px 2px 0 rgba(0, 0, 0, 0.12), 0 1px 3px 0 rgba(0, 0, 0, 0.2);
   transition: background 200ms;
   display: flex;
   flex-direction: column;
@@ -17,11 +17,10 @@
 
 .confirmation-overlay label {
   font-size: 1.4rem;
-  line-height: 2rem;
-  letter-spacing: -0.056rem;
-  font-weight: 700;
+  line-height: 1.6rem;
+  font-weight: normal;
   flex: 1;
-  color: var(--text-white);
-  margin-bottom: 1rem;
+  color: var(--color-text-white);
+  margin-bottom: 0.8rem;
   overflow: visible;
 }

--- a/src/app/content/highlights/components/Confirmation.tsx
+++ b/src/app/content/highlights/components/Confirmation.tsx
@@ -6,7 +6,7 @@ import { useDrawFocus, useTrapTabNavigation, useOnEsc } from '../../../reactUtil
 import { mergeRefs } from '../../../utils';
 import './Confirmation.css';
 
-interface Props {
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
   message: string;
   'data-analytics-region'?: string;
   'data-analytics-label'?: string;
@@ -33,14 +33,11 @@ const Confirmation = React.forwardRef<HTMLElement, Props>((
   useOnEsc(true, onCancel);
 
   return <div
+    {...props}
     className="confirmation-overlay"
     ref={mergeRefs(ref, drawFocus ? drawFocusRef : overlayRef)}
     tabIndex={-1}
     role='alertdialog'
-    {...props['data-analytics-region']
-      ? { 'data-analytics-region': props['data-analytics-region'] }
-      : {}
-    }
   >
     <FormattedMessage id={message}>
       {(msg) => <label>{msg}</label>}

--- a/src/app/content/highlights/components/Confirmation.tsx
+++ b/src/app/content/highlights/components/Confirmation.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import Button, { ButtonGroup } from '../../../components/Button';
 import { useDrawFocus, useTrapTabNavigation, useOnEsc } from '../../../reactUtils';
 import { mergeRefs } from '../../../utils';
+import classNames from 'classnames';
 import './Confirmation.css';
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
@@ -34,7 +35,7 @@ const Confirmation = React.forwardRef<HTMLElement, Props>((
 
   return <div
     {...props}
-    className="confirmation-overlay"
+    className={classNames('confirmation-overlay', props.className)}
     ref={mergeRefs(ref, drawFocus ? drawFocusRef : overlayRef)}
     tabIndex={-1}
     role='alertdialog'

--- a/src/app/content/highlights/components/Confirmation.tsx
+++ b/src/app/content/highlights/components/Confirmation.tsx
@@ -1,38 +1,10 @@
 import { HTMLElement } from '@openstax/types/lib.dom';
-import Color from 'color';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import styled from 'styled-components/macro';
 import Button, { ButtonGroup } from '../../../components/Button';
-import { labelStyle } from '../../../components/Typography';
 import { useDrawFocus, useTrapTabNavigation, useOnEsc } from '../../../reactUtils';
-import theme from '../../../theme';
 import { mergeRefs } from '../../../utils';
-import { cardPadding } from '../constants';
-import { cardBorder } from './style';
-
-export const Overlay = styled.div`
-  background: ${Color(theme.color.black).alpha(0.90).string()};
-  outline: none;
-  ${cardBorder}
-  transition: background 200ms;
-  display: flex;
-  flex-direction: column;
-  padding: 1.6rem;
-  overflow: visible;
-  min-height: 100%;
-  min-width: 100%;
-  position: static;
-  width: min-content;
-
-  label {
-    ${labelStyle}
-    flex: 1;
-    color: ${theme.color.text.white};
-    margin-bottom: ${cardPadding}rem;
-    overflow: visible;
-  }
-`;
+import './Confirmation.css';
 
 interface Props {
   message: string;
@@ -60,7 +32,8 @@ const Confirmation = React.forwardRef<HTMLElement, Props>((
   useTrapTabNavigation(trapRef, undefined, !drawFocus);
   useOnEsc(true, onCancel);
 
-  return <Overlay
+  return <div
+    className="confirmation-overlay"
     ref={mergeRefs(ref, drawFocus ? drawFocusRef : overlayRef)}
     tabIndex={-1}
     role='alertdialog'
@@ -112,7 +85,7 @@ const Confirmation = React.forwardRef<HTMLElement, Props>((
         >{msg}</Button>}
       </FormattedMessage>
     </ButtonGroup>
-  </Overlay>;
+  </div>;
 });
 
 export default Confirmation;

--- a/src/app/content/highlights/components/Confirmation.tsx
+++ b/src/app/content/highlights/components/Confirmation.tsx
@@ -19,7 +19,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const Confirmation = React.forwardRef<HTMLElement, Props>((
-  { message, confirmMessage, confirmLink, always, onCancel, onConfirm, drawFocus = true, ...props }: Props,
+  { message, confirmMessage, confirmLink, always, onCancel, onConfirm, drawFocus = true, 'data-analytics-label': analyticsLabel, ...props }: Props,
   ref
 ) => {
   const drawFocusRef = useDrawFocus();
@@ -27,7 +27,7 @@ const Confirmation = React.forwardRef<HTMLElement, Props>((
 
   // Use drawFocusRef if drawFocus is true, otherwise use overlayRef for trap navigation
   const trapRef = drawFocus ? drawFocusRef : overlayRef;
-  
+
   // Auto-focus first element when drawFocus=false (overlay case)
   useTrapTabNavigation(trapRef, undefined, !drawFocus);
   useOnEsc(true, onCancel);
@@ -46,7 +46,7 @@ const Confirmation = React.forwardRef<HTMLElement, Props>((
       <FormattedMessage id={confirmMessage}>
         {(msg) => <Button
           size='small'
-          data-analytics-label={props['data-analytics-label'] ? props['data-analytics-label'] : 'confirm'}
+          data-analytics-label={analyticsLabel ? analyticsLabel : 'confirm'}
           data-testid='confirm'
           variant='primary'
           onClick={(e: React.FormEvent) => {

--- a/src/app/content/highlights/components/ConfirmationModal.css
+++ b/src/app/content/highlights/components/ConfirmationModal.css
@@ -1,0 +1,4 @@
+/* ConfirmationModal footer styles */
+.confirmation-modal-footer {
+  justify-content: space-between;
+}

--- a/src/app/content/highlights/components/ConfirmationModal.tsx
+++ b/src/app/content/highlights/components/ConfirmationModal.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import styled from 'styled-components';
 import Button from '../../../components/Button';
 import Modal from '../../../components/Modal';
 import { Body, BodyHeading, Footer } from '../../../components/Modal/styles';
+import './ConfirmationModal.css';
 
 interface Props {
   deny: () => void;
   confirm: () => void;
 }
-
-const ConfirmationFooter = styled(Footer)`
-  justify-content: space-between;
-`;
 
 const ConfirmationModal = ({deny, confirm}: Props) => {
   return <Modal onModalClose={deny} heading='i18n:discard:heading'>
@@ -21,7 +17,7 @@ const ConfirmationModal = ({deny, confirm}: Props) => {
         {(msg) => <BodyHeading>{msg}</BodyHeading>}
       </FormattedMessage>
     </Body>
-    <ConfirmationFooter>
+    <Footer className="confirmation-modal-footer">
       <FormattedMessage id='i18n:discard:button:discard'>
         {(msg) => <Button
           data-testid='discard-changes'
@@ -38,7 +34,7 @@ const ConfirmationModal = ({deny, confirm}: Props) => {
           > {msg}
         </Button>}
       </FormattedMessage>
-    </ConfirmationFooter>
+    </Footer>
   </Modal>;
 };
 

--- a/src/app/content/highlights/components/DisplayNote.css
+++ b/src/app/content/highlights/components/DisplayNote.css
@@ -29,6 +29,11 @@
   background: #fff; /* theme.color.white */
 }
 
+/* === Note Label === */
+.display-note > .note-label {
+  display: none;
+}
+
 /* === Dropdown Menu Positioning === */
 .display-note .dropdown {
   position: absolute;
@@ -68,8 +73,14 @@
     width: unset;
   }
 
-  .display-note > label {
+  .display-note > .note-label {
     display: block;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: 400;
+    color: var(--highlight-color, #000); /* Dynamic highlight color */
+    font-size: 1.4rem;
+    line-height: 2rem;
+    margin: 1.2rem 0 0 1.6rem; /* cardPadding * 1.5, 0, 0, cardPadding * 2 */
   }
 
   .display-note .dropdown {

--- a/src/app/content/highlights/components/DisplayNote.css
+++ b/src/app/content/highlights/components/DisplayNote.css
@@ -29,17 +29,6 @@
   background: #fff; /* theme.color.white */
 }
 
-/* === Note Label === */
-.display-note > label {
-  display: none;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-weight: 400;
-  color: var(--highlight-color, #000); /* Dynamic highlight color */
-  font-size: 1.4rem;
-  line-height: 2rem;
-  margin: 1.2rem 0 0 1.6rem; /* cardPadding * 1.5, 0, 0, cardPadding * 2 */
-}
-
 /* === Dropdown Menu Positioning === */
 .display-note .dropdown {
   position: absolute;

--- a/src/app/content/highlights/components/DisplayNote.tsx
+++ b/src/app/content/highlights/components/DisplayNote.tsx
@@ -133,6 +133,7 @@ const DisplayNote = React.forwardRef<HTMLElement, DisplayNoteProps>((
         onClick={onBlur}
         aria-hidden='true'
       />
+      <div className='note-label'>Note:</div>
       <TruncatedText id={noteId} text={note} isActive={isActive} onChange={() => setTextToggle((state) => !state)} />
       {confirmingDelete && <Confirmation
         ref={confirmationRef}

--- a/src/app/content/highlights/components/DisplayNote.tsx
+++ b/src/app/content/highlights/components/DisplayNote.tsx
@@ -133,7 +133,6 @@ const DisplayNote = React.forwardRef<HTMLElement, DisplayNoteProps>((
         onClick={onBlur}
         aria-hidden='true'
       />
-      <label>Note:</label>
       <TruncatedText id={noteId} text={note} isActive={isActive} onChange={() => setTextToggle((state) => !state)} />
       {confirmingDelete && <Confirmation
         ref={confirmationRef}

--- a/src/app/content/highlights/components/EditCard.css
+++ b/src/app/content/highlights/components/EditCard.css
@@ -1,0 +1,17 @@
+/* EditCard styles */
+.edit-card {
+  background: var(--neutral-form-background);
+  user-select: none;
+  overflow: visible;
+}
+
+.edit-card .button-group {
+  margin-top: 1rem;
+}
+
+/* Touch device query - hide edit card on touch devices */
+@media (max-width: 75em) and (pointer: coarse) {
+  .edit-card {
+    visibility: hidden;
+  }
+}

--- a/src/app/content/highlights/components/EditCard.css
+++ b/src/app/content/highlights/components/EditCard.css
@@ -1,16 +1,16 @@
 /* EditCard styles */
 .edit-card {
-  background: var(--neutral-form-background);
+  background: var(--color-neutral-form-background);
   user-select: none;
   overflow: visible;
 }
 
 .edit-card .button-group {
-  margin-top: 1rem;
+  margin-top: 0.8rem;
 }
 
 /* Touch device query - hide edit card on touch devices */
-@media (max-width: 75em) and (pointer: coarse) {
+@media (max-width: 75em) and (pointer: coarse), (max-width: 75em) and (hover: none) {
   .edit-card {
     visibility: hidden;
   }

--- a/src/app/content/highlights/components/EditCard.css
+++ b/src/app/content/highlights/components/EditCard.css
@@ -11,8 +11,10 @@
 
 /* Touch device query - hide edit card on touch devices
  * Equivalent to theme.breakpoints.touchDeviceQuery */
-@media screen and (max-width: 75em) and (not (pointer: fine)), screen and (max-width: 75em) and (hover: none) {
-  .edit-card {
-    visibility: hidden;
+@media screen and (max-width: 75em) {
+  @media not all and (pointer: fine), (hover: none) {
+    .edit-card {
+      visibility: hidden;
+    }
   }
 }

--- a/src/app/content/highlights/components/EditCard.css
+++ b/src/app/content/highlights/components/EditCard.css
@@ -9,8 +9,9 @@
   margin-top: 0.8rem;
 }
 
-/* Touch device query - hide edit card on touch devices */
-@media (max-width: 75em) and (pointer: coarse), (max-width: 75em) and (hover: none) {
+/* Touch device query - hide edit card on touch devices
+ * Equivalent to theme.breakpoints.touchDeviceQuery */
+@media screen and (max-width: 75em) and (not (pointer: fine)), screen and (max-width: 75em) and (hover: none) {
   .edit-card {
     visibility: hidden;
   }

--- a/src/app/content/highlights/components/EditCard.spec.tsx
+++ b/src/app/content/highlights/components/EditCard.spec.tsx
@@ -36,7 +36,7 @@ describe('EditCard', () => {
     dispatch: store.dispatch,
     getState: store.getState,
   };
-  let editCardProps: Partial<EditCardProps>;
+  let editCardProps: EditCardProps;
 
   // Test Helper Functions
   const setupAuthenticatedUser = () => {
@@ -45,7 +45,9 @@ describe('EditCard', () => {
     return () => mockSpyUser.mockClear();
   };
 
-  const renderEditCard = (props: Partial<EditCardProps> & Pick<EditCardProps, 'highlight'>) => {
+  const renderEditCard = (
+    props: EditCardProps
+  ) => {
     return renderer.create(
       <TestContainer services={services} store={store}>
         <ConfirmationToastProvider>
@@ -87,15 +89,22 @@ describe('EditCard', () => {
       onCreate: jest.fn(),
       onRemove: jest.fn(),
       setAnnotationChangesPending: jest.fn(),
+      hasUnsavedHighlight: false,
+      locationFilterId: 'lfi',
+      pageId: 'pid',
+      onHeightChange: jest.fn(),
+      className: '',
+      shouldFocusCard: false
     };
   });
 
   describe('Snapshots and Rendering', () => {
     it('matches snapshot when focused', () => {
       const data = {
+        ...highlight,
         color: highlightStyles[0].label,
-        ...highlightData,
-      };
+        scopeId: 'test-scope',
+      } as any;
       const component = renderer.create(
         <TestContainer services={services} store={store}>
           <EditCard {...editCardProps} data={data} isActive={true} shouldFocusCard={true} />
@@ -652,9 +661,10 @@ describe('EditCard', () => {
       const cleanup = setupAuthenticatedUser();
       const onHeightChange = jest.fn();
       const data = {
+        ...highlight,
         color: highlightStyles[0].label,
-        ...highlightData,
-      };
+        scopeId: 'test-scope',
+      } as any;
 
       const component = renderToDom(
         <div id={MAIN_CONTENT_ID} tabIndex={-1}>

--- a/src/app/content/highlights/components/EditCard.tsx
+++ b/src/app/content/highlights/components/EditCard.tsx
@@ -55,11 +55,9 @@
 import { Highlight } from '@openstax/highlighter';
 import { FocusEvent, HTMLElement, HTMLTextAreaElement } from '@openstax/types/lib.dom';
 import React from 'react';
-import styled, { css } from 'styled-components/macro';
 import { useAnalyticsEvent } from '../../../../helpers/analytics';
-import { ButtonGroup as ButtonGroupBase } from '../../../components/Button';
+import { ButtonGroup } from '../../../components/Button';
 import { useTrapTabNavigation } from '../../../reactUtils';
-import theme from '../../../theme';
 import { MAIN_CONTENT_ID } from '../../../context/constants';
 import { useIntl } from 'react-intl';
 import {
@@ -67,7 +65,6 @@ import {
   setAnnotationChangesPending as setAnnotationChangesPendingAction,
 } from '../actions';
 import { useConfirmationToastContext } from '../../components/ConfirmationToast';
-import { cardPadding } from '../constants';
 import { HighlightData } from '../types';
 import ColorPicker from './ColorPicker';
 import Confirmation from './Confirmation';
@@ -75,9 +72,7 @@ import { LoginOrEdit } from './EditCard/AuthenticationGate';
 import { SaveButton, CancelButton } from './EditCard/ActionButtons';
 import { AnnotationEditor } from './EditCard/AnnotationEditor';
 import { useOnRemove, useOnColorChange, useSaveAnnotation } from './EditCard/hooks';
-
-// Wrap ButtonGroup with styled() to make it compatible with component selectors
-const ButtonGroup = styled(ButtonGroupBase)``;
+import './EditCard.css';
 
 export interface EditCardProps {
   isActive: boolean;
@@ -116,7 +111,7 @@ const EditCard = React.forwardRef<HTMLElement, EditCardProps>((props, ref) => {
 
   return (
     <LoginOrEdit
-      className={props.className}
+      className={`edit-card ${props.className || ''}`}
       isNewSelection={isNewSelection}
       shouldFocusCard={props.shouldFocusCard}
       hasAnnotation={Boolean(props.data?.annotation)}
@@ -321,16 +316,4 @@ function ActiveEditCard({
 }
 
 // tslint:disable-next-line
-export default styled(EditCard)`
-  background: ${theme.color.neutral.formBackground};
-  user-select: none;
-  overflow: visible;
-
-  ${ButtonGroup} {
-    margin-top: ${cardPadding}rem;
-  }
-
-  ${theme.breakpoints.touchDeviceQuery(css`
-    visibility: hidden;
-  `)}
-`;
+export default EditCard;

--- a/src/app/content/highlights/components/EditCard.tsx
+++ b/src/app/content/highlights/components/EditCard.tsx
@@ -91,7 +91,7 @@ export interface EditCardProps {
   shouldFocusCard: boolean;
   minimize?: boolean;
   onClick?: () => void;
-  cardStyle?: React.CSSProperties;
+  style?: React.CSSProperties;
   'data-testid'?: string;
   'data-active'?: boolean;
   'data-hidden'?: boolean;
@@ -124,7 +124,7 @@ const EditCard = React.forwardRef<HTMLElement, EditCardProps>((props, ref) => {
       data-hidden={props['data-hidden']}
       data-toc-open={props['data-toc-open']}
       data-has-query={props['data-has-query']}
-      style={props.cardStyle}
+      style={props.style}
     >
       <ActiveEditCard props={props} element={element} />
     </LoginOrEdit>

--- a/src/app/content/highlights/components/SummaryPopup/__snapshots__/ContextMenu.spec.tsx.snap
+++ b/src/app/content/highlights/components/SummaryPopup/__snapshots__/ContextMenu.spec.tsx.snap
@@ -124,7 +124,6 @@ exports[`ContextMenu match snapshot when open 1`] = `
                 style={
                   Object {
                     "--focus-border-color": "#8f7700",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#fed200",
                     "--passive-color": "#ffff8a",
                   }
@@ -164,7 +163,6 @@ exports[`ContextMenu match snapshot when open 1`] = `
                 style={
                   Object {
                     "--focus-border-color": "#4e6f01",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#92d101",
                     "--passive-color": "#def99f",
                   }
@@ -204,7 +202,6 @@ exports[`ContextMenu match snapshot when open 1`] = `
                 style={
                   Object {
                     "--focus-border-color": "#006880",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#00c3ed",
                     "--passive-color": "#c8f5ff",
                   }
@@ -244,7 +241,6 @@ exports[`ContextMenu match snapshot when open 1`] = `
                 style={
                   Object {
                     "--focus-border-color": "#141a3e",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#545ec8",
                     "--passive-color": "#cbcfff",
                   }
@@ -284,7 +280,6 @@ exports[`ContextMenu match snapshot when open 1`] = `
                 style={
                   Object {
                     "--focus-border-color": "#560131",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#de017e",
                     "--passive-color": "#ffc5e1",
                   }

--- a/src/app/content/highlights/components/SummaryPopup/__snapshots__/ContextMenu.spec.tsx.snap
+++ b/src/app/content/highlights/components/SummaryPopup/__snapshots__/ContextMenu.spec.tsx.snap
@@ -48,269 +48,6 @@ exports[`ContextMenu match snapshot when closed 1`] = `
 `;
 
 exports[`ContextMenu match snapshot when open 1`] = `
-.c3 {
-  display: none;
-}
-
-.c5 {
-  display: none;
-  position: absolute;
-  height: 2rem;
-  width: 2rem;
-  background-color: transparent;
-  z-index: -1;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-}
-
-.c6 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #fed200;
-}
-
-.c8 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #92d101;
-}
-
-.c10 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #00c3ed;
-}
-
-.c12 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #545ec8;
-}
-
-.c14 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #de017e;
-}
-
-.c1 {
-  position: relative;
-  background-color: #ffff8a;
-  border: 1px solid #8f7700;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c1 .c2 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c1 input:focus + .c4 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c7 {
-  position: relative;
-  background-color: #def99f;
-  border: 1px solid #4e6f01;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c7 .c2 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c7 input:focus + .c4 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c9 {
-  position: relative;
-  background-color: #c8f5ff;
-  border: 1px solid #006880;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c9 .c2 {
-  height: 1rem;
-  width: 1rem;
-  color: #00c3ed;
-  stroke: #006880;
-  stroke-width: 5%;
-  display: block;
-}
-
-.c9 input:focus + .c4 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c11 {
-  position: relative;
-  background-color: #cbcfff;
-  border: 1px solid #141a3e;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c11 .c2 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c11 input:focus + .c4 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c13 {
-  position: relative;
-  background-color: #ffc5e1;
-  border: 1px solid #560131;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c13 .c2 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c13 input:focus + .c4 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
 .c0 {
   overflow: visible;
   position: relative;
@@ -381,23 +118,22 @@ exports[`ContextMenu match snapshot when open 1`] = `
               </legend>
               <label
                 aria-label="Apply yellow highlight"
-                checked={false}
-                className="c1 color-button "
-                component={<label />}
-                size="small"
+                className="color-indicator color-button "
+                data-checked={false}
+                data-size="small"
                 style={
                   Object {
-                    "focusBorder": "#8f7700",
-                    "focused": "#fed200",
-                    "label": "yellow",
-                    "passive": "#ffff8a",
+                    "--focus-border-color": "#8f7700",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#fed200",
+                    "--passive-color": "#ffff8a",
                   }
                 }
                 title="yellow"
               >
                 <svg
                   aria-hidden="true"
-                  className="c2 c3"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -414,49 +150,30 @@ exports[`ContextMenu match snapshot when open 1`] = `
                   type="radio"
                 />
                 <span
-                  className="c4 c5"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#8f7700",
-                      "focused": "#fed200",
-                      "label": "yellow",
-                      "passive": "#ffff8a",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c6"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#8f7700",
-                      "focused": "#fed200",
-                      "label": "yellow",
-                      "passive": "#ffff8a",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </label>
               <label
                 aria-label="Apply green highlight"
-                checked={false}
-                className="c7 color-button "
-                component={<label />}
-                size="small"
+                className="color-indicator color-button "
+                data-checked={false}
+                data-size="small"
                 style={
                   Object {
-                    "focusBorder": "#4e6f01",
-                    "focused": "#92d101",
-                    "label": "green",
-                    "passive": "#def99f",
+                    "--focus-border-color": "#4e6f01",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#92d101",
+                    "--passive-color": "#def99f",
                   }
                 }
                 title="green"
               >
                 <svg
                   aria-hidden="true"
-                  className="c2 c3"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -473,49 +190,30 @@ exports[`ContextMenu match snapshot when open 1`] = `
                   type="radio"
                 />
                 <span
-                  className="c4 c5"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#4e6f01",
-                      "focused": "#92d101",
-                      "label": "green",
-                      "passive": "#def99f",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c8"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#4e6f01",
-                      "focused": "#92d101",
-                      "label": "green",
-                      "passive": "#def99f",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </label>
               <label
                 aria-label="Apply blue highlight"
-                checked={true}
-                className="c9 color-button "
-                component={<label />}
-                size="small"
+                className="color-indicator color-button "
+                data-checked={true}
+                data-size="small"
                 style={
                   Object {
-                    "focusBorder": "#006880",
-                    "focused": "#00c3ed",
-                    "label": "blue",
-                    "passive": "#c8f5ff",
+                    "--focus-border-color": "#006880",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#00c3ed",
+                    "--passive-color": "#c8f5ff",
                   }
                 }
                 title="blue"
               >
                 <svg
                   aria-hidden="true"
-                  className="c2 c3"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -532,49 +230,30 @@ exports[`ContextMenu match snapshot when open 1`] = `
                   type="radio"
                 />
                 <span
-                  className="c4 c5"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#006880",
-                      "focused": "#00c3ed",
-                      "label": "blue",
-                      "passive": "#c8f5ff",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c10"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#006880",
-                      "focused": "#00c3ed",
-                      "label": "blue",
-                      "passive": "#c8f5ff",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </label>
               <label
                 aria-label="Apply purple highlight"
-                checked={false}
-                className="c11 color-button "
-                component={<label />}
-                size="small"
+                className="color-indicator color-button "
+                data-checked={false}
+                data-size="small"
                 style={
                   Object {
-                    "focusBorder": "#141a3e",
-                    "focused": "#545ec8",
-                    "label": "purple",
-                    "passive": "#cbcfff",
+                    "--focus-border-color": "#141a3e",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#545ec8",
+                    "--passive-color": "#cbcfff",
                   }
                 }
                 title="purple"
               >
                 <svg
                   aria-hidden="true"
-                  className="c2 c3"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -591,49 +270,30 @@ exports[`ContextMenu match snapshot when open 1`] = `
                   type="radio"
                 />
                 <span
-                  className="c4 c5"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#141a3e",
-                      "focused": "#545ec8",
-                      "label": "purple",
-                      "passive": "#cbcfff",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c12"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#141a3e",
-                      "focused": "#545ec8",
-                      "label": "purple",
-                      "passive": "#cbcfff",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </label>
               <label
                 aria-label="Apply pink highlight"
-                checked={false}
-                className="c13 color-button "
-                component={<label />}
-                size="small"
+                className="color-indicator color-button "
+                data-checked={false}
+                data-size="small"
                 style={
                   Object {
-                    "focusBorder": "#560131",
-                    "focused": "#de017e",
-                    "label": "pink",
-                    "passive": "#ffc5e1",
+                    "--focus-border-color": "#560131",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#de017e",
+                    "--passive-color": "#ffc5e1",
                   }
                 }
                 title="pink"
               >
                 <svg
                   aria-hidden="true"
-                  className="c2 c3"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -650,28 +310,10 @@ exports[`ContextMenu match snapshot when open 1`] = `
                   type="radio"
                 />
                 <span
-                  className="c4 c5"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#560131",
-                      "focused": "#de017e",
-                      "label": "pink",
-                      "passive": "#ffc5e1",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c14"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#560131",
-                      "focused": "#de017e",
-                      "label": "pink",
-                      "passive": "#ffc5e1",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </label>
             </fieldset>

--- a/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
+++ b/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
@@ -31,277 +31,18 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
   padding: 0 1rem;
 }
 
-.c18 {
-  display: none;
-}
-
-.c20 {
-  display: none;
-  position: absolute;
-  height: 2rem;
-  width: 2rem;
-  background-color: transparent;
-  z-index: -1;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-}
-
-.c21 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #fed200;
-}
-
 .c24 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #92d101;
-}
-
-.c26 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #00c3ed;
-}
-
-.c28 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #545ec8;
-}
-
-.c30 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #de017e;
-}
-
-.c16 {
-  position: relative;
-  background-color: #ffff8a;
-  border: 1px solid #8f7700;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c16 .c17 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c16 input:focus + .c19 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c23 {
-  position: relative;
-  background-color: #def99f;
-  border: 1px solid #4e6f01;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c23 .c17 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c23 input:focus + .c19 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c25 {
-  position: relative;
-  background-color: #c8f5ff;
-  border: 1px solid #006880;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c25 .c17 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c25 input:focus + .c19 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c27 {
-  position: relative;
-  background-color: #cbcfff;
-  border: 1px solid #141a3e;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c27 .c17 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c27 input:focus + .c19 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c29 {
-  position: relative;
-  background-color: #ffc5e1;
-  border: 1px solid #560131;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c29 .c17 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c29 input:focus + .c19 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c38 {
   height: 1.7rem;
   margin-right: 0.4rem;
 }
 
-.c38 svg {
+.c24 svg {
   height: 0.8rem;
   width: 0.8rem;
   color: #5e6062;
 }
 
-.c39 {
+.c25 {
   color: #424242;
   font-weight: 300;
   color: #5e6062;
@@ -313,7 +54,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
   line-height: 1.5rem;
 }
 
-.c37 {
+.c23 {
   margin-right: 3.2rem;
   display: -webkit-box;
   display: -webkit-flex;
@@ -327,7 +68,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
   height: 4rem;
 }
 
-.c34 {
+.c20 {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -340,7 +81,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
   border: 0;
 }
 
-.c36 {
+.c22 {
   color: #424242;
   font-size: 1.4rem;
   display: -webkit-box;
@@ -500,11 +241,11 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
   margin: 0 1.6rem 0 1.6rem;
 }
 
-.c7 .c40:last-child {
+.c7 .c26:last-child {
   border-bottom: none;
 }
 
-.c22 {
+.c16 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -543,13 +284,13 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
   margin: 0 1.6rem 0 1.6rem;
 }
 
-.c32 {
+.c18 {
   height: 2.5rem;
   width: 2.5rem;
   padding: 0.4rem;
 }
 
-.c31 {
+.c17 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -562,20 +303,20 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
   padding-right: 2.4rem;
 }
 
-.c31 .c33 {
+.c17 .c19 {
   font-size: 1.6rem;
   line-height: 2.5rem;
   margin: 0px 0px 0px 0.5rem;
 }
 
 @media print {
-  .c38 {
+  .c24 {
     display: none;
   }
 }
 
 @media print {
-  .c39 {
+  .c25 {
     max-width: -webkit-max-content;
     max-width: -moz-max-content;
     max-width: max-content;
@@ -583,13 +324,13 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
 }
 
 @media screen and (max-width:75em) {
-  .c36 {
+  .c22 {
     padding: 0 2.4rem 0.4rem 2.4rem;
   }
 }
 
 @media print {
-  .c36 {
+  .c22 {
     margin: 0;
   }
 }
@@ -624,7 +365,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
 }
 
 @media print {
-  .c0 > *:not(.c35) {
+  .c0 > *:not(.c21) {
     display: none;
   }
 }
@@ -651,13 +392,13 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
 }
 
 @media screen and (max-width:75em) {
-  .c31 {
+  .c17 {
     padding-right: 1.6rem;
   }
 }
 
 @media screen and (max-width:75em) {
-  .c31 .c33 {
+  .c17 .c19 {
     display: none;
   }
 }
@@ -850,11 +591,20 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 </svg>
               </span>
               <div
-                className="c15 c16"
+                className="color-indicator c15 "
+                data-size="small"
+                style={
+                  Object {
+                    "--focus-border-color": "#8f7700",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#fed200",
+                    "--passive-color": "#ffff8a",
+                  }
+                }
               >
                 <svg
                   aria-hidden="true"
-                  className="c17 c18"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -863,32 +613,14 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                   />
                 </svg>
                 <span
-                  className="c19 c20"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#8f7700",
-                      "focused": "#fed200",
-                      "label": "yellow",
-                      "passive": "#ffff8a",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c21"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#8f7700",
-                      "focused": "#fed200",
-                      "label": "yellow",
-                      "passive": "#ffff8a",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </div>
               <span
-                className="c22"
+                className="c16"
               >
                 yellow
               </span>
@@ -918,11 +650,20 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 </svg>
               </span>
               <div
-                className="c15 c23"
+                className="color-indicator c15 "
+                data-size="small"
+                style={
+                  Object {
+                    "--focus-border-color": "#4e6f01",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#92d101",
+                    "--passive-color": "#def99f",
+                  }
+                }
               >
                 <svg
                   aria-hidden="true"
-                  className="c17 c18"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -931,32 +672,14 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                   />
                 </svg>
                 <span
-                  className="c19 c20"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#4e6f01",
-                      "focused": "#92d101",
-                      "label": "green",
-                      "passive": "#def99f",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c24"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#4e6f01",
-                      "focused": "#92d101",
-                      "label": "green",
-                      "passive": "#def99f",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </div>
               <span
-                className="c22"
+                className="c16"
               >
                 green
               </span>
@@ -986,11 +709,20 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 </svg>
               </span>
               <div
-                className="c15 c25"
+                className="color-indicator c15 "
+                data-size="small"
+                style={
+                  Object {
+                    "--focus-border-color": "#006880",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#00c3ed",
+                    "--passive-color": "#c8f5ff",
+                  }
+                }
               >
                 <svg
                   aria-hidden="true"
-                  className="c17 c18"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -999,32 +731,14 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                   />
                 </svg>
                 <span
-                  className="c19 c20"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#006880",
-                      "focused": "#00c3ed",
-                      "label": "blue",
-                      "passive": "#c8f5ff",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c26"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#006880",
-                      "focused": "#00c3ed",
-                      "label": "blue",
-                      "passive": "#c8f5ff",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </div>
               <span
-                className="c22"
+                className="c16"
               >
                 blue
               </span>
@@ -1054,11 +768,20 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 </svg>
               </span>
               <div
-                className="c15 c27"
+                className="color-indicator c15 "
+                data-size="small"
+                style={
+                  Object {
+                    "--focus-border-color": "#141a3e",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#545ec8",
+                    "--passive-color": "#cbcfff",
+                  }
+                }
               >
                 <svg
                   aria-hidden="true"
-                  className="c17 c18"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -1067,32 +790,14 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                   />
                 </svg>
                 <span
-                  className="c19 c20"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#141a3e",
-                      "focused": "#545ec8",
-                      "label": "purple",
-                      "passive": "#cbcfff",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c28"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#141a3e",
-                      "focused": "#545ec8",
-                      "label": "purple",
-                      "passive": "#cbcfff",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </div>
               <span
-                className="c22"
+                className="c16"
               >
                 purple
               </span>
@@ -1122,11 +827,20 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 </svg>
               </span>
               <div
-                className="c15 c29"
+                className="color-indicator c15 "
+                data-size="small"
+                style={
+                  Object {
+                    "--focus-border-color": "#560131",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#de017e",
+                    "--passive-color": "#ffc5e1",
+                  }
+                }
               >
                 <svg
                   aria-hidden="true"
-                  className="c17 c18"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -1135,32 +849,14 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                   />
                 </svg>
                 <span
-                  className="c19 c20"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#560131",
-                      "focused": "#de017e",
-                      "label": "pink",
-                      "passive": "#ffc5e1",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c30"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#560131",
-                      "focused": "#de017e",
-                      "label": "pink",
-                      "passive": "#ffc5e1",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </div>
               <span
-                className="c22"
+                className="c16"
               >
                 pink
               </span>
@@ -1171,7 +867,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
     </div>
     <button
       aria-label="print"
-      className="toolbar-plain-button toolbar-print-opt-wrapper c31"
+      className="toolbar-plain-button toolbar-print-opt-wrapper c17"
       data-analytics-label="print"
       data-testid="print"
       disabled={false}
@@ -1186,7 +882,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="c32"
+        className="c18"
         viewBox="0 0 512 512"
       >
         <path
@@ -1195,28 +891,28 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
         />
       </svg>
       <span
-        className="toolbar-print-options c33 "
+        className="toolbar-print-options c19 "
       >
         Print
       </span>
     </button>
   </div>
   <div
-    className="c34"
+    className="c20"
     role="status"
   />
   <ul
     aria-atomic="true"
     aria-label="Applied filters"
     aria-live="polite"
-    className="c35 c36"
+    className="c21 c22"
   >
     <li
-      className="c37"
+      className="c23"
     >
       <button
         aria-label="Remove color blue"
-        className="plain-button c38"
+        className="plain-button c24"
         data-analytics-label="Remove breadcrumb for color blue"
         onClick={[Function]}
       >
@@ -1248,17 +944,17 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
         </svg>
       </button>
       <span
-        className="c39"
+        className="c25"
       >
         blue
       </span>
     </li>
     <li
-      className="c37"
+      className="c23"
     >
       <button
         aria-label="Remove color green"
-        className="plain-button c38"
+        className="plain-button c24"
         data-analytics-label="Remove breadcrumb for color green"
         onClick={[Function]}
       >
@@ -1290,17 +986,17 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
         </svg>
       </button>
       <span
-        className="c39"
+        className="c25"
       >
         green
       </span>
     </li>
     <li
-      className="c37"
+      className="c23"
     >
       <button
         aria-label="Remove color pink"
-        className="plain-button c38"
+        className="plain-button c24"
         data-analytics-label="Remove breadcrumb for color pink"
         onClick={[Function]}
       >
@@ -1332,17 +1028,17 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
         </svg>
       </button>
       <span
-        className="c39"
+        className="c25"
       >
         pink
       </span>
     </li>
     <li
-      className="c37"
+      className="c23"
     >
       <button
         aria-label="Remove color purple"
-        className="plain-button c38"
+        className="plain-button c24"
         data-analytics-label="Remove breadcrumb for color purple"
         onClick={[Function]}
       >
@@ -1374,17 +1070,17 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
         </svg>
       </button>
       <span
-        className="c39"
+        className="c25"
       >
         purple
       </span>
     </li>
     <li
-      className="c37"
+      className="c23"
     >
       <button
         aria-label="Remove color yellow"
-        className="plain-button c38"
+        className="plain-button c24"
         data-analytics-label="Remove breadcrumb for color yellow"
         onClick={[Function]}
       >
@@ -1416,7 +1112,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
         </svg>
       </button>
       <span
-        className="c39"
+        className="c25"
       >
         yellow
       </span>

--- a/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
+++ b/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
@@ -596,7 +596,6 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 style={
                   Object {
                     "--focus-border-color": "#8f7700",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#fed200",
                     "--passive-color": "#ffff8a",
                   }
@@ -655,7 +654,6 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 style={
                   Object {
                     "--focus-border-color": "#4e6f01",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#92d101",
                     "--passive-color": "#def99f",
                   }
@@ -714,7 +712,6 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 style={
                   Object {
                     "--focus-border-color": "#006880",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#00c3ed",
                     "--passive-color": "#c8f5ff",
                   }
@@ -773,7 +770,6 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 style={
                   Object {
                     "--focus-border-color": "#141a3e",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#545ec8",
                     "--passive-color": "#cbcfff",
                   }
@@ -832,7 +828,6 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 style={
                   Object {
                     "--focus-border-color": "#560131",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#de017e",
                     "--passive-color": "#ffc5e1",
                   }

--- a/src/app/content/highlights/components/__snapshots__/ColorIndicator.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/ColorIndicator.spec.tsx.snap
@@ -7,7 +7,6 @@ exports[`ColorIndicator matches snapshot (checked) 1`] = `
   style={
     Object {
       "--focus-border-color": "#8f7700",
-      "--focus-outline-color": "var(--focus-outline-color)",
       "--focused-color": "#fed200",
       "--passive-color": "#ffff8a",
     }
@@ -38,7 +37,6 @@ exports[`ColorIndicator matches snapshot 1`] = `
   style={
     Object {
       "--focus-border-color": "#8f7700",
-      "--focus-outline-color": "var(--focus-outline-color)",
       "--focused-color": "#fed200",
       "--passive-color": "#ffff8a",
     }

--- a/src/app/content/highlights/components/__snapshots__/ColorIndicator.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/ColorIndicator.spec.tsx.snap
@@ -1,95 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorIndicator matches snapshot (checked) 1`] = `
-.c2 {
-  display: none;
-}
-
-.c4 {
-  display: none;
-  position: absolute;
-  height: 2.8rem;
-  width: 2.8rem;
-  background-color: transparent;
-  z-index: -1;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-}
-
-.c5 {
-  height: 2.1999999999999997rem;
-  width: 2.1999999999999997rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #fed200;
-}
-
-.c6 .c1 {
-  height: 1.6rem;
-  width: 1.6rem;
-}
-
-.c6 input:focus + .c3 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c0 {
-  position: relative;
-  background-color: #ffff8a;
-  border: 1px solid #8f7700;
-  height: 2.4rem;
-  width: 2.4rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c0 .c1 {
-  height: 1.6rem;
-  width: 1.6rem;
-  color: #fed200;
-  stroke: #8f7700;
-  stroke-width: 5%;
-  display: block;
-}
-
-.c0 input:focus + .c3 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
 <div
-  className="c0"
+  className="color-indicator "
+  data-checked={true}
+  style={
+    Object {
+      "--focus-border-color": "#8f7700",
+      "--focus-outline-color": "var(--focus-outline-color)",
+      "--focused-color": "#fed200",
+      "--passive-color": "#ffff8a",
+    }
+  }
 >
   <svg
     aria-hidden="true"
-    className="c1 c2"
+    className="color-indicator-check "
     viewBox="0 0 512 512"
   >
     <path
@@ -98,104 +24,29 @@ exports[`ColorIndicator matches snapshot (checked) 1`] = `
     />
   </svg>
   <span
-    className="c3 c4"
-    style={
-      Object {
-        "focusBorder": "#8f7700",
-        "focused": "#fed200",
-        "label": "yellow",
-        "passive": "#ffff8a",
-      }
-    }
+    className="color-indicator-focus"
   />
   <span
-    className="c5"
-    style={
-      Object {
-        "focusBorder": "#8f7700",
-        "focused": "#fed200",
-        "label": "yellow",
-        "passive": "#ffff8a",
-      }
-    }
+    className="color-indicator-ring"
   />
 </div>
 `;
 
 exports[`ColorIndicator matches snapshot 1`] = `
-.c2 {
-  display: none;
-}
-
-.c4 {
-  display: none;
-  position: absolute;
-  height: 2.8rem;
-  width: 2.8rem;
-  background-color: transparent;
-  z-index: -1;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-}
-
-.c5 {
-  height: 2.1999999999999997rem;
-  width: 2.1999999999999997rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #fed200;
-}
-
-.c0 {
-  position: relative;
-  background-color: #ffff8a;
-  border: 1px solid #8f7700;
-  height: 2.4rem;
-  width: 2.4rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c0 .c1 {
-  height: 1.6rem;
-  width: 1.6rem;
-}
-
-.c0 input:focus + .c3 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
 <div
-  className="c0"
+  className="color-indicator "
+  style={
+    Object {
+      "--focus-border-color": "#8f7700",
+      "--focus-outline-color": "var(--focus-outline-color)",
+      "--focused-color": "#fed200",
+      "--passive-color": "#ffff8a",
+    }
+  }
 >
   <svg
     aria-hidden="true"
-    className="c1 c2"
+    className="color-indicator-check "
     viewBox="0 0 512 512"
   >
     <path
@@ -204,26 +55,10 @@ exports[`ColorIndicator matches snapshot 1`] = `
     />
   </svg>
   <span
-    className="c3 c4"
-    style={
-      Object {
-        "focusBorder": "#8f7700",
-        "focused": "#fed200",
-        "label": "yellow",
-        "passive": "#ffff8a",
-      }
-    }
+    className="color-indicator-focus"
   />
   <span
-    className="c5"
-    style={
-      Object {
-        "focusBorder": "#8f7700",
-        "focused": "#fed200",
-        "label": "yellow",
-        "passive": "#ffff8a",
-      }
-    }
+    className="color-indicator-ring"
   />
 </div>
 `;

--- a/src/app/content/highlights/components/__snapshots__/ColorPicker.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/ColorPicker.spec.tsx.snap
@@ -27,7 +27,6 @@ exports[`ColorPicker matches snapshot no selection 1`] = `
       style={
         Object {
           "--focus-border-color": "#8f7700",
-          "--focus-outline-color": "var(--focus-outline-color)",
           "--focused-color": "#fed200",
           "--passive-color": "#ffff8a",
         }
@@ -66,7 +65,6 @@ exports[`ColorPicker matches snapshot no selection 1`] = `
       style={
         Object {
           "--focus-border-color": "#4e6f01",
-          "--focus-outline-color": "var(--focus-outline-color)",
           "--focused-color": "#92d101",
           "--passive-color": "#def99f",
         }
@@ -105,7 +103,6 @@ exports[`ColorPicker matches snapshot no selection 1`] = `
       style={
         Object {
           "--focus-border-color": "#006880",
-          "--focus-outline-color": "var(--focus-outline-color)",
           "--focused-color": "#00c3ed",
           "--passive-color": "#c8f5ff",
         }
@@ -144,7 +141,6 @@ exports[`ColorPicker matches snapshot no selection 1`] = `
       style={
         Object {
           "--focus-border-color": "#141a3e",
-          "--focus-outline-color": "var(--focus-outline-color)",
           "--focused-color": "#545ec8",
           "--passive-color": "#cbcfff",
         }
@@ -183,7 +179,6 @@ exports[`ColorPicker matches snapshot no selection 1`] = `
       style={
         Object {
           "--focus-border-color": "#560131",
-          "--focus-outline-color": "var(--focus-outline-color)",
           "--focused-color": "#de017e",
           "--passive-color": "#ffc5e1",
         }

--- a/src/app/content/highlights/components/__snapshots__/ColorPicker.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/ColorPicker.spec.tsx.snap
@@ -1,270 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorPicker matches snapshot no selection 1`] = `
-.c2 {
-  display: none;
-}
-
-.c4 {
-  display: none;
-  position: absolute;
-  height: 2.8rem;
-  width: 2.8rem;
-  background-color: transparent;
-  z-index: -1;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-}
-
-.c5 {
-  height: 2.1999999999999997rem;
-  width: 2.1999999999999997rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #fed200;
-}
-
-.c7 {
-  height: 2.1999999999999997rem;
-  width: 2.1999999999999997rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #92d101;
-}
-
-.c9 {
-  height: 2.1999999999999997rem;
-  width: 2.1999999999999997rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #00c3ed;
-}
-
-.c11 {
-  height: 2.1999999999999997rem;
-  width: 2.1999999999999997rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #545ec8;
-}
-
-.c13 {
-  height: 2.1999999999999997rem;
-  width: 2.1999999999999997rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #de017e;
-}
-
-.c0 {
-  position: relative;
-  background-color: #ffff8a;
-  border: 1px solid #8f7700;
-  height: 2.4rem;
-  width: 2.4rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c0 .c1 {
-  height: 1.6rem;
-  width: 1.6rem;
-}
-
-.c0 input:focus + .c3 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c6 {
-  position: relative;
-  background-color: #def99f;
-  border: 1px solid #4e6f01;
-  height: 2.4rem;
-  width: 2.4rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c6 .c1 {
-  height: 1.6rem;
-  width: 1.6rem;
-}
-
-.c6 input:focus + .c3 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c8 {
-  position: relative;
-  background-color: #c8f5ff;
-  border: 1px solid #006880;
-  height: 2.4rem;
-  width: 2.4rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c8 .c1 {
-  height: 1.6rem;
-  width: 1.6rem;
-}
-
-.c8 input:focus + .c3 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c10 {
-  position: relative;
-  background-color: #cbcfff;
-  border: 1px solid #141a3e;
-  height: 2.4rem;
-  width: 2.4rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c10 .c1 {
-  height: 1.6rem;
-  width: 1.6rem;
-}
-
-.c10 input:focus + .c3 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c12 {
-  position: relative;
-  background-color: #ffc5e1;
-  border: 1px solid #560131;
-  height: 2.4rem;
-  width: 2.4rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c12 .c1 {
-  height: 1.6rem;
-  width: 1.6rem;
-}
-
-.c12 input:focus + .c3 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c14 img {
-  height: 1.9rem;
-  width: 1.9rem;
-}
-
 <div
   className="color-picker-wrapper"
 >
@@ -286,22 +22,21 @@ exports[`ColorPicker matches snapshot no selection 1`] = `
     </legend>
     <label
       aria-label="Apply yellow highlight"
-      checked={false}
-      className="c0 color-button "
-      component={<label />}
+      className="color-indicator color-button "
+      data-checked={false}
       style={
         Object {
-          "focusBorder": "#8f7700",
-          "focused": "#fed200",
-          "label": "yellow",
-          "passive": "#ffff8a",
+          "--focus-border-color": "#8f7700",
+          "--focus-outline-color": "var(--focus-outline-color)",
+          "--focused-color": "#fed200",
+          "--passive-color": "#ffff8a",
         }
       }
       title="yellow"
     >
       <svg
         aria-hidden="true"
-        className="c1 c2"
+        className="color-indicator-check "
         viewBox="0 0 512 512"
       >
         <path
@@ -318,46 +53,29 @@ exports[`ColorPicker matches snapshot no selection 1`] = `
         type="radio"
       />
       <span
-        className="c3 c4"
-        style={
-          Object {
-            "focusBorder": "#8f7700",
-            "focused": "#fed200",
-            "label": "yellow",
-            "passive": "#ffff8a",
-          }
-        }
+        className="color-indicator-focus"
       />
       <span
-        className="c5"
-        style={
-          Object {
-            "focusBorder": "#8f7700",
-            "focused": "#fed200",
-            "label": "yellow",
-            "passive": "#ffff8a",
-          }
-        }
+        className="color-indicator-ring"
       />
     </label>
     <label
       aria-label="Apply green highlight"
-      checked={false}
-      className="c6 color-button "
-      component={<label />}
+      className="color-indicator color-button "
+      data-checked={false}
       style={
         Object {
-          "focusBorder": "#4e6f01",
-          "focused": "#92d101",
-          "label": "green",
-          "passive": "#def99f",
+          "--focus-border-color": "#4e6f01",
+          "--focus-outline-color": "var(--focus-outline-color)",
+          "--focused-color": "#92d101",
+          "--passive-color": "#def99f",
         }
       }
       title="green"
     >
       <svg
         aria-hidden="true"
-        className="c1 c2"
+        className="color-indicator-check "
         viewBox="0 0 512 512"
       >
         <path
@@ -374,46 +92,29 @@ exports[`ColorPicker matches snapshot no selection 1`] = `
         type="radio"
       />
       <span
-        className="c3 c4"
-        style={
-          Object {
-            "focusBorder": "#4e6f01",
-            "focused": "#92d101",
-            "label": "green",
-            "passive": "#def99f",
-          }
-        }
+        className="color-indicator-focus"
       />
       <span
-        className="c7"
-        style={
-          Object {
-            "focusBorder": "#4e6f01",
-            "focused": "#92d101",
-            "label": "green",
-            "passive": "#def99f",
-          }
-        }
+        className="color-indicator-ring"
       />
     </label>
     <label
       aria-label="Apply blue highlight"
-      checked={false}
-      className="c8 color-button "
-      component={<label />}
+      className="color-indicator color-button "
+      data-checked={false}
       style={
         Object {
-          "focusBorder": "#006880",
-          "focused": "#00c3ed",
-          "label": "blue",
-          "passive": "#c8f5ff",
+          "--focus-border-color": "#006880",
+          "--focus-outline-color": "var(--focus-outline-color)",
+          "--focused-color": "#00c3ed",
+          "--passive-color": "#c8f5ff",
         }
       }
       title="blue"
     >
       <svg
         aria-hidden="true"
-        className="c1 c2"
+        className="color-indicator-check "
         viewBox="0 0 512 512"
       >
         <path
@@ -430,46 +131,29 @@ exports[`ColorPicker matches snapshot no selection 1`] = `
         type="radio"
       />
       <span
-        className="c3 c4"
-        style={
-          Object {
-            "focusBorder": "#006880",
-            "focused": "#00c3ed",
-            "label": "blue",
-            "passive": "#c8f5ff",
-          }
-        }
+        className="color-indicator-focus"
       />
       <span
-        className="c9"
-        style={
-          Object {
-            "focusBorder": "#006880",
-            "focused": "#00c3ed",
-            "label": "blue",
-            "passive": "#c8f5ff",
-          }
-        }
+        className="color-indicator-ring"
       />
     </label>
     <label
       aria-label="Apply purple highlight"
-      checked={false}
-      className="c10 color-button "
-      component={<label />}
+      className="color-indicator color-button "
+      data-checked={false}
       style={
         Object {
-          "focusBorder": "#141a3e",
-          "focused": "#545ec8",
-          "label": "purple",
-          "passive": "#cbcfff",
+          "--focus-border-color": "#141a3e",
+          "--focus-outline-color": "var(--focus-outline-color)",
+          "--focused-color": "#545ec8",
+          "--passive-color": "#cbcfff",
         }
       }
       title="purple"
     >
       <svg
         aria-hidden="true"
-        className="c1 c2"
+        className="color-indicator-check "
         viewBox="0 0 512 512"
       >
         <path
@@ -486,46 +170,29 @@ exports[`ColorPicker matches snapshot no selection 1`] = `
         type="radio"
       />
       <span
-        className="c3 c4"
-        style={
-          Object {
-            "focusBorder": "#141a3e",
-            "focused": "#545ec8",
-            "label": "purple",
-            "passive": "#cbcfff",
-          }
-        }
+        className="color-indicator-focus"
       />
       <span
-        className="c11"
-        style={
-          Object {
-            "focusBorder": "#141a3e",
-            "focused": "#545ec8",
-            "label": "purple",
-            "passive": "#cbcfff",
-          }
-        }
+        className="color-indicator-ring"
       />
     </label>
     <label
       aria-label="Apply pink highlight"
-      checked={false}
-      className="c12 color-button "
-      component={<label />}
+      className="color-indicator color-button "
+      data-checked={false}
       style={
         Object {
-          "focusBorder": "#560131",
-          "focused": "#de017e",
-          "label": "pink",
-          "passive": "#ffc5e1",
+          "--focus-border-color": "#560131",
+          "--focus-outline-color": "var(--focus-outline-color)",
+          "--focused-color": "#de017e",
+          "--passive-color": "#ffc5e1",
         }
       }
       title="pink"
     >
       <svg
         aria-hidden="true"
-        className="c1 c2"
+        className="color-indicator-check "
         viewBox="0 0 512 512"
       >
         <path
@@ -542,32 +209,17 @@ exports[`ColorPicker matches snapshot no selection 1`] = `
         type="radio"
       />
       <span
-        className="c3 c4"
-        style={
-          Object {
-            "focusBorder": "#560131",
-            "focused": "#de017e",
-            "label": "pink",
-            "passive": "#ffc5e1",
-          }
-        }
+        className="color-indicator-focus"
       />
       <span
-        className="c13"
-        style={
-          Object {
-            "focusBorder": "#560131",
-            "focused": "#de017e",
-            "label": "pink",
-            "passive": "#ffc5e1",
-          }
-        }
+        className="color-indicator-ring"
       />
     </label>
   </fieldset>
   <button
     aria-label="Deselect current highlight color"
-    className="c14"
+    className="trash-button "
+    data-testid="editcard-trash-icon"
     onClick={[MockFunction]}
     type="button"
   >

--- a/src/app/content/highlights/components/__snapshots__/Confirmation.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/Confirmation.spec.tsx.snap
@@ -82,6 +82,7 @@ exports[`Confirmation matches snapshot no selection 1`] = `
 exports[`Confirmation renders with data-analytics-label and ref 1`] = `
 <div
   className="confirmation-overlay"
+  data-analytics-label="custom-label"
   role="alertdialog"
   tabIndex={-1}
 >

--- a/src/app/content/highlights/components/__snapshots__/Confirmation.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/Confirmation.spec.tsx.snap
@@ -1,45 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Confirmation matches snapshot no selection 1`] = `
-.c0 {
-  background: rgba(0,0,0,0.9);
-  outline: none;
-  border-radius: 0.4rem;
-  box-shadow: 0 0 2px 0 rgba(0,0,0,0.14),0 2px 2px 0 rgba(0,0,0,0.12),0 1px 3px 0 rgba(0,0,0,0.2);
-  -webkit-transition: background 200ms;
-  transition: background 200ms;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 1.6rem;
-  overflow: visible;
-  min-height: 100%;
-  min-width: 100%;
-  position: static;
-  width: -webkit-min-content;
-  width: -moz-min-content;
-  width: min-content;
-}
-
-.c0 label {
-  color: #424242;
-  font-size: 1.4rem;
-  line-height: 1.6rem;
-  font-weight: normal;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  color: #fff;
-  margin-bottom: 0.8rem;
-  overflow: visible;
-}
-
 <div
-  className="c0"
+  className="confirmation-overlay"
   data-analytics-region="region"
   role="alertdialog"
   tabIndex={-1}
@@ -117,45 +80,8 @@ exports[`Confirmation matches snapshot no selection 1`] = `
 `;
 
 exports[`Confirmation renders with data-analytics-label and ref 1`] = `
-.c0 {
-  background: rgba(0,0,0,0.9);
-  outline: none;
-  border-radius: 0.4rem;
-  box-shadow: 0 0 2px 0 rgba(0,0,0,0.14),0 2px 2px 0 rgba(0,0,0,0.12),0 1px 3px 0 rgba(0,0,0,0.2);
-  -webkit-transition: background 200ms;
-  transition: background 200ms;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 1.6rem;
-  overflow: visible;
-  min-height: 100%;
-  min-width: 100%;
-  position: static;
-  width: -webkit-min-content;
-  width: -moz-min-content;
-  width: min-content;
-}
-
-.c0 label {
-  color: #424242;
-  font-size: 1.4rem;
-  line-height: 1.6rem;
-  font-weight: normal;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  color: #fff;
-  margin-bottom: 0.8rem;
-  overflow: visible;
-}
-
 <div
-  className="c0"
+  className="confirmation-overlay"
   role="alertdialog"
   tabIndex={-1}
 >
@@ -232,45 +158,8 @@ exports[`Confirmation renders with data-analytics-label and ref 1`] = `
 `;
 
 exports[`Confirmation works without optional props and drawFocus={true} 1`] = `
-.c0 {
-  background: rgba(0,0,0,0.9);
-  outline: none;
-  border-radius: 0.4rem;
-  box-shadow: 0 0 2px 0 rgba(0,0,0,0.14),0 2px 2px 0 rgba(0,0,0,0.12),0 1px 3px 0 rgba(0,0,0,0.2);
-  -webkit-transition: background 200ms;
-  transition: background 200ms;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 1.6rem;
-  overflow: visible;
-  min-height: 100%;
-  min-width: 100%;
-  position: static;
-  width: -webkit-min-content;
-  width: -moz-min-content;
-  width: min-content;
-}
-
-.c0 label {
-  color: #424242;
-  font-size: 1.4rem;
-  line-height: 1.6rem;
-  font-weight: normal;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  color: #fff;
-  margin-bottom: 0.8rem;
-  overflow: visible;
-}
-
 <div
-  className="c0"
+  className="confirmation-overlay"
   role="alertdialog"
   tabIndex={-1}
 >

--- a/src/app/content/highlights/components/__snapshots__/Confirmation.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/Confirmation.spec.tsx.snap
@@ -82,7 +82,6 @@ exports[`Confirmation matches snapshot no selection 1`] = `
 exports[`Confirmation renders with data-analytics-label and ref 1`] = `
 <div
   className="confirmation-overlay"
-  data-analytics-label="custom-label"
   role="alertdialog"
   tabIndex={-1}
 >

--- a/src/app/content/highlights/components/__snapshots__/ConfirmationModal.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/ConfirmationModal.spec.tsx.snap
@@ -1,13 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfirmationModal matches snapshot 1`] = `
-.c0 {
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
 <div
   className="modal-wrapper"
   style={
@@ -87,7 +80,7 @@ exports[`ConfirmationModal matches snapshot 1`] = `
         </h3>
       </div>
       <div
-        className="modal-footer c0"
+        className="modal-footer confirmation-modal-footer"
       >
         <button
           className="button button-primary button-medium"

--- a/src/app/content/highlights/components/__snapshots__/DisplayNote.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/DisplayNote.spec.tsx.snap
@@ -75,9 +75,6 @@ exports[`DisplayNote matches snapshot 1`] = `
       </g>
     </g>
   </svg>
-  <label>
-    Note:
-  </label>
   <div
     id="display-note-test-highlight-id"
     isActive={false}
@@ -163,9 +160,6 @@ exports[`DisplayNote matches snapshot when focused 1`] = `
       </g>
     </g>
   </svg>
-  <label>
-    Note:
-  </label>
   <div
     id="display-note-test-highlight-id"
     isActive={true}
@@ -279,9 +273,6 @@ exports[`DisplayNote matches snapshot when focused with opened dropdown 1`] = `
       </g>
     </g>
   </svg>
-  <label>
-    Note:
-  </label>
   <div
     id="display-note-test-highlight-id"
     isActive={true}

--- a/src/app/content/highlights/components/__snapshots__/DisplayNote.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/DisplayNote.spec.tsx.snap
@@ -76,6 +76,11 @@ exports[`DisplayNote matches snapshot 1`] = `
     </g>
   </svg>
   <div
+    className="note-label"
+  >
+    Note:
+  </div>
+  <div
     id="display-note-test-highlight-id"
     isActive={false}
     mock-truncated-text={true}
@@ -160,6 +165,11 @@ exports[`DisplayNote matches snapshot when focused 1`] = `
       </g>
     </g>
   </svg>
+  <div
+    className="note-label"
+  >
+    Note:
+  </div>
   <div
     id="display-note-test-highlight-id"
     isActive={true}
@@ -273,6 +283,11 @@ exports[`DisplayNote matches snapshot when focused with opened dropdown 1`] = `
       </g>
     </g>
   </svg>
+  <div
+    className="note-label"
+  >
+    Note:
+  </div>
   <div
     id="display-note-test-highlight-id"
     isActive={true}

--- a/src/app/content/highlights/components/__snapshots__/EditCard.spec.tsx.snap
+++ b/src/app/content/highlights/components/__snapshots__/EditCard.spec.tsx.snap
@@ -23,30 +23,17 @@ Array [
     aria-live="polite"
     className="c0 c1"
   />,
-  .c1 {
+  .c0 {
   min-width: 20rem;
-}
-
-.c0 {
-  background: #f5f5f5;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  overflow: visible;
-}
-
-.c0 .c2 {
-  margin-top: 0.8rem;
 }
 
 <div
     aria-label="Edit highlighted note"
-    className="c0"
+    className="edit-card "
     role="dialog"
   >
     <div
-      className="c1"
+      className="c0"
     >
       <form
         data-analytics-region="edit-note"
@@ -78,7 +65,7 @@ Array [
             mock-note="true"
           />
           <div
-            className="button-group c2 "
+            className="button-group"
           >
             <button
               className="button button-primary button-small"
@@ -151,22 +138,9 @@ Array [
 `;
 
 exports[`EditCard Snapshots and Rendering matches snapshot when focused 1`] = `
-.c0 {
-  background: #f5f5f5;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  overflow: visible;
-}
-
-.c0 .c1 {
-  margin-top: 0.8rem;
-}
-
 <div
   aria-label="Edit highlighted note"
-  className="c0"
+  className="edit-card "
   role="dialog"
 >
   <div
@@ -209,30 +183,17 @@ Array [
     aria-live="polite"
     className="c0 c1"
   />,
-  .c1 {
+  .c0 {
   min-width: 20rem;
-}
-
-.c0 {
-  background: #f5f5f5;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  overflow: visible;
-}
-
-.c0 .c2 {
-  margin-top: 0.8rem;
 }
 
 <div
     aria-label="Edit highlighted note"
-    className="c0"
+    className="edit-card "
     role="dialog"
   >
     <div
-      className="c1"
+      className="c0"
     >
       <form
         data-analytics-region="edit-note"
@@ -271,22 +232,9 @@ Array [
 `;
 
 exports[`EditCard Snapshots and Rendering matches snapshot without data 1`] = `
-.c0 {
-  background: #f5f5f5;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  overflow: visible;
-}
-
-.c0 .c1 {
-  margin-top: 0.8rem;
-}
-
 <div
   aria-label="Edit highlighted note"
-  className="c0"
+  className="edit-card "
   role="dialog"
 >
   <div

--- a/src/app/content/highlights/components/style.ts
+++ b/src/app/content/highlights/components/style.ts
@@ -1,6 +1,0 @@
-import { css } from 'styled-components';
-
-export const cardBorder = css`
-  border-radius: 0.4rem;
-  box-shadow: 0 0 2px 0 rgba(0,0,0,0.14), 0 2px 2px 0 rgba(0,0,0,0.12), 0 1px 3px 0 rgba(0,0,0,0.2);
-`;

--- a/src/app/content/studyGuides/components/__snapshots__/Filters.spec.tsx.snap
+++ b/src/app/content/studyGuides/components/__snapshots__/Filters.spec.tsx.snap
@@ -913,7 +913,6 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 style={
                   Object {
                     "--focus-border-color": "#8f7700",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#fed200",
                     "--passive-color": "#ffff8a",
                   }
@@ -972,7 +971,6 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 style={
                   Object {
                     "--focus-border-color": "#4e6f01",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#92d101",
                     "--passive-color": "#def99f",
                   }
@@ -1031,7 +1029,6 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 style={
                   Object {
                     "--focus-border-color": "#006880",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#00c3ed",
                     "--passive-color": "#c8f5ff",
                   }
@@ -1090,7 +1087,6 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 style={
                   Object {
                     "--focus-border-color": "#141a3e",
-                    "--focus-outline-color": "var(--focus-outline-color)",
                     "--focused-color": "#545ec8",
                     "--passive-color": "#cbcfff",
                   }

--- a/src/app/content/studyGuides/components/__snapshots__/Filters.spec.tsx.snap
+++ b/src/app/content/studyGuides/components/__snapshots__/Filters.spec.tsx.snap
@@ -6,18 +6,18 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
   position: relative;
 }
 
-.c39 {
+.c27 {
   height: 1.7rem;
   margin-right: 0.4rem;
 }
 
-.c39 svg {
+.c27 svg {
   height: 0.8rem;
   width: 0.8rem;
   color: #5e6062;
 }
 
-.c40 {
+.c28 {
   color: #424242;
   font-weight: 300;
   color: #5e6062;
@@ -29,7 +29,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
   line-height: 1.5rem;
 }
 
-.c38 {
+.c26 {
   margin-right: 3.2rem;
   display: -webkit-box;
   display: -webkit-flex;
@@ -43,7 +43,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
   height: 4rem;
 }
 
-.c35 {
+.c23 {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -56,7 +56,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
   border: 0;
 }
 
-.c37 {
+.c25 {
   color: #424242;
   font-size: 1.4rem;
   display: -webkit-box;
@@ -97,217 +97,6 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
 
 .c9 span {
   padding: 0 1rem;
-}
-
-.c20 {
-  display: none;
-}
-
-.c22 {
-  display: none;
-  position: absolute;
-  height: 2rem;
-  width: 2rem;
-  background-color: transparent;
-  z-index: -1;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-}
-
-.c23 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #fed200;
-}
-
-.c26 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #92d101;
-}
-
-.c28 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #00c3ed;
-}
-
-.c30 {
-  height: 1.4000000000000001rem;
-  width: 1.4000000000000001rem;
-  background-color: transparent;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  border-radius: 50%;
-  border: 1px solid #545ec8;
-}
-
-.c18 {
-  position: relative;
-  background-color: #ffff8a;
-  border: 1px solid #8f7700;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c18 .c19 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c18 input:focus + .c21 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c25 {
-  position: relative;
-  background-color: #def99f;
-  border: 1px solid #4e6f01;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c25 .c19 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c25 input:focus + .c21 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c27 {
-  position: relative;
-  background-color: #c8f5ff;
-  border: 1px solid #006880;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c27 .c19 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c27 input:focus + .c21 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
-}
-
-.c29 {
-  position: relative;
-  background-color: #cbcfff;
-  border: 1px solid #141a3e;
-  height: 1.6rem;
-  width: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border-radius: 2rem;
-  overflow: visible;
-}
-
-.c29 .c19 {
-  height: 1rem;
-  width: 1rem;
-}
-
-.c29 input:focus + .c21 {
-  display: block;
-  outline: 0.2rem auto Highlight;
-  outline: 0.2rem auto -webkit-focus-ring-color;
-  z-index: 1;
 }
 
 .c6 {
@@ -493,11 +282,11 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
   margin: 0 1.6rem 0 1.6rem;
 }
 
-.c7 .c41:last-child {
+.c7 .c29:last-child {
   border-bottom: none;
 }
 
-.c24 {
+.c18 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -506,13 +295,13 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
   white-space: nowrap;
 }
 
-.c33 {
+.c21 {
   height: 2.5rem;
   width: 2.5rem;
   padding: 0.4rem;
 }
 
-.c32 {
+.c20 {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -525,7 +314,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
   padding-right: 2.4rem;
 }
 
-.c32 .c34 {
+.c20 .c22 {
   font-size: 1.6rem;
   line-height: 2.5rem;
   margin: 0px 0px 0px 0.5rem;
@@ -562,7 +351,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
   margin: 0 1.6rem 0 1.6rem;
 }
 
-.c31 {
+.c19 {
   margin-left: auto;
   display: -webkit-box;
   display: -webkit-flex;
@@ -576,13 +365,13 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
 }
 
 @media print {
-  .c39 {
+  .c27 {
     display: none;
   }
 }
 
 @media print {
-  .c40 {
+  .c28 {
     max-width: -webkit-max-content;
     max-width: -moz-max-content;
     max-width: max-content;
@@ -590,13 +379,13 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
 }
 
 @media screen and (max-width:75em) {
-  .c37 {
+  .c25 {
     padding: 0 2.4rem 0.4rem 2.4rem;
   }
 }
 
 @media print {
-  .c37 {
+  .c25 {
     margin: 0;
   }
 }
@@ -631,7 +420,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
 }
 
 @media print {
-  .c0 > *:not(.c36) {
+  .c0 > *:not(.c24) {
     display: none;
   }
 }
@@ -652,13 +441,13 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
 }
 
 @media screen and (max-width:75em) {
-  .c32 {
+  .c20 {
     padding-right: 1.6rem;
   }
 }
 
 @media screen and (max-width:75em) {
-  .c32 .c34 {
+  .c20 .c22 {
     display: none;
   }
 }
@@ -1119,11 +908,20 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 </svg>
               </span>
               <div
-                className="c17 c18"
+                className="color-indicator c17 "
+                data-size="small"
+                style={
+                  Object {
+                    "--focus-border-color": "#8f7700",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#fed200",
+                    "--passive-color": "#ffff8a",
+                  }
+                }
               >
                 <svg
                   aria-hidden="true"
-                  className="c19 c20"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -1132,32 +930,14 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                   />
                 </svg>
                 <span
-                  className="c21 c22"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#8f7700",
-                      "focused": "#fed200",
-                      "label": "yellow",
-                      "passive": "#ffff8a",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c23"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#8f7700",
-                      "focused": "#fed200",
-                      "label": "yellow",
-                      "passive": "#ffff8a",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </div>
               <span
-                className="c24"
+                className="c18"
               >
                 Key Terms
               </span>
@@ -1187,11 +967,20 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 </svg>
               </span>
               <div
-                className="c17 c25"
+                className="color-indicator c17 "
+                data-size="small"
+                style={
+                  Object {
+                    "--focus-border-color": "#4e6f01",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#92d101",
+                    "--passive-color": "#def99f",
+                  }
+                }
               >
                 <svg
                   aria-hidden="true"
-                  className="c19 c20"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -1200,32 +989,14 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                   />
                 </svg>
                 <span
-                  className="c21 c22"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#4e6f01",
-                      "focused": "#92d101",
-                      "label": "green",
-                      "passive": "#def99f",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c26"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#4e6f01",
-                      "focused": "#92d101",
-                      "label": "green",
-                      "passive": "#def99f",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </div>
               <span
-                className="c24"
+                className="c18"
               >
                 Connections & Relationships
               </span>
@@ -1255,11 +1026,20 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 </svg>
               </span>
               <div
-                className="c17 c27"
+                className="color-indicator c17 "
+                data-size="small"
+                style={
+                  Object {
+                    "--focus-border-color": "#006880",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#00c3ed",
+                    "--passive-color": "#c8f5ff",
+                  }
+                }
               >
                 <svg
                   aria-hidden="true"
-                  className="c19 c20"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -1268,32 +1048,14 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                   />
                 </svg>
                 <span
-                  className="c21 c22"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#006880",
-                      "focused": "#00c3ed",
-                      "label": "blue",
-                      "passive": "#c8f5ff",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c28"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#006880",
-                      "focused": "#00c3ed",
-                      "label": "blue",
-                      "passive": "#c8f5ff",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </div>
               <span
-                className="c24"
+                className="c18"
               >
                 Important Concepts
               </span>
@@ -1323,11 +1085,20 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 </svg>
               </span>
               <div
-                className="c17 c29"
+                className="color-indicator c17 "
+                data-size="small"
+                style={
+                  Object {
+                    "--focus-border-color": "#141a3e",
+                    "--focus-outline-color": "var(--focus-outline-color)",
+                    "--focused-color": "#545ec8",
+                    "--passive-color": "#cbcfff",
+                  }
+                }
               >
                 <svg
                   aria-hidden="true"
-                  className="c19 c20"
+                  className="color-indicator-check "
                   viewBox="0 0 512 512"
                 >
                   <path
@@ -1336,32 +1107,14 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                   />
                 </svg>
                 <span
-                  className="c21 c22"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#141a3e",
-                      "focused": "#545ec8",
-                      "label": "purple",
-                      "passive": "#cbcfff",
-                    }
-                  }
+                  className="color-indicator-focus"
                 />
                 <span
-                  className="c30"
-                  size="small"
-                  style={
-                    Object {
-                      "focusBorder": "#141a3e",
-                      "focused": "#545ec8",
-                      "label": "purple",
-                      "passive": "#cbcfff",
-                    }
-                  }
+                  className="color-indicator-ring"
                 />
               </div>
               <span
-                className="c24"
+                className="c18"
               >
                 Enrichment
               </span>
@@ -1371,11 +1124,11 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
       </div>
     </div>
     <div
-      className="c31"
+      className="c19"
     >
       <button
         aria-label="print"
-        className="toolbar-plain-button toolbar-print-opt-wrapper c32"
+        className="toolbar-plain-button toolbar-print-opt-wrapper c20"
         data-analytics-label="print"
         data-testid="print"
         disabled={true}
@@ -1390,7 +1143,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
       >
         <svg
           aria-hidden="true"
-          className="c33"
+          className="c21"
           viewBox="0 0 512 512"
         >
           <path
@@ -1399,7 +1152,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
           />
         </svg>
         <span
-          className="toolbar-print-options c34 "
+          className="toolbar-print-options c22 "
         >
           Print
         </span>
@@ -1407,21 +1160,21 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
     </div>
   </div>
   <div
-    className="c35"
+    className="c23"
     role="status"
   />
   <ul
     aria-atomic="true"
     aria-label="Applied filters"
     aria-live="polite"
-    className="c36 c37 filters-list"
+    className="c24 c25 filters-list"
   >
     <li
-      className="c38"
+      className="c26"
     >
       <button
         aria-label="Remove chapter 2 Test Chapter 2"
-        className="plain-button c39"
+        className="plain-button c27"
         data-analytics-label="Remove breadcrumb for chapter 2 Test Chapter 2"
         onClick={[Function]}
       >
@@ -1453,7 +1206,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
         </svg>
       </button>
       <span
-        className="c40"
+        className="c28"
         dangerouslySetInnerHTML={
           Object {
             "__html": "<span class=\\"os-number\\">2</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 2</span>",
@@ -1462,11 +1215,11 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
       />
     </li>
     <li
-      className="c38"
+      className="c26"
     >
       <button
         aria-label="Remove label Important Concepts"
-        className="plain-button c39"
+        className="plain-button c27"
         data-analytics-label="Remove breadcrumb for label Important Concepts"
         onClick={[Function]}
       >
@@ -1498,17 +1251,17 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
         </svg>
       </button>
       <span
-        className="c40"
+        className="c28"
       >
         Important Concepts
       </span>
     </li>
     <li
-      className="c38"
+      className="c26"
     >
       <button
         aria-label="Remove label Connections & Relationships"
-        className="plain-button c39"
+        className="plain-button c27"
         data-analytics-label="Remove breadcrumb for label Connections & Relationships"
         onClick={[Function]}
       >
@@ -1540,17 +1293,17 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
         </svg>
       </button>
       <span
-        className="c40"
+        className="c28"
       >
         Connections & Relationships
       </span>
     </li>
     <li
-      className="c38"
+      className="c26"
     >
       <button
         aria-label="Remove label Enrichment"
-        className="plain-button c39"
+        className="plain-button c27"
         data-analytics-label="Remove breadcrumb for label Enrichment"
         onClick={[Function]}
       >
@@ -1582,17 +1335,17 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
         </svg>
       </button>
       <span
-        className="c40"
+        className="c28"
       >
         Enrichment
       </span>
     </li>
     <li
-      className="c38"
+      className="c26"
     >
       <button
         aria-label="Remove label Key Terms"
-        className="plain-button c39"
+        className="plain-button c27"
         data-analytics-label="Remove breadcrumb for label Key Terms"
         onClick={[Function]}
       >
@@ -1624,7 +1377,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
         </svg>
       </button>
       <span
-        className="c40"
+        className="c28"
       >
         Key Terms
       </span>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -38,6 +38,7 @@ import './content/components/Topbar/Topbar.css';
 import './errors/components/ErrorModal.css';
 import './notifications/components/ToastNotifications/ToastNotifications.css';
 import './content/highlights/components/ColorPicker.css';
+import './content/highlights/components/ColorIndicator.css';
 
 export const actions = {
   app: appAactions,


### PR DESCRIPTION
## Summary
Migrates the editable highlight card interface from styled-components to plain CSS as part of Phase 5.3.

## Jira Ticket
https://openstax.atlassian.net/browse/CORE-1834

## Components Migrated
- **EditCard.tsx** (322 lines) - Main editable card interface
- **ColorIndicator.tsx** (168 lines) - Visual color badge component
- **Confirmation.tsx** (119 lines) - Delete confirmation overlay dialog
- **ConfirmationModal.tsx** (46 lines) - Discard changes modal dialog

## Technical Changes

### EditCard.tsx
- Removed styled() wrapper export
- Created EditCard.css with touch device media query
- Applied `edit-card` className to component
- Removed styled-components import
- Changed prop from `cardStyle` to `style` to match Card.tsx usage

### ColorIndicator.tsx
- Replaced nested styled components (CheckIcon, FocusedStyle, ColorRing) with plain divs/spans
- Created ColorIndicator.css with classes for indicator, check, focus, and ring
- Used CSS custom properties for dynamic highlight colors:
  - `--passive-color`
  - `--focused-color`
  - `--focus-border-color`
- Used data attributes for variants:
  - `data-size` for small/normal sizes
  - `data-checked` for checked state
  - `data-shape` for square/circle shapes
- Converted TrashButton to plain function component
- Exported styled wrapper for backward compatibility with CSS selectors (temporary)

### Confirmation.tsx
- Replaced Overlay styled component with plain div
- Created Confirmation.css with overlay styles
- Applied `confirmation-overlay` className
- Removed styled-components imports

### ConfirmationModal.tsx
- Replaced styled ConfirmationFooter with Footer + className
- Created ConfirmationModal.css with footer styles
- Applied `confirmation-modal-footer` className

### DisplayNote.tsx (Additional Change)
- ** "Note:" label element** - This was a label not attached to any form element, which is a structural problem. It only appears when a note highlight is selected in mobile. It has been changed to be a div rather than a label.

## Dependencies
- ✅ CORE-1706 (Phase 5.1) - Completed
- ✅ CORE-1707 (Phase 5.2) - Completed

## Testing Requirements
- [ ] Test authentication gate flow
- [ ] Test color picker selection and visual feedback
- [ ] Test annotation textarea and editing
- [ ] Test Save/Cancel button states
- [ ] Test Delete confirmation dialog
- [ ] Test mobile vs desktop layouts
- [ ] Test keyboard navigation and accessibility

## Success Criteria
- [x] All styled-components imports removed from EditCard.tsx and related files (except temporary compatibility wrapper)
- [ ] Edit mode interactions work identically to before
- [ ] All existing tests pass
- [ ] No visual regressions in screenshot tests
- [ ] Color indicators display correctly with hover and checked states

🤖 Generated with [Claude Code](https://claude.com/claude-code)
