### PR TITLE
Fix narrow caption width in highlights and excerpts (CORE-2373)

### DIFF
--- a/src/app/content/styles/HighlightsWrapper.css
+++ b/src/app/content/styles/HighlightsWrapper.css
@@ -1,15 +1,15 @@
 .highlights-wrapper {
   overflow: visible;
+}
 
-  /* Fix for orphaned figure captions in highlights (CORE-2373)
-   * When a highlight includes a caption but not the wrapping .os-figure container,
-   * the caption needs explicit styling to display properly with full width.
-   */
-  figcaption.os-caption-container.os-caption-container {
-    display: block;
-    text-align: left;
-    padding: 1rem 2rem 0;
-  }
+/* Fix for orphaned figure captions in highlights (CORE-2373)
+  * When a highlight includes a caption but not the wrapping .os-figure container,
+  * the caption needs explicit styling to display properly with full width.
+  */
+.highlights-wrapper figcaption.os-caption-container.os-caption-container {
+  display: block;
+  text-align: left;
+  padding: 1rem 2rem 0;
 }
 
 .highlights-wrapper .os-divider {

--- a/src/app/content/styles/HighlightsWrapper.css
+++ b/src/app/content/styles/HighlightsWrapper.css
@@ -1,5 +1,15 @@
 .highlights-wrapper {
   overflow: visible;
+
+  /* Fix for orphaned figure captions in highlights (CORE-2373)
+   * When a highlight includes a caption but not the wrapping .os-figure container,
+   * the caption needs explicit styling to display properly with full width.
+   */
+  figcaption.os-caption-container.os-caption-container {
+    display: block;
+    text-align: left;
+    padding: 1rem 2rem 0;
+  }
 }
 
 .highlights-wrapper .os-divider {


### PR DESCRIPTION
## Summary

Fixes narrow caption width issue in My Highlights view when image captions are highlighted without their parent `.os-figure` container.

**Jira Issue:** [CORE-2373](https://openstax.atlassian.net/browse/CORE-2373)

## Problem

When users create highlights that include an image caption but not the wrapping `.os-figure` container, the caption text displays in a very narrow vertical column (~72px width) in the My Highlights view. This is because:

1. In normal page view, `.os-figure` has `display: table` and `.os-caption-container` inside it has `display: table-caption`
2. When the highlight doesn't include the `.os-figure` wrapper, the orphaned `figcaption.os-caption-container` doesn't receive the `display: table-caption` style
3. Without proper styling, the caption renders with unpredictable narrow width behavior

## Solution

Added explicit CSS styling for `.os-caption-container` elements in ContentExcerpt contexts to ensure proper display even when orphaned from their `.os-figure` parent.

### Changes Made
HighlightsWrapper was where the issue was arising. Figure captions that are not part of a complete figure unit (because the highlight did not include the entire figure unit) now style as a left-aligned block.

## Testing

Manual testing needed to verify:
- Highlights with image captions display with reasonable (generally full-width minus a little padding) width in My Highlights view
- No regression in normal page view with full `.os-figure` containers

## Screenshots

See attached screenshots in [CORE-2373](https://openstax.atlassian.net/browse/CORE-2373) showing the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-2373]: https://openstax.atlassian.net/browse/CORE-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-2373]: https://openstax.atlassian.net/browse/CORE-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ