### PR TITLE
CORE-2704: repair dead [class*=...] locators in Playwright fixtures

### DIFF
--- a/e2e_tests/src/fixtures/MHmodal.ts
+++ b/e2e_tests/src/fixtures/MHmodal.ts
@@ -27,7 +27,7 @@ class MHModal {
 
   async waitForHighlights() {
     // Wait for the highlights to be loaded in MH modal
-    await this.page.waitForSelector('[class*=HighlightOuterWrapper]')
+    await this.page.waitForSelector('.highlight-outer-wrapper')
   }
 
   async chapterDropdownCount() {
@@ -145,7 +145,7 @@ class MHHighlights {
 
   constructor(page: Page) {
     this.page = page
-    this.highlight = page.locator('[class*="HighlightOuterWrapper"]')
+    this.highlight = page.locator('.highlight-outer-wrapper')
     this.MHContextMenu = this.page.locator('[data-testid="highlight-dropdown-menu-toggle"]')
     this.blue = this.page.locator('[data-testid="show-myhighlights-body"] [aria-label="Apply blue highlight"]')
     this.green = this.page.locator('[data-testid="show-myhighlights-body"] [aria-label="Apply green highlight"]')
@@ -164,7 +164,7 @@ class MHHighlights {
 
   async highlightCount() {
     // Total number of highlights in MH page
-    await Promise.all([this.page.waitForSelector('[class*="HighlightOuterWrapper"]')])
+    await Promise.all([this.page.waitForSelector('.highlight-outer-wrapper')])
     return await this.highlight.count()
   }
 

--- a/e2e_tests/src/fixtures/MHmodal.ts
+++ b/e2e_tests/src/fixtures/MHmodal.ts
@@ -164,7 +164,7 @@ class MHHighlights {
 
   async highlightCount() {
     // Total number of highlights in MH page
-    await Promise.all([this.page.waitForSelector('.highlight-outer-wrapper')])
+    await this.page.waitForSelector('.highlight-outer-wrapper')
     return await this.highlight.count()
   }
 

--- a/e2e_tests/src/fixtures/content.page.ts
+++ b/e2e_tests/src/fixtures/content.page.ts
@@ -44,15 +44,15 @@ class ContentPage {
     this.paragraph = this.page.locator('p[id*=para]')
     this.body = this.page.locator('[class*="page-content"]')
     this.MHbodyLoaded = this.page.locator('[data-testid="show-myhighlights-body"]')
-    this.contentHighlightsLoaded = this.page.locator('[class*="HighlightsWrapper"]')
+    this.contentHighlightsLoaded = this.page.locator('.highlights-wrapper')
     this.noteTextBox = this.page.locator('[data-analytics-region="edit-note"]')
     this.saveNote = this.page.locator('[data-testid="save"]')
     this.cancelNote = this.page.locator('[data-testid="cancel"]')
     this.contextMenu = this.page.locator('[data-testid="dot-menu-toggle"]')
     this.editHighlightLocator = this.page.locator('[data-testid="card"] >> text=Edit')
-    this.noteTextLocator = this.page.locator('[class*=TruncatedText]')
+    this.noteTextLocator = this.page.locator('.truncated-text-note')
     this.noteEditCard = this.page.locator('form[data-analytics-region="edit-note"]')
-    this.textarea = this.page.locator('textarea[class*="TextArea"]')
+    this.textarea = this.page.locator('textarea.note-textarea')
   }
 
   async open(path: string) {

--- a/e2e_tests/src/fixtures/toc.ts
+++ b/e2e_tests/src/fixtures/toc.ts
@@ -13,8 +13,8 @@ class TOC {
   constructor(page: Page) {
     this.page = page
     this.pageLocator = this.page.locator('[data-type="page"]')
-    this.tocDropdownLocator = this.page.locator('div[class*="StyledTreeItemContent"]')
-    this.sectionNameLocator = this.page.locator('h1[class*="BookBanner"]')
+    this.tocDropdownLocator = this.page.locator('div.toc-summary-wrapper')
+    this.sectionNameLocator = this.page.locator('h1.book-banner-chapter')
     this.pageSlugLocator = this.page.locator('[data-type="page"] a')
     this.currentPageLocator = this.page.locator("[aria-label*='Current Page'] a")
   }
@@ -72,7 +72,7 @@ class TOC {
         await this.pageLocator.nth(pageNumber).click()
       } else {
         // expand the dropdowns in toc
-        await this.page.waitForSelector('div[class*="StyledTreeItemContent"]')
+        await this.page.waitForSelector('div.toc-summary-wrapper')
         const tocDropdownCounts = await this.tocDropdownLocator.count()
         let tocDropdownCount: number
         for (tocDropdownCount = 0; tocDropdownCount < tocDropdownCounts; tocDropdownCount++) {
@@ -135,7 +135,7 @@ class TOC {
     const chapterLocator = toc.locator('[data-type=chapter]', {
       has: this.page.locator(`[href="${await this.CurrentPageSlug()}"]`),
     })
-    const chapter = chapterLocator.locator('span[class*="SummaryTitle"]').first().textContent()
+    const chapter = chapterLocator.locator('span.toc-summary-title').first().textContent()
     return (await chapter).replace(/[\n\r]/g, '')
   }
 
@@ -157,7 +157,7 @@ class TOC {
     const eocLocator = toc.locator('[data-type=eoc-dropdown]', {
       has: this.page.locator(`[href="${await this.CurrentPageSlug()}"]`),
     })
-    const eocSectionHeading = eocLocator.locator('span[class*="SummaryTitle"]').first().textContent()
+    const eocSectionHeading = eocLocator.locator('span.toc-summary-title').first().textContent()
     return (await eocSectionHeading).replace(/[\n\r]/g, '')
   }
 
@@ -167,7 +167,7 @@ class TOC {
     const eobLocator = toc.locator('[data-type=eob-dropdown]', {
       has: this.page.locator(`[href="${await this.CurrentPageSlug()}"]`),
     })
-    const eobSectionHeading = eobLocator.locator('span[class*="SummaryTitle"]').first().textContent()
+    const eobSectionHeading = eobLocator.locator('span.toc-summary-title').first().textContent()
     return (await eobSectionHeading).replace(/[\n\r]/g, '')
   }
 }

--- a/e2e_tests/src/utilities/utilities.ts
+++ b/e2e_tests/src/utilities/utilities.ts
@@ -86,12 +86,12 @@ class MobileNavigation {
   async openMobileMenu(menu: any) {
     switch (menu) {
       case 'toc':
-        await this.page.click('[id*="mobile-menu-button"] [class*="styled__PlainButton"]')
+        await this.page.click('[id*="mobile-menu-button"] .topbar-menu-button')
         await this.page.click('[data-analytics-label="Open the Table of Contents"]')
         break
 
       case 'MH':
-        await this.page.click('[id*="mobile-menu-button"] [class*="styled__PlainButton"]')
+        await this.page.click('[id*="mobile-menu-button"] .topbar-menu-button')
         await this.page.click('[data-analytics-label="My highlights"]')
         // Close the mobile help notification tooltip
         await this.page.locator('[data-testid="highlights-popup-wrapper"] button').nth(4).click()

--- a/e2e_tests/src/utilities/utilities.ts
+++ b/e2e_tests/src/utilities/utilities.ts
@@ -86,12 +86,12 @@ class MobileNavigation {
   async openMobileMenu(menu: any) {
     switch (menu) {
       case 'toc':
-        await this.page.click('[id*="mobile-menu-button"] .topbar-menu-button')
+        await this.page.click('#mobile-menu-button .topbar-menu-button')
         await this.page.click('[data-analytics-label="Open the Table of Contents"]')
         break
 
       case 'MH':
-        await this.page.click('[id*="mobile-menu-button"] .topbar-menu-button')
+        await this.page.click('#mobile-menu-button .topbar-menu-button')
         await this.page.click('[data-analytics-label="My highlights"]')
         // Close the mobile help notification tooltip
         await this.page.locator('[data-testid="highlights-popup-wrapper"] button').nth(4).click()


### PR DESCRIPTION
Jira: [CORE-2704](https://openstax.atlassian.net/browse/CORE-2704)

Follow-up to the [routing note](https://github.com/openstax/rex-web/pull/3116#issuecomment-5396668117) on #3116. That PR fixed the three locators its own diff broke; this one repairs the eight that were **already dead on `main`** before it.

## What was wrong

All eight matched styled-components' generated class names — `HighlightListElement__HighlightOuterWrapper-sc-abc123`, `Note__TextArea-sc-*`, and friends. The plain-CSS migration (phases 3.2a / 7.4a / 7.4b) replaced those with hand-authored kebab-case classes, so every `[class*=...]` substring selector now matches zero elements.

Each replacement is the class the component actually renders today, verified against `main`:

| file | was | now | renders at |
| --- | --- | --- | --- |
| `MHmodal.ts:30,148,167` | `[class*=HighlightOuterWrapper]` | `.highlight-outer-wrapper` | `SummaryPopup/HighlightListElement.tsx:22` |
| `content.page.ts:47` | `[class*="HighlightsWrapper"]` | `.highlights-wrapper` | `content/styles/HighlightsWrapper.tsx:19` |
| `content.page.ts:53` | `[class*=TruncatedText]` | `.truncated-text-note` | `highlights/components/TruncatedText.tsx:58` |
| `content.page.ts:55` | `textarea[class*="TextArea"]` | `textarea.note-textarea` | `highlights/components/Note.tsx:69` |
| `toc.ts:16,75` | `div[class*="StyledTreeItemContent"]` | `div.toc-summary-wrapper` | `TableOfContents/index.tsx:133` |
| `toc.ts:17` | `h1[class*="BookBanner"]` | `h1.book-banner-chapter` | `content/components/BookBanner.tsx:113-117` |
| `toc.ts:138,160,170` | `span[class*="SummaryTitle"]` | `span.toc-summary-title` | `TableOfContents/index.tsx:136` |
| `utilities.ts:89,94` | `[class*="styled__PlainButton"]` | `.topbar-menu-button` | `Topbar/styled.tsx:165` |

Two notes on specific choices:

- **`h1.book-banner-chapter`** — `BookChapter` renders `h1` only for `variant="big"` (`variant="mini"` renders a `span`), and `BookTitle` is always a `span`. So the `h1` the fixture wanted is unambiguously the chapter/section name. The fixture calls it `sectionNameLocator`, which matches.
- **`textarea.note-textarea`** — `Note.tsx` also sets `id='note-textarea'`, but the fixture indexes with `.nth(i)` across multiple cards, so the id would be duplicated. Keeping it a class selector.

`content.page.ts:45`'s `[class*="page-content"]` is left alone: `page-content` is a real hand-authored class (`Page/PageComponent.tsx:208`), not a generated one.

## Not in this PR

`MHmodal.ts:20,119,149` and `content.page.ts:51` (`Checkbox`, `MenuToggle`) are fixed in #3116 and deliberately untouched here — no overlapping lines, so the two branches merge cleanly in either order.

## ⚠️ Bigger finding: `toc.ts` needs more than a locator swap

While verifying `StyledTreeItemContent` I rendered the real TOC with react-aria unmocked and dumped the DOM. **The `toc.ts` fixture is broken well beyond these class names**, and the cause predates the CSS migration — it's the react-aria Tree migration (#2477, June 2025).

`TreeItemContent` is a `createLeafComponent('content', ...)`; it renders `renderProps.children` and **no DOM node of its own**. So the `className="toc-nav-item"` and `data-type={sectionType}` passed to it at `TableOfContents/index.tsx:256-258` are silently discarded. This is invisible in unit tests because `index.spec.tsx:22-35` mocks `TreeItemContent` as `<div {...props}>`, which *does* render them.

Actual rendered TOC row today:

```html
<div role="row" class="toc-tree-item" aria-level="1" data-level="1" data-has-child-items="true" aria-expanded="false">
  <div role="gridcell" style="display: contents;">
    <div class="toc-summary-wrapper">
      <span class="toc-expand-icon">…</span>
      <span class="toc-collapse-icon">…</span>
      <span class="toc-summary-title">…</span>
    </div>
  </div>
</div>
```

Consequences for `toc.ts`, none of which this PR fixes:

1. **No `data-type` anywhere in the TOC.** `[data-type="page"]` (`:15`, `:18`, `:68`), `[data-type=chapter]` (`:30`, `:135`), `[data-type=eob-dropdown]` (`:43`, `:167`), `[data-type=eoc-dropdown]` (`:157`), `[data-type=unit]` (`:36`, `:146`) all match nothing.
2. **No `<ol>` / `<li>` / `<details>`.** `:36`'s XPath and `:49`'s `nav[...] > ol > [data-type="page"]` target a DOM that no longer exists.
3. **Rows are flat siblings, not nested.** react-aria Tree emits one `role="row"` per node in a single flat container, so every `toc.locator('[data-type=…]', {has: currentPageLink})` containment query is structurally impossible now. `ChapterName()`, `UnitName()`, `eocSectionHeading()` and `eobSectionHeading()` all depend on it. Nesting is expressed via `aria-level`/`data-level`, so these need rewriting to walk backwards from the current row to the nearest preceding row of a lower level.
4. **`:19`'s `[aria-label*='Current Page']` matches nothing.** The current page is marked `aria-current="page"` on `a.toc-content-link` — which is what `TableOfContents/utils.ts:10` itself uses.

The three `toc.ts` swaps in this PR are still correct and worth landing, but they sit inside functions whose surrounding scoping is dead, so they won't make those helpers work on their own.

My recommendation, for discussion on the ticket:

- Move `data-type={sectionType}` from `TreeItemContent` to `TreeItem` (react-aria's `filterDOMProps` passes `data-*` through to the row div, so this is a small change that restores items 1 and part of 2), and add it to the `isArchiveTree` branch at `index.tsx:307` too, which never had it.
- Rewrite the four containment-based helpers around `aria-level`.
- Drop the dead `className="toc-nav-item"` and its now-unused CSS rule.

That's a materially larger change than this ticket described, and it touches app source rather than just fixtures, so I've left it out pending a call on whether to fold it in here or split it.

## Verification

- `npx eslint 'src/**/*.ts' --quiet` in `e2e_tests/`: **6 errors, all pre-existing** — identical output with the changes stashed (`base.ts` prettier ×5, `content.page.ts:76` prefer-const). Zero new.
- `tsc --noEmit` over the four edited files: 3 errors, all pre-existing, all from the `playwright@1.55` / `@playwright/test@1.23` version skew in `e2e_tests/package.json`. None in the edited lines — these are string-literal swaps inside existing `Locator` assignments.
- DOM claims above were verified by rendering the real components under jest with react-aria **unmocked** and dumping `outerHTML`, not by reading source alone.
- **These changes are not exercised by CI.** `.github/workflows/playwright.yml` triggers on `e2e_tests/**` but runs the *Python* suite (`pytest … e2e`) against `staging.openstax.org`. Nothing runs `e2e_tests/tests/rex-test`. So the Playwright check going green on this PR says nothing about these fixtures either way — which is also why this rot went unnoticed for ~14 months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CORE-2704]: https://openstax.atlassian.net/browse/CORE-2704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ