### PR TITLE
[CORE-1847] Phase 6: Use CSS variables for highlight colors and break out position styles

### DIFF
--- a/src/app/content/__snapshots__/routes.spec.tsx.snap
+++ b/src/app/content/__snapshots__/routes.spec.tsx.snap
@@ -416,6 +416,8 @@ exports[`assigned route route renders renders a component 1`] = `
         style={
           Object {
             "--content-text-width": "82.5rem",
+            "--highlight-pink-text": "var(--color-text-white)",
+            "--highlight-purple-text": "var(--color-text-white)",
             "--page-margin-top-desktop": "3.2rem",
             "--page-margin-top-mobile": "1.6rem",
           }

--- a/src/app/content/components/Page/PageContent.css
+++ b/src/app/content/components/Page/PageContent.css
@@ -2,6 +2,38 @@
 
 .page-content {
   overflow: visible;
+
+  /* CSS variables for highlight colors */
+
+  /* Yellow highlight colors */
+  --highlight-yellow-passive: #ffff8a;
+  --highlight-yellow-focused: #fed200;
+  --highlight-yellow-focus-border: #8f7700;
+  --highlight-yellow-text: inherit;
+
+  /* Green highlight colors */
+  --highlight-green-passive: #def99f;
+  --highlight-green-focused: #92d101;
+  --highlight-green-focus-border: #4e6f01;
+  --highlight-green-text: inherit;
+
+  /* Blue highlight colors */
+  --highlight-blue-passive: #c8f5ff;
+  --highlight-blue-focused: #00c3ed;
+  --highlight-blue-focus-border: #006880;
+  --highlight-blue-text: inherit;
+
+  /* Purple highlight colors */
+  --highlight-purple-passive: #cbcfff;
+  --highlight-purple-focused: #545ec8;
+  --highlight-purple-focus-border: #141a3e;
+  --highlight-purple-text: inherit;
+
+  /* Pink highlight colors */
+  --highlight-pink-passive: #ffc5e1;
+  --highlight-pink-focused: #de017e;
+  --highlight-pink-focus-border: #560131;
+  --highlight-pink-text: inherit;
 }
 
 .page-content:focus-visible {
@@ -49,6 +81,208 @@
   position: relative;
   z-index: 1;
   user-select: none;
+}
+
+/* Generic block highlight layout styles (shared across all colors) */
+.page-content .highlight.block {
+  display: block;
+}
+
+.page-content .highlight.block::after {
+  position: absolute;
+  z-index: -1;
+  content: "";
+  display: block;
+  top: -1rem;
+  bottom: -1rem;
+  left: -1rem;
+  right: -1rem;
+}
+
+/* Note indicator triangle for block highlights */
+.page-content .highlight.block.first.has-note::before {
+  position: absolute;
+  top: -1rem;
+  left: -1rem;
+  content: "";
+  width: 0;
+  height: 0;
+  opacity: 0.8;
+  border-left: 1.2em solid;
+  border-bottom: 1.2em solid transparent;
+}
+
+/* Note indicator triangle for text highlights */
+.page-content .highlight.first.text.has-note::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  content: "";
+  width: 0;
+  height: 0;
+  opacity: 0.8;
+  border-left: 0.9em solid;
+  border-top: 0.9em solid transparent;
+  transform: rotate(90deg);
+}
+
+/* Focused highlight layout styles */
+@media screen {
+  .page-content .highlight[aria-current] {
+    border-bottom: 0.2rem solid;
+    padding: 0.2rem 0 0;
+  }
+
+  .page-content .highlight[aria-current].first.text.has-note::after {
+    display: none;
+  }
+}
+
+/* Color-specific highlight styles using CSS variables */
+
+/* Yellow highlight */
+.page-content .highlight.yellow {
+  background-color: var(--highlight-yellow-passive);
+}
+
+.page-content .highlight.yellow.block::after {
+  background-color: var(--highlight-yellow-passive);
+}
+
+.page-content .highlight.yellow.block.first.has-note::before {
+  border-left-color: var(--highlight-yellow-focused);
+}
+
+.page-content .highlight.yellow.first.text.has-note::after {
+  border-left-color: var(--highlight-yellow-focused);
+}
+
+@media screen {
+  .page-content .highlight.yellow[aria-current] {
+    background-color: var(--highlight-yellow-focused);
+    border-bottom-color: var(--highlight-yellow-focus-border);
+    color: var(--highlight-yellow-text);
+  }
+
+  .page-content .highlight.yellow[aria-current].block::after {
+    background-color: var(--highlight-yellow-focused);
+  }
+}
+
+/* Green highlight */
+.page-content .highlight.green {
+  background-color: var(--highlight-green-passive);
+}
+
+.page-content .highlight.green.block::after {
+  background-color: var(--highlight-green-passive);
+}
+
+.page-content .highlight.green.block.first.has-note::before {
+  border-left-color: var(--highlight-green-focused);
+}
+
+.page-content .highlight.green.first.text.has-note::after {
+  border-left-color: var(--highlight-green-focused);
+}
+
+@media screen {
+  .page-content .highlight.green[aria-current] {
+    background-color: var(--highlight-green-focused);
+    border-bottom-color: var(--highlight-green-focus-border);
+    color: var(--highlight-green-text);
+  }
+
+  .page-content .highlight.green[aria-current].block::after {
+    background-color: var(--highlight-green-focused);
+  }
+}
+
+/* Blue highlight */
+.page-content .highlight.blue {
+  background-color: var(--highlight-blue-passive);
+}
+
+.page-content .highlight.blue.block::after {
+  background-color: var(--highlight-blue-passive);
+}
+
+.page-content .highlight.blue.block.first.has-note::before {
+  border-left-color: var(--highlight-blue-focused);
+}
+
+.page-content .highlight.blue.first.text.has-note::after {
+  border-left-color: var(--highlight-blue-focused);
+}
+
+@media screen {
+  .page-content .highlight.blue[aria-current] {
+    background-color: var(--highlight-blue-focused);
+    border-bottom-color: var(--highlight-blue-focus-border);
+    color: var(--highlight-blue-text);
+  }
+
+  .page-content .highlight.blue[aria-current].block::after {
+    background-color: var(--highlight-blue-focused);
+  }
+}
+
+/* Purple highlight */
+.page-content .highlight.purple {
+  background-color: var(--highlight-purple-passive);
+}
+
+.page-content .highlight.purple.block::after {
+  background-color: var(--highlight-purple-passive);
+}
+
+.page-content .highlight.purple.block.first.has-note::before {
+  border-left-color: var(--highlight-purple-focused);
+}
+
+.page-content .highlight.purple.first.text.has-note::after {
+  border-left-color: var(--highlight-purple-focused);
+}
+
+@media screen {
+  .page-content .highlight.purple[aria-current] {
+    background-color: var(--highlight-purple-focused);
+    border-bottom-color: var(--highlight-purple-focus-border);
+    color: var(--highlight-purple-text);
+  }
+
+  .page-content .highlight.purple[aria-current].block::after {
+    background-color: var(--highlight-purple-focused);
+  }
+}
+
+/* Pink highlight */
+.page-content .highlight.pink {
+  background-color: var(--highlight-pink-passive);
+}
+
+.page-content .highlight.pink.block::after {
+  background-color: var(--highlight-pink-passive);
+}
+
+.page-content .highlight.pink.block.first.has-note::before {
+  border-left-color: var(--highlight-pink-focused);
+}
+
+.page-content .highlight.pink.first.text.has-note::after {
+  border-left-color: var(--highlight-pink-focused);
+}
+
+@media screen {
+  .page-content .highlight.pink[aria-current] {
+    background-color: var(--highlight-pink-focused);
+    border-bottom-color: var(--highlight-pink-focus-border);
+    color: var(--highlight-pink-text);
+  }
+
+  .page-content .highlight.pink[aria-current].block::after {
+    background-color: var(--highlight-pink-focused);
+  }
 }
 
 /* fixes to keep MathJax 4 highlighted equations centered and

--- a/src/app/content/components/Page/PageContent.tsx
+++ b/src/app/content/components/Page/PageContent.tsx
@@ -7,11 +7,6 @@ import theme from '../../../theme';
 import { TextResizerValue } from '../../constants';
 import { State } from '../../types';
 import { highlightStyles } from '../../constants';
-import {
-  highlightBlockPadding,
-  highlightIndicatorSize,
-  highlightIndicatorSizeForBlock,
-} from '../../highlights/constants';
 import { contentTextWidth } from '../constants';
 import './PageContent.css';
 
@@ -23,100 +18,25 @@ interface PageContentProps extends React.HTMLAttributes<HTMLDivElement> {
   textSize?: TextResizerValue;
 }
 
-// Generate dynamic highlight styles once at module level
-const dynamicHighlightStyles = highlightStyles.map((highlightStyle) => {
-  const isDark = Color(highlightStyle.focused).isDark();
-
-  return `
-    .page-content .highlight.${highlightStyle.label} {
-      background-color: ${highlightStyle.passive};
-    }
-
-    .page-content .highlight.${highlightStyle.label}.block {
-      display: block;
-    }
-
-    .page-content .highlight.${highlightStyle.label}.block:after {
-      position: absolute;
-      z-index: -1;
-      content: "";
-      display: block;
-      top: -1rem;
-      bottom: -1rem;
-      left: -1rem;
-      right: -1rem;
-      background-color: ${highlightStyle.passive};
-    }
-
-    .page-content .highlight.${highlightStyle.label}.block.first.has-note:before {
-      position: absolute;
-      top: -${highlightBlockPadding}rem;
-      left: -${highlightBlockPadding}rem;
-      content: "";
-      width: 0;
-      height: 0;
-      opacity: 0.8;
-      border-left: ${highlightIndicatorSizeForBlock}em solid ${highlightStyle.focused};
-      border-bottom: ${highlightIndicatorSizeForBlock}em solid transparent;
-    }
-
-    .page-content .highlight.${highlightStyle.label}.first.text.has-note:after {
-      position: absolute;
-      top: 0;
-      left: 0;
-      content: "";
-      width: 0;
-      height: 0;
-      opacity: 0.8;
-      border-left: ${highlightIndicatorSize}em solid ${highlightStyle.focused};
-      border-top: ${highlightIndicatorSize}em solid transparent;
-      transform: rotate(90deg);
-    }
-
-    @media screen {
-      .page-content .highlight.${highlightStyle.label}[aria-current] {
-        background-color: ${highlightStyle.focused};
-        border-bottom: 0.2rem solid ${highlightStyle.focusBorder};
-        padding: 0.2rem 0 0;
-        ${isDark ? `color: var(--color-text-white);` : ''}
-      }
-
-      .page-content .highlight.${highlightStyle.label}[aria-current].block:after {
-        background-color: ${highlightStyle.focused};
-      }
-
-      .page-content .highlight.${highlightStyle.label}[aria-current].first.text.has-note:after {
-        display: none;
-      }
-    }
-  `;
-}).join('\n');
-
-// Track if styles have been injected globally to avoid duplicates
-let stylesInjected = false;
-
-// Inject dynamic highlight styles once globally
-function injectHighlightStyles() {
-  if (typeof document !== 'undefined' && !stylesInjected) {
-    const styleElement = document.createElement('style');
-    styleElement.setAttribute('data-page-content-highlights', '');
-    styleElement.textContent = dynamicHighlightStyles;
-    document.head.appendChild(styleElement);
-    stylesInjected = true;
-  }
-}
-
 /**
  * PageContent component - Main content container for book pages
  *
  * Migrated from styled-components to plain CSS.
- * Dynamic highlight styles are generated as inline <style> tag.
+ * Highlight color styles are now defined in PageContent.css using CSS variables.
  */
 const PageContent = React.forwardRef<HTMLDivElement, React.PropsWithChildren<PageContentProps>>(
   ({ book, className, dangerouslySetInnerHTML, textSize, style, children, ...props }, ref) => {
-    // Inject highlight styles once globally on first mount
-    React.useEffect(() => {
-      injectHighlightStyles();
+    // Compute dynamic text colors for dark focused highlight backgrounds
+    // This needs to be done in JavaScript, but the result is set as CSS variables
+    const dynamicTextColorVars = React.useMemo(() => {
+      const vars: Record<string, string> = {};
+      highlightStyles.forEach((highlightStyle) => {
+        const isDark = Color(highlightStyle.focused).isDark();
+        if (isDark) {
+          vars[`--highlight-${highlightStyle.label}-text`] = 'var(--color-text-white)';
+        }
+      });
+      return vars;
     }, []);
 
     // Only add 'page-content' if not already present to avoid duplication
@@ -135,6 +55,7 @@ const PageContent = React.forwardRef<HTMLDivElement, React.PropsWithChildren<Pag
           '--content-text-width': `${contentTextWidth}rem`,
           '--page-margin-top-desktop': `${theme.padding.page.desktop}rem`,
           '--page-margin-top-mobile': `${theme.padding.page.mobile}rem`,
+          ...dynamicTextColorVars,
           ...style,
         } as React.CSSProperties}
       >


### PR DESCRIPTION
## Summary

This PR addresses a refactoring opportunity identified during PR #2926 (Phase 2.6: Content Page Components Migration). The current implementation generates dynamic highlight styles using JavaScript at module load time and injects them into a `<style>` tag. This PR refactors the code to use CSS variables and static CSS rules instead.

## Changes

### PageContent.css
- Added CSS variables for all 5 highlight colors (yellow, green, blue, purple, pink) with 3 states each:
  - `--highlight-{color}-passive`: Background color for passive (non-focused) highlights
  - `--highlight-{color}-focused`: Background color for focused/active highlights
  - `--highlight-{color}-focus-border`: Border color for focused highlights
  - `--highlight-{color}-text`: Text color for focused highlights (dynamically set for dark backgrounds)

- Added generic highlight positioning/layout rules (shared across all colors):
  - Block highlight pseudo-element positioning
  - Note indicator triangles for text and block highlights
  - Focused highlight border and padding styles

- Added color-specific rules that only reference CSS variables:
  - Background colors for passive states
  - Border colors for note indicators
  - Background, border, and text colors for focused states

### PageContent.tsx
- **Removed** ~80 lines of dynamic style generation code:
  - `dynamicHighlightStyles` constant
  - `stylesInjected` tracking variable
  - `injectHighlightStyles()` function
  - `document.createElement('style')` logic

- **Added** minimal CSS variable computation (~15 lines):
  - Compute text colors for dark focused backgrounds using `Color().isDark()`
  - Set CSS variables only for colors that need white text (purple, pink)
  - Pass variables through the `style` prop

- **Removed imports** that are no longer needed:
  - `highlightBlockPadding`, `highlightIndicatorSize`, `highlightIndicatorSizeForBlock` from highlights/constants

## Benefits

- ✅ **Better separation of concerns**: Colors defined in CSS, not JavaScript
- ✅ **Easier to maintain**: All highlight styles in one place (PageContent.css)
- ✅ **No runtime style injection**: All styles loaded statically
- ✅ **Reduced code duplication**: Positioning rules defined once, not per-color
- ✅ **Consistent with migration pattern** from PR #2926

## Testing

This is a refactoring with **no functional changes**. Highlights should work exactly as before:

- [x] All 5 highlight colors render correctly in passive state
- [x] Focused highlights show the correct background and border colors
- [x] Text color changes to white for dark focused colors (purple, pink)
- [x] Note indicator triangles display correctly for both text and block highlights

## Related

- Jira ticket: [CORE-1847](https://openstax.atlassian.net/browse/CORE-1847)
- Original PR review comment: https://github.com/openstax/rex-web/pull/2926#pullrequestreview-4199649515
- Initial analysis comment: https://github.com/openstax/rex-web/pull/2926#issuecomment-4354382269

## Files Changed

- `src/app/content/components/Page/PageContent.tsx` - ~80 lines removed, ~15 lines added
- `src/app/content/components/Page/PageContent.css` - ~220 lines added (CSS variables + static styles for all 5 colors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-1847]: https://openstax.atlassian.net/browse/CORE-1847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ