### PR TITLE
CORE-2611 Probably make it easier to get spot instances for pre-rendering

### DIFF
--- a/script/prerender/cfn.yml
+++ b/script/prerender/cfn.yml
@@ -141,8 +141,6 @@ Resources:
         ImageId: >-
           {{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id}}
         InstanceInitiatedShutdownBehavior: terminate
-        # Having less, larger instances is generally cheaper due to lower EBS costs
-        InstanceType: r6a.4xlarge
         SecurityGroupIds:
           - !ImportValue RexPrerenderWorkersSecurityGroupID
         TagSpecifications:
@@ -197,6 +195,7 @@ Resources:
                   Cpu:
                     References:
                       - InstanceFamily: r5
+                MaxSpotPriceAsPercentageOfOptimalOnDemandPrice: 101
                 MemoryGiBPerVCpu:
                   Min: 4
                   Max: 8


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-2611

The standard spot price protection is like 2x the minimum matching spot instance price.
Change to 101% of the on-demand price instead.