### PR TITLE
Phase 7.1e: Complete HighlightStyles.tsx Migration

### DIFF
--- a/src/app/content/highlights/components/HighlightStyles.css
+++ b/src/app/content/highlights/components/HighlightStyles.css
@@ -15,6 +15,12 @@
  * - GreenStickyNote: Green sticky note variant
  * - StickyNoteUl: Unordered list within sticky notes
  * - StickyNoteLi: List items within sticky notes
+ * - GeneralText: H3 heading with full width and padding
+ * - GeneralTextWrapper: Base text wrapper with body copy typography
+ * - GeneralLeftText: Left-aligned text wrapper (extends GeneralTextWrapper)
+ * - GeneralCenterText: Center-aligned text wrapper (extends GeneralTextWrapper)
+ * - MyHighlightsImage: Help popup image for "My Highlights" section
+ * - StyledHiddenLiveRegion: Screen reader only element
  *
  * GridWrapper and MyHighlightsWrapper use mobile breakpoint for responsive hiding.
  */
@@ -192,4 +198,74 @@
     font-size: 1.6rem;
     line-height: 2rem;
   }
+}
+
+/* === Text Wrapper Components === */
+
+/* GeneralText - H3 heading with full width and vertical padding */
+.general-text {
+  width: 100%;
+  padding: 0.8rem 0;
+}
+
+/* GeneralTextWrapper - Base text wrapper with bodyCopyRegularStyle typography */
+.general-text-wrapper {
+  /* bodyCopyRegularStyle: textRegularStyle + link styles
+   * textRegularStyle: textStyle + textRegularSize */
+  color: #424242; /* theme.color.text.default */
+  font-size: 1.6rem;
+  line-height: 2.5rem;
+  padding: 2.4rem 3.2rem 0; /* popupBodyPadding, popupPadding */
+}
+
+/* Link styles within GeneralTextWrapper */
+.general-text-wrapper a {
+  color: #0dc0dc; /* linkColor */
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.general-text-wrapper a:hover {
+  color: #63a524; /* linkHover */
+}
+
+/* Print behavior for GeneralTextWrapper */
+@media print {
+  .general-text-wrapper {
+    height: max-content;
+    overflow: auto;
+  }
+}
+
+/* GeneralLeftText - Left-aligned text wrapper (extends GeneralTextWrapper) */
+.general-left-text {
+  display: flex;
+  flex-direction: column;
+  padding: 2rem 3.2rem; /* popupPadding */
+}
+
+/* GeneralCenterText - Center-aligned text wrapper (extends GeneralTextWrapper) */
+.general-center-text {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  padding: 5rem 3.2rem; /* popupPadding */
+  text-align: center;
+}
+
+/* === MyHighlightsImage === */
+.my-highlights-image {
+  width: 72.8rem; /* myHighlightsImageWidth */
+  height: 23.2rem; /* myHighlightsImageHeight */
+  margin-top: 2.4rem; /* popupBodyPadding */
+}
+
+/* === StyledHiddenLiveRegion === */
+.styled-hidden-live-region {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
 }

--- a/src/app/content/highlights/components/HighlightStyles.css
+++ b/src/app/content/highlights/components/HighlightStyles.css
@@ -93,7 +93,7 @@
 .second-image {
   height: 25.6rem;
   width: 36rem;
-  box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 0.2);
+  box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 1);
 }
 
 .second-image {
@@ -118,7 +118,7 @@
   height: 1.6rem; /* bulletSize */
   transform: rotate(45deg);
   top: 0.8rem; /* bulletSize / 2 */
-  box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 0.3);
+  box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 1);
 }
 
 /* StickyNote - Base sticky note styles */
@@ -127,7 +127,7 @@
   position: absolute;
   padding: 1.6rem 2.4rem; /* bulletSize, popupBodyPadding */
   overflow: visible;
-  box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 0.3);
+  box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 1);
   opacity: 0.85;
 }
 
@@ -177,14 +177,14 @@
 
 /* StickyNoteLi - List items with h4Style typography */
 .sticky-note-li {
-  /* h4Style desktop typography */
   font-size: 1.8rem;
-  font-weight: 700;
   line-height: 2.5rem;
+  letter-spacing: -0.02rem;
+  margin: 0;
   overflow: visible;
   padding: 0;
   display: flex;
-  color: #fff; /* theme.color.neutral.base */
+  color: var(--color-neutral-base);
 }
 
 .sticky-note-li::before {
@@ -212,7 +212,7 @@
 .general-text-wrapper {
   /* bodyCopyRegularStyle: textRegularStyle + link styles
    * textRegularStyle: textStyle + textRegularSize */
-  color: #424242; /* theme.color.text.default */
+  color: var(--color-text-default);
   font-size: 1.6rem;
   line-height: 2.5rem;
   padding: 2.4rem 3.2rem 0; /* popupBodyPadding, popupPadding */
@@ -220,13 +220,13 @@
 
 /* Link styles within GeneralTextWrapper */
 .general-text-wrapper a {
-  color: #0dc0dc; /* linkColor */
+  color: var(--link-color, #027eb5);
   cursor: pointer;
   text-decoration: underline;
 }
 
 .general-text-wrapper a:hover {
-  color: #63a524; /* linkHover */
+  color: var(--link-hover-color, #0064a0);
 }
 
 /* Print behavior for GeneralTextWrapper */

--- a/src/app/content/highlights/components/HighlightStyles.css
+++ b/src/app/content/highlights/components/HighlightStyles.css
@@ -9,6 +9,12 @@
  * - ImageWrapper: Wrapper for individual images
  * - FirstImage: First help popup image
  * - SecondImage: Second help popup image (with top margin)
+ * - StickyNoteBullet: Bullet decoration for sticky notes
+ * - StickyNote: Base sticky note (used by blue and green variants)
+ * - BlueStickyNote: Blue sticky note variant
+ * - GreenStickyNote: Green sticky note variant
+ * - StickyNoteUl: Unordered list within sticky notes
+ * - StickyNoteLi: List items within sticky notes
  *
  * GridWrapper and MyHighlightsWrapper use mobile breakpoint for responsive hiding.
  */
@@ -17,6 +23,22 @@
  * desktopPopupWidth: 74.4rem (from PopupStyles/PopupConstants)
  * popupBodyPadding: 2.4rem (from PopupStyles/PopupConstants)
  * mobileBreak: 75em (1200px) from theme.ts
+ *
+ * stickyNoteMeasures (from HighlightStyles.tsx):
+ * - blue: rgb(13, 192, 220)
+ * - green: rgb(99, 165, 36)
+ * - bulletSize: 1.6rem
+ * - defaultOffset: 3.2rem
+ * - left: 32.8rem
+ * - opacity: 0.85
+ * - width: 29.8rem
+ *
+ * h4Style (from Typography/Headings.legacy.ts):
+ * - Desktop: font-size 1.8rem, line-height 2.5rem
+ * - Mobile: font-size 1.6rem, line-height 2rem
+ * - color: theme.color.text.default (#424242)
+ *
+ * theme.color.neutral.base: #fff
  */
 
 /* === GridWrapper === */
@@ -70,4 +92,104 @@
 
 .second-image {
   margin-top: 17.6rem;
+}
+
+/* === Sticky Note Components === */
+
+/* StickyNoteBullet - Base bullet decoration */
+.sticky-note-bullet {
+  position: absolute;
+  height: 3.2rem; /* bulletSize * 2 = 1.6 * 2 */
+  width: 1.6rem; /* bulletSize */
+  top: 50%;
+  overflow: hidden;
+}
+
+.sticky-note-bullet::after {
+  content: "";
+  position: absolute;
+  width: 1.6rem; /* bulletSize */
+  height: 1.6rem; /* bulletSize */
+  transform: rotate(45deg);
+  top: 0.8rem; /* bulletSize / 2 */
+  box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 0.3);
+}
+
+/* StickyNote - Base sticky note styles */
+.sticky-note {
+  width: 29.8rem;
+  position: absolute;
+  padding: 1.6rem 2.4rem; /* bulletSize, popupBodyPadding */
+  overflow: visible;
+  box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 0.3);
+  opacity: 0.85;
+}
+
+/* BlueStickyNote - Blue variant positioning and bullet styling */
+.blue-sticky-note {
+  background: rgb(13, 192, 220);
+  top: 3.2rem; /* defaultOffset */
+  left: 33.6rem; /* left + (bulletSize / 2) = 32.8 + 0.8 */
+}
+
+.blue-sticky-note .sticky-note-bullet {
+  transform: translate(-100%, -50%);
+  left: 0%;
+}
+
+.blue-sticky-note .sticky-note-bullet::after {
+  transform: rotate(45deg);
+  left: 0.8rem; /* bulletSize / 2 */
+  background: rgb(13, 192, 220);
+}
+
+/* GreenStickyNote - Green variant positioning and bullet styling */
+.green-sticky-note {
+  background: rgb(99, 165, 36);
+  bottom: 3.2rem; /* defaultOffset */
+  right: 33.6rem; /* left + (bulletSize / 2) = 32.8 + 0.8 */
+}
+
+.green-sticky-note .sticky-note-bullet {
+  transform: translate(100%, -50%);
+  right: 0%;
+}
+
+.green-sticky-note .sticky-note-bullet::after {
+  transform: rotate(-45deg);
+  right: 0.8rem; /* bulletSize / 2 */
+  background: rgb(99, 165, 36);
+}
+
+/* StickyNoteUl - List container within sticky notes */
+.sticky-note-ul {
+  padding: 0;
+  overflow: visible;
+  margin: 0;
+  list-style: none;
+}
+
+/* StickyNoteLi - List items with h4Style typography */
+.sticky-note-li {
+  /* h4Style desktop typography */
+  font-size: 1.8rem;
+  font-weight: 700;
+  line-height: 2.5rem;
+  overflow: visible;
+  padding: 0;
+  display: flex;
+  color: #fff; /* theme.color.neutral.base */
+}
+
+.sticky-note-li::before {
+  content: "\2022";
+  padding-right: 0.5rem;
+}
+
+/* Mobile breakpoint for h4Style */
+@media screen and (max-width: 75em) {
+  .sticky-note-li {
+    font-size: 1.6rem;
+    line-height: 2rem;
+  }
 }

--- a/src/app/content/highlights/components/HighlightStyles.css
+++ b/src/app/content/highlights/components/HighlightStyles.css
@@ -5,12 +5,17 @@
  * styled-components to plain CSS. Currently includes:
  * - GridWrapper: Container for image grid in help popup
  * - MyHighlightsWrapper: Container for "My Highlights" section
+ * - ImagesGrid: Flex container for image layout
+ * - ImageWrapper: Wrapper for individual images
+ * - FirstImage: First help popup image
+ * - SecondImage: Second help popup image (with top margin)
  *
- * Both components use mobile breakpoint for responsive hiding.
+ * GridWrapper and MyHighlightsWrapper use mobile breakpoint for responsive hiding.
  */
 
 /* === Constants from various files ===
  * desktopPopupWidth: 74.4rem (from PopupStyles/PopupConstants)
+ * popupBodyPadding: 2.4rem (from PopupStyles/PopupConstants)
  * mobileBreak: 75em (1200px) from theme.ts
  */
 
@@ -40,4 +45,29 @@
   .my-highlights-wrapper {
     display: none;
   }
+}
+
+/* === ImagesGrid === */
+.images-grid {
+  display: flex;
+  position: relative;
+  justify-content: space-between;
+  overflow: visible;
+}
+
+/* === ImageWrapper === */
+.image-wrapper {
+  width: 36rem; /* (desktopPopupWidth - popupBodyPadding) / 2 = (74.4 - 2.4) / 2 = 36 */
+}
+
+/* === Image Components === */
+.first-image,
+.second-image {
+  height: 25.6rem;
+  width: 36rem;
+  box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 0.2);
+}
+
+.second-image {
+  margin-top: 17.6rem;
 }

--- a/src/app/content/highlights/components/HighlightStyles.tsx
+++ b/src/app/content/highlights/components/HighlightStyles.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
-// NOTE: This file is partially migrated to plain CSS. The following components have been migrated
-// and use HighlightStyles.css:
-// - GridWrapper, MyHighlightsWrapper (wrapper components)
-// - FirstImage, SecondImage, ImageWrapper, ImagesGrid (image components)
-// - StickyNoteBullet, StickyNote, BlueStickyNote, GreenStickyNote, StickyNoteUl, StickyNoteLi (sticky note components)
+// NOTE: This file has been fully migrated from styled-components to plain CSS.
+// All 18 components now use HighlightStyles.css for styling:
+// - Wrapper components (2): GridWrapper, MyHighlightsWrapper
+// - Image components (4): FirstImage, SecondImage, ImageWrapper, ImagesGrid
+// - Sticky note components (6): StickyNoteBullet, StickyNote, BlueStickyNote, GreenStickyNote, StickyNoteUl, StickyNoteLi
+// - Text wrapper components (4): GeneralText, GeneralTextWrapper, GeneralLeftText, GeneralCenterText
+// - Other components (2): MyHighlightsImage, StyledHiddenLiveRegion
 //
-// The remaining 6 styled components (text wrappers and MyHighlightsImage) will be migrated in future work.
-// They remain here using styled-components due to their complexity (component inheritance patterns
-// and css fragments like h4Style and bodyCopyRegularStyle).
-import styled from 'styled-components/macro';
+// The file no longer imports styled-components. All styling is done via plain CSS classes
+// with className composition using the classnames package.
 import htmlMessage from '../../../components/htmlMessage';
-import { bodyCopyRegularStyle } from '../../../components/Typography';
 import { H3 } from '../../../components/Typography';
-import { popupBodyPadding, popupPadding } from '../../styles/PopupStyles';
 import classNames from 'classnames';
 import './HighlightStyles.css';
 
@@ -99,20 +97,17 @@ export const ImagesGrid = (
   <div {...props} className={classNames('images-grid', className)} />
 );
 
-export const GeneralText = styled(H3)`
-  width: 100%;
-  padding: 0.8rem 0;
-`;
+// Migrated to plain CSS - see HighlightStyles.css
+export function GeneralText(props: React.ComponentProps<typeof H3>) {
+  const { className, ...rest } = props;
+  return <H3 {...rest} className={classNames('general-text', className)} />;
+}
 
-export const GeneralTextWrapper = styled.div`
-  ${bodyCopyRegularStyle}
-  padding: ${popupBodyPadding}rem ${popupPadding}rem 0;
-
-  @media print {
-    height: max-content;
-    overflow: auto;
-  }
-`;
+export const GeneralTextWrapper = (
+  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+) => (
+  <div {...props} className={classNames('general-text-wrapper', className)} />
+);
 
 export const LoginText = htmlMessage('i18n:toolbar:highlights:popup:login-text', GeneralTextWrapper);
 
@@ -123,31 +118,28 @@ export const MyHighlightsWrapper = (
   <div {...props} className={classNames('my-highlights-wrapper', className)} />
 );
 
-export const GeneralLeftText = styled(GeneralTextWrapper)`
-  display: flex;
-  flex-direction: column;
-  padding: 2rem 3.2rem;
-`;
+// Migrated to plain CSS - see HighlightStyles.css
+export const GeneralLeftText = (
+  { className, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+) => (
+  <GeneralTextWrapper {...props} className={classNames('general-left-text', className)} />
+);
 
-export const GeneralCenterText = styled(GeneralTextWrapper)`
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  padding: 5rem 3.2rem;
-  text-align: center;
-`;
+export const GeneralCenterText = (
+  { className, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+) => (
+  <GeneralTextWrapper {...props} className={classNames('general-center-text', className)} />
+);
 
-export const MyHighlightsImage = styled.img`
-  width: ${myHighlightsImageWidth}rem;
-  height: ${myHighlightsImageHeight}rem;
-  margin-top: ${popupBodyPadding}rem;
-`;
+// Migrated to plain CSS - see HighlightStyles.css
+export const MyHighlightsImage = (
+  { className, theme: _theme, ...props }: React.ImgHTMLAttributes<HTMLImageElement> & { theme?: unknown }
+) => (
+  <img alt="" {...props} className={classNames('my-highlights-image', className)} />
+);
 
-export const StyledHiddenLiveRegion = styled.div`
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(1px, 1px, 1px, 1px);
-  white-space: nowrap;
-`;
+export const StyledHiddenLiveRegion = (
+  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+) => (
+  <div {...props} className={classNames('styled-hidden-live-region', className)} />
+);

--- a/src/app/content/highlights/components/HighlightStyles.tsx
+++ b/src/app/content/highlights/components/HighlightStyles.tsx
@@ -27,119 +27,109 @@ export const stickyNoteMeasures = {
   width: 29.8, /* to allow text to fit in one line with tooltip */
 };
 
+type SimpleWrapper = React.PropsWithChildren<{}>
+
 // Migrated to plain CSS - see HighlightStyles.css
 export const FirstImage = (
-  { className, theme: _theme, ...props }: React.ImgHTMLAttributes<HTMLImageElement> & { theme?: unknown }
+  { ...props }: Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'className'>
 ) => (
-  <img alt="" {...props} className={classNames('first-image', className)} />
+  <img alt="" {...props} className="first-image" />
 );
 
 export const SecondImage = (
-  { className, theme: _theme, ...props }: React.ImgHTMLAttributes<HTMLImageElement> & { theme?: unknown }
+  { ...props }: Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'className'>
 ) => (
-  <img alt="" {...props} className={classNames('second-image', className)} />
+  <img alt="" {...props} className="second-image" />
 );
 
-export const ImageWrapper = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
-) => (
-  <div {...props} className={classNames('image-wrapper', className)} />
-);
-
-// Migrated to plain CSS - see HighlightStyles.css
-export const StickyNoteBullet = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
-) => (
-  <div {...props} className={classNames('sticky-note-bullet', className)} />
-);
-
-export const StickyNote = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
-) => (
-  <div {...props} className={classNames('sticky-note', className)} />
-);
-
-export const BlueStickyNote = (
-  { className, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
-) => (
-  <StickyNote {...props} className={classNames('blue-sticky-note', className)} />
-);
-
-export const GreenStickyNote = (
-  { className, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
-) => (
-  <StickyNote {...props} className={classNames('green-sticky-note', className)} />
-);
-
-export const StickyNoteUl = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLUListElement> & { theme?: unknown }
-) => (
-  <ul {...props} className={classNames('sticky-note-ul', className)} />
-);
-
-export const StickyNoteLi = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLLIElement> & { theme?: unknown }
-) => (
-  <li {...props} className={classNames('sticky-note-li', className)} />
+export const ImageWrapper = ({children}: SimpleWrapper) => (
+  <div className="image-wrapper">
+    {children}
+  </div>
 );
 
 // Migrated to plain CSS - see HighlightStyles.css
-export const GridWrapper = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
-) => (
-  <div {...props} className={classNames('grid-wrapper', className)} />
+export const StickyNoteBullet = () => (
+  <div className="sticky-note-bullet" />
 );
 
-// Migrated to plain CSS - see HighlightStyles.css
-export const ImagesGrid = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
-) => (
-  <div {...props} className={classNames('images-grid', className)} />
+export const BlueStickyNote = ({children}: SimpleWrapper) => (
+  <div className="blue-sticky-note">
+    {children}
+  </div>
 );
 
-// Migrated to plain CSS - see HighlightStyles.css
-export function GeneralText(props: React.ComponentProps<typeof H3>) {
-  const { className, ...rest } = props;
-  return <H3 {...rest} className={classNames('general-text', className)} />;
-}
+export const GreenStickyNote = ({children}: SimpleWrapper) => (
+  <div className="green-sticky-note">
+    {children}
+  </div>
+);
 
-export const GeneralTextWrapper = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
-) => (
-  <div {...props} className={classNames('general-text-wrapper', className)} />
+export const StickyNoteUl = ({children}: SimpleWrapper) => (
+  <ul className="sticky-note-ul">
+    {children}
+  </ul>
+);
+
+export const StickyNoteLi = ({children}: SimpleWrapper) => (
+  <li className="sticky-note-li">
+    {children}
+  </li>
+);
+
+export const GridWrapper = ({children}: SimpleWrapper) => (
+  <div className="grid-wrapper">
+    {children}
+  </div>
+);
+
+export const ImagesGrid = ({children}: SimpleWrapper) => (
+  <div className="images-grid">
+    {children}
+  </div>
+);
+
+export const GeneralText = ({children}: SimpleWrapper) => (
+  <H3 className="general-text">
+    {children}
+  </H3>
+);
+
+export const GeneralTextWrapper = ({className, children}: SimpleWrapper & {className?: string} ) => (
+  <div className={classNames('general-text-wrapper', className)} >
+    {children}
+  </div>
 );
 
 export const LoginText = htmlMessage('i18n:toolbar:highlights:popup:login-text', GeneralTextWrapper);
 
-// Migrated to plain CSS - see HighlightStyles.css
-export const MyHighlightsWrapper = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
-) => (
-  <div {...props} className={classNames('my-highlights-wrapper', className)} />
+export const MyHighlightsWrapper = ({children}: SimpleWrapper) => (
+  <div className="my-highlights-wrapper">
+    {children}
+  </div>
 );
 
-// Migrated to plain CSS - see HighlightStyles.css
-export const GeneralLeftText = (
-  { className, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
-) => (
-  <GeneralTextWrapper {...props} className={classNames('general-left-text', className)} />
+export const GeneralLeftText = ({children}: SimpleWrapper) => (
+  <GeneralTextWrapper className="general-left-text">
+    {children}
+  </GeneralTextWrapper>
 );
 
-export const GeneralCenterText = (
-  { className, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
-) => (
-  <GeneralTextWrapper {...props} className={classNames('general-center-text', className)} />
+export const GeneralCenterText = ({children}: SimpleWrapper) => (
+  <GeneralTextWrapper className="general-center-text">
+    {children}
+  </GeneralTextWrapper>
 );
 
 // Migrated to plain CSS - see HighlightStyles.css
 export const MyHighlightsImage = (
-  { className, theme: _theme, ...props }: React.ImgHTMLAttributes<HTMLImageElement> & { theme?: unknown }
+  { className, ...props }: React.ImgHTMLAttributes<HTMLImageElement>
 ) => (
   <img alt="" {...props} className={classNames('my-highlights-image', className)} />
 );
 
 export const StyledHiddenLiveRegion = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+  { className, ...props }: React.HTMLAttributes<HTMLDivElement>
 ) => (
   <div {...props} className={classNames('styled-hidden-live-region', className)} />
 );

--- a/src/app/content/highlights/components/HighlightStyles.tsx
+++ b/src/app/content/highlights/components/HighlightStyles.tsx
@@ -27,7 +27,7 @@ export const stickyNoteMeasures = {
   width: 29.8, /* to allow text to fit in one line with tooltip */
 };
 
-type SimpleWrapper = React.PropsWithChildren<{}>
+type SimpleWrapper = React.PropsWithChildren<{}>;
 
 // Migrated to plain CSS - see HighlightStyles.css
 export const FirstImage = (

--- a/src/app/content/highlights/components/HighlightStyles.tsx
+++ b/src/app/content/highlights/components/HighlightStyles.tsx
@@ -62,15 +62,15 @@ export const StickyNote = (
 );
 
 export const BlueStickyNote = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+  { className, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
 ) => (
-  <div {...props} className={classNames('sticky-note', 'blue-sticky-note', className)} />
+  <StickyNote {...props} className={classNames('blue-sticky-note', className)} />
 );
 
 export const GreenStickyNote = (
-  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+  { className, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
 ) => (
-  <div {...props} className={classNames('sticky-note', 'green-sticky-note', className)} />
+  <StickyNote {...props} className={classNames('green-sticky-note', className)} />
 );
 
 export const StickyNoteUl = (

--- a/src/app/content/highlights/components/HighlightStyles.tsx
+++ b/src/app/content/highlights/components/HighlightStyles.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
-// NOTE: This file is partially migrated to plain CSS. Two wrapper components (GridWrapper and
-// MyHighlightsWrapper) have been migrated and use HighlightStyles.css. The remaining ~15 styled
-// components (image components, sticky note components, text wrappers, etc.) will be migrated in
-// future work. They remain here using styled-components due to their complexity (component
-// selectors, nested pseudo-elements, calculated values, and component inheritance patterns).
-import styled, { css } from 'styled-components/macro';
+// NOTE: This file is partially migrated to plain CSS. The following components have been migrated
+// and use HighlightStyles.css:
+// - GridWrapper, MyHighlightsWrapper (wrapper components)
+// - FirstImage, SecondImage, ImageWrapper, ImagesGrid (image components)
+//
+// The remaining ~11 styled components (sticky note components, text wrappers, etc.) will be
+// migrated in future work. They remain here using styled-components due to their complexity
+// (component selectors, nested pseudo-elements, calculated values, and component inheritance patterns).
+import styled from 'styled-components/macro';
 import htmlMessage from '../../../components/htmlMessage';
 import { bodyCopyRegularStyle } from '../../../components/Typography';
 import { H3, h4Style } from '../../../components/Typography';
 import theme from '../../../theme';
-import { desktopPopupWidth, popupBodyPadding, popupPadding } from '../../styles/PopupStyles';
+import { popupBodyPadding, popupPadding } from '../../styles/PopupStyles';
 import classNames from 'classnames';
 import './HighlightStyles.css';
 
@@ -26,24 +29,24 @@ export const stickyNoteMeasures = {
   width: 29.8, /* to allow text to fit in one line with tooltip */
 };
 
-export const imageStyles = css`
-  height: 25.6rem;
-  width: 36rem;
-  box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 20);
-`;
+// Migrated to plain CSS - see HighlightStyles.css
+export const FirstImage = (
+  { className, theme: _theme, ...props }: React.ImgHTMLAttributes<HTMLImageElement> & { theme?: unknown }
+) => (
+  <img alt="" {...props} className={classNames('first-image', className)} />
+);
 
-export const FirstImage = styled.img`
-  ${imageStyles}
-`;
+export const SecondImage = (
+  { className, theme: _theme, ...props }: React.ImgHTMLAttributes<HTMLImageElement> & { theme?: unknown }
+) => (
+  <img alt="" {...props} className={classNames('second-image', className)} />
+);
 
-export const SecondImage = styled.img`
-  ${imageStyles}
-  margin-top: 17.6rem;
-`;
-
-export const ImageWrapper = styled.div`
-  width: ${(desktopPopupWidth - popupBodyPadding) / 2}rem;
-`;
+export const ImageWrapper = (
+  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+) => (
+  <div {...props} className={classNames('image-wrapper', className)} />
+);
 
 export const StickyNoteBullet = styled.div`
   position: absolute;
@@ -133,12 +136,12 @@ export const GridWrapper = (
   <div {...props} className={classNames('grid-wrapper', className)} />
 );
 
-export const ImagesGrid = styled.div`
-  display: flex;
-  position: relative;
-  justify-content: space-between;
-  overflow: visible;
-`;
+// Migrated to plain CSS - see HighlightStyles.css
+export const ImagesGrid = (
+  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+) => (
+  <div {...props} className={classNames('images-grid', className)} />
+);
 
 export const GeneralText = styled(H3)`
   width: 100%;

--- a/src/app/content/highlights/components/HighlightStyles.tsx
+++ b/src/app/content/highlights/components/HighlightStyles.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 // NOTE: This file has been fully migrated from styled-components to plain CSS.
-// All 18 components now use HighlightStyles.css for styling:
+// All styling is now handled by HighlightStyles.css for:
 // - Wrapper components (2): GridWrapper, MyHighlightsWrapper
 // - Image components (4): FirstImage, SecondImage, ImageWrapper, ImagesGrid
-// - Sticky note components (6): StickyNoteBullet, StickyNote, BlueStickyNote, GreenStickyNote, StickyNoteUl, StickyNoteLi
+// - Sticky note components (5): StickyNoteBullet, BlueStickyNote, GreenStickyNote, StickyNoteUl, StickyNoteLi (plus base `.sticky-note` CSS class)
 // - Text wrapper components (4): GeneralText, GeneralTextWrapper, GeneralLeftText, GeneralCenterText
 // - Other components (2): MyHighlightsImage, StyledHiddenLiveRegion
 //
@@ -53,16 +53,22 @@ export const StickyNoteBullet = () => (
   <div className="sticky-note-bullet" />
 );
 
-export const BlueStickyNote = ({children}: SimpleWrapper) => (
-  <div className="blue-sticky-note">
+const StickyNote = ({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div {...props} className={classNames('sticky-note', className)}>
     {children}
   </div>
 );
 
-export const GreenStickyNote = ({children}: SimpleWrapper) => (
-  <div className="green-sticky-note">
+export const BlueStickyNote = ({children}: SimpleWrapper) => (
+  <StickyNote className="blue-sticky-note">
     {children}
-  </div>
+  </StickyNote>
+);
+
+export const GreenStickyNote = ({children}: SimpleWrapper) => (
+  <StickyNote className="green-sticky-note">
+    {children}
+  </StickyNote>
 );
 
 export const StickyNoteUl = ({children}: SimpleWrapper) => (
@@ -95,8 +101,8 @@ export const GeneralText = ({children}: SimpleWrapper) => (
   </H3>
 );
 
-export const GeneralTextWrapper = ({className, children}: SimpleWrapper & {className?: string} ) => (
-  <div className={classNames('general-text-wrapper', className)} >
+export const GeneralTextWrapper = ({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div {...props} className={classNames('general-text-wrapper', className)}>
     {children}
   </div>
 );

--- a/src/app/content/highlights/components/HighlightStyles.tsx
+++ b/src/app/content/highlights/components/HighlightStyles.tsx
@@ -3,15 +3,15 @@ import React from 'react';
 // and use HighlightStyles.css:
 // - GridWrapper, MyHighlightsWrapper (wrapper components)
 // - FirstImage, SecondImage, ImageWrapper, ImagesGrid (image components)
+// - StickyNoteBullet, StickyNote, BlueStickyNote, GreenStickyNote, StickyNoteUl, StickyNoteLi (sticky note components)
 //
-// The remaining ~11 styled components (sticky note components, text wrappers, etc.) will be
-// migrated in future work. They remain here using styled-components due to their complexity
-// (component selectors, nested pseudo-elements, calculated values, and component inheritance patterns).
+// The remaining 6 styled components (text wrappers and MyHighlightsImage) will be migrated in future work.
+// They remain here using styled-components due to their complexity (component inheritance patterns
+// and css fragments like h4Style and bodyCopyRegularStyle).
 import styled from 'styled-components/macro';
 import htmlMessage from '../../../components/htmlMessage';
 import { bodyCopyRegularStyle } from '../../../components/Typography';
-import { H3, h4Style } from '../../../components/Typography';
-import theme from '../../../theme';
+import { H3 } from '../../../components/Typography';
 import { popupBodyPadding, popupPadding } from '../../styles/PopupStyles';
 import classNames from 'classnames';
 import './HighlightStyles.css';
@@ -48,86 +48,42 @@ export const ImageWrapper = (
   <div {...props} className={classNames('image-wrapper', className)} />
 );
 
-export const StickyNoteBullet = styled.div`
-  position: absolute;
-  height: ${stickyNoteMeasures.bulletSize * 2}rem;
-  width: ${stickyNoteMeasures.bulletSize}rem;
-  top: 50%;
-  overflow: hidden;
+// Migrated to plain CSS - see HighlightStyles.css
+export const StickyNoteBullet = (
+  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+) => (
+  <div {...props} className={classNames('sticky-note-bullet', className)} />
+);
 
-  ::after {
-    content: "";
-    position: absolute;
-    width: ${stickyNoteMeasures.bulletSize}rem;
-    height: ${stickyNoteMeasures.bulletSize}rem;
-    transform: rotate(45deg);
-    top: ${stickyNoteMeasures.bulletSize / 2}rem;
-    box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 30);
-  }
-`;
+export const StickyNote = (
+  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+) => (
+  <div {...props} className={classNames('sticky-note', className)} />
+);
 
-export const StickyNote = styled.div`
-  width: ${stickyNoteMeasures.width}rem;
-  position: absolute;
-  padding: ${stickyNoteMeasures.bulletSize}rem ${popupBodyPadding}rem;
-  overflow: visible;
-  box-shadow: 0.1rem 0.1rem 0.4rem 0 rgba(0, 0, 0, 30);
-  opacity: ${stickyNoteMeasures.opacity};
-`;
+export const BlueStickyNote = (
+  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+) => (
+  <div {...props} className={classNames('sticky-note', 'blue-sticky-note', className)} />
+);
 
-export const BlueStickyNote = styled(StickyNote)`
-  background: ${stickyNoteMeasures.blue};
-  top: ${stickyNoteMeasures.defaultOffset}rem;
-  left: ${stickyNoteMeasures.left + (stickyNoteMeasures.bulletSize / 2)}rem;
+export const GreenStickyNote = (
+  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLDivElement> & { theme?: unknown }
+) => (
+  <div {...props} className={classNames('sticky-note', 'green-sticky-note', className)} />
+);
 
-  ${StickyNoteBullet} {
-    transform: translate(-100%, -50%);
-    left: 0%;
+export const StickyNoteUl = (
+  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLUListElement> & { theme?: unknown }
+) => (
+  <ul {...props} className={classNames('sticky-note-ul', className)} />
+);
 
-    ::after {
-      transform: rotate(45deg);
-      left: ${stickyNoteMeasures.bulletSize / 2}rem;
-      background: ${stickyNoteMeasures.blue};
-    }
-  }
-`;
-
-export const GreenStickyNote = styled(StickyNote)`
-  background: ${stickyNoteMeasures.green};
-  bottom: ${stickyNoteMeasures.defaultOffset}rem;
-  right: ${stickyNoteMeasures.left + (stickyNoteMeasures.bulletSize / 2)}rem;
-
-  ${StickyNoteBullet} {
-    transform: translate(100%, -50%);
-    right: 0%;
-
-    ::after {
-      transform: rotate(-45deg);
-      right: ${stickyNoteMeasures.bulletSize / 2}rem;
-      background: ${stickyNoteMeasures.green};
-    }
-  }
-`;
-
-export const StickyNoteUl = styled.ul`
-  padding: 0;
-  overflow: visible;
-  margin: 0;
-  list-style: none;
-`;
-
-export const StickyNoteLi = styled.li`
-  ${h4Style}
-  overflow: visible;
-  padding: 0;
-  display: flex;
-  color: ${theme.color.neutral.base};
-
-  ::before {
-    content: "\\2022";
-    padding-right: 0.5rem;
-  }
-`;
+export const StickyNoteLi = (
+  { className, theme: _theme, ...props }: React.HTMLAttributes<HTMLLIElement> & { theme?: unknown }
+) => (
+  <li {...props} className={classNames('sticky-note-li', className)} />
+);
 
 // Migrated to plain CSS - see HighlightStyles.css
 export const GridWrapper = (


### PR DESCRIPTION
## Summary

**[DRAFT] Phase 7.1e: Complete HighlightStyles.tsx Migration**

Related Jira: CORE-2282 (sub-task to be created)

This draft PR continues the styled-components to plain CSS migration for the remaining complex components in HighlightStyles.tsx that were deferred from Phase 7.1d (PR #3037).

## Background

Phase 7.1d successfully migrated 8 highlights components, but the remaining ~15 styled components in HighlightStyles.tsx were deferred due to their complexity. This PR will complete that migration.

## 🚧 Components to Migrate (~15)

### Image Components (4)
- [x] FirstImage
- [x] SecondImage  
- [x] ImageWrapper
- [x] ImagesGrid

### Sticky Note Components (6)
- [x] StickyNoteBullet
- [x] StickyNote
- [x] BlueStickyNote
- [x] GreenStickyNote
- [x] StickyNoteUl
- [x] StickyNoteLi

### Text Wrapper Components (4)
- [x] GeneralText
- [x] GeneralTextWrapper
- [x] GeneralLeftText
- [x] GeneralCenterText

### Other Components (3)
- [x] MyHighlightsImage
- [x] StyledHiddenLiveRegion
- [x] LoginText (htmlMessage wrapper)

## Complexity Factors

These components are complex due to:

1. **Component Selectors**: e.g., `${StickyNoteBullet}` used within `BlueStickyNote` and `GreenStickyNote`
2. **Nested Pseudo-elements**: `::before` and `::after` with complex positioning and transforms
3. **Calculated Values**: From `stickyNoteMeasures` constants (bulletSize, width, opacity, etc.)
4. **Component Inheritance**: `BlueStickyNote extends StickyNote`, sharing and overriding styles

## Migration Strategy

Following the patterns established in Phase 7.1d:

1. **No .legacy/.new files** - Convert components directly in HighlightStyles.tsx
2. **Comprehensive CSS file** - Expand HighlightStyles.css with all remaining styles
3. **CSS Variables** - Use for calculated values from `stickyNoteMeasures` constants
4. **Component Selectors → CSS Selectors** - Convert `${Component}` to `.component-class`
5. **Maintain Inheritance** - Use CSS classes like `.sticky-note.blue` instead of extending

## Success Criteria

- [ ] All remaining styled components converted to plain CSS
- [ ] No visual regressions in:
  - Sticky notes (blue and green with bullets)
  - Image grid layouts
  - Text wrapper alignments
  - Help popup images
- [ ] All tests passing
- [ ] No `styled-components` imports in HighlightStyles.tsx
- [ ] TypeScript compilation successful
- [ ] Linting passes

## Related Work

- **Parent Ticket**: CORE-2282 - Phase 7.1: Migrate Content Highlights & Keyboard Shortcuts
- **Completed**: PR #3037 - Phase 7.1d (8 components migrated)
- **Dependencies**: PR #3037 must be merged first

---

**Note**: This PR is not ready for review yet. It will be converted from draft once all components are migrated and tests are passing.
