### PR TITLE
Phase 7.4d: Migrate Popup/Filter Components to Plain CSS

### DIFF
--- a/src/app/components/Dropdown.tsx
+++ b/src/app/components/Dropdown.tsx
@@ -5,7 +5,6 @@ import isUndefined from 'lodash/fp/isUndefined';
 import omitBy from 'lodash/fp/omitBy';
 import React, { ReactNode } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import styled from 'styled-components/macro';
 import classNames from 'classnames';
 import { useFocusLost, useTrapTabNavigation, focusableItemQuery } from '../reactUtils';
 import { useOnEsc } from '../reactUtils';
@@ -260,13 +259,11 @@ export type TabHiddenDropdownProps = CommonDropdownProps & (Props | Props & Cont
 
 export type DropdownProps = TabTransparentDropdownProps | TabHiddenDropdownProps;
 
-// Plain React component for Dropdown, but wrapped with styled() for backward compatibility
-const DropdownBase = React.forwardRef<HTMLElement, DropdownProps>(({transparentTab, className, ...props}, ref) => {
+// Plain React component for Dropdown. Consumers that used to reference it with a
+// styled-components component selector target the .dropdown-wrapper class instead.
+const Dropdown = React.forwardRef<HTMLElement, DropdownProps>(({transparentTab, className, ...props}, ref) => {
   const Component = transparentTab !== false ? TabTransparentDropdown : TabHiddenDropDown;
   return <Component ref={ref} className={classNames('dropdown-wrapper', className)} {...props} />;
 });
-
-// Wrap with styled() for backward compatibility with component selectors
-const Dropdown = styled(DropdownBase)``;
 
 export default Dropdown;

--- a/src/app/components/__snapshots__/Dropdown.spec.tsx.snap
+++ b/src/app/components/__snapshots__/Dropdown.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Dropdown matches snapshot 1`] = `
 <div
-  className="dropdown-transparent dropdown-wrapper "
+  className="dropdown-transparent dropdown-wrapper"
 >
   <div
     className="dropdown-focus-wrapper"
@@ -56,7 +56,7 @@ exports[`Dropdown matches snapshot 1`] = `
 
 exports[`Dropdown matches snapshot for tab hidden (closed) 1`] = `
 <div
-  className="dropdown-wrapper "
+  className="dropdown-wrapper"
 >
   <button
     className="dropdown-toggle"
@@ -70,7 +70,7 @@ exports[`Dropdown matches snapshot for tab hidden (closed) 1`] = `
 
 exports[`Dropdown matches snapshot for tab hidden (open) 1`] = `
 <div
-  className="dropdown-wrapper "
+  className="dropdown-wrapper"
 >
   <button
     className="dropdown-toggle"

--- a/src/app/content/__snapshots__/routes.spec.tsx.snap
+++ b/src/app/content/__snapshots__/routes.spec.tsx.snap
@@ -1,40 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`assigned route route renders renders a component 1`] = `
-.c0 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-}
-
-.c0 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-@media screen and (max-width:75em) {
-  .c0 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
 <div
   className="platform-wrapper"
   data-platform="assignable"
@@ -108,7 +74,7 @@ exports[`assigned route route renders renders a component 1`] = `
         aria-controls="text-resizer-menu"
         aria-expanded={false}
         aria-label="Change text size"
-        className="plain-button c0 dropdown-toggle"
+        className="plain-button filters-toggle dropdown-toggle"
         data-analytics-label="Change text size"
         onClick={[Function]}
       >

--- a/src/app/content/components/Topbar/__snapshots__/index.spec.tsx.snap
+++ b/src/app/content/components/Topbar/__snapshots__/index.spec.tsx.snap
@@ -314,81 +314,6 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
   display: contents;
 }
 
-.c2 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-}
-
-.c2 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c1 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-  z-index: 2;
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  -webkit-clip-path: inset(0 -0.6rem 0px -0.6rem);
-  clip-path: inset(0 -0.6rem 0px -0.6rem);
-  background-color: #fff;
-  border-left: 0.1rem solid #d5d5d5;
-  border-right: 0.1rem solid #d5d5d5;
-}
-
-.c1 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-@media screen and (max-width:75em) {
-  .c2 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c1 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
 <div
   className="topbar-wrapper"
   data-testid="topbar"
@@ -572,7 +497,7 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
         aria-controls="text-resizer-menu"
         aria-expanded={true}
         aria-label="Change text size"
-        className="plain-button c1 dropdown-toggle"
+        className="plain-button filters-toggle filters-toggle-open dropdown-toggle"
         data-analytics-label="Change text size"
         onClick={[Function]}
       >
@@ -798,7 +723,7 @@ exports[`text resizer opens menu when clicking menu button 1`] = `
           aria-controls="text-resizer-menu"
           aria-expanded={false}
           aria-label="Change text size"
-          className="plain-button c2 dropdown-toggle"
+          className="plain-button filters-toggle dropdown-toggle"
           data-analytics-label="Change text size"
           onClick={[Function]}
         >

--- a/src/app/content/components/__snapshots__/AssignedTopBar.spec.tsx.snap
+++ b/src/app/content/components/__snapshots__/AssignedTopBar.spec.tsx.snap
@@ -1,40 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssignedTopBar renders 1`] = `
-.c0 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-}
-
-.c0 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-@media screen and (max-width:75em) {
-  .c0 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
 <div
   className="topbar-wrapper assigned-topbar-wrapper"
   style={
@@ -66,7 +32,7 @@ exports[`AssignedTopBar renders 1`] = `
       aria-controls="text-resizer-menu"
       aria-expanded={false}
       aria-label="Change text size"
-      className="plain-button c0 dropdown-toggle"
+      className="plain-button filters-toggle dropdown-toggle"
       data-analytics-label="Change text size"
       onClick={[Function]}
     >

--- a/src/app/content/components/popUp/ChapterFilter.css
+++ b/src/app/content/components/popUp/ChapterFilter.css
@@ -1,0 +1,156 @@
+/* ChapterFilter styles - plain CSS version
+ *
+ * Values previously interpolated from theme.ts / PopupConstants.ts are inlined
+ * here with the original expression in a comment.
+ */
+
+/* Row - holds the section columns */
+.chapter-filter-row {
+  display: flex;
+  flex-direction: row;
+}
+
+/* theme.breakpoints.mobile */
+@media screen and (max-width: 75em) {
+  .chapter-filter-row {
+    flex-direction: column;
+    overflow: hidden;
+  }
+}
+
+/* Column - a list of sections */
+.chapter-filter-column {
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* ChapterTitle - book-supplied markup, so the .os-* classes come from content */
+.chapter-filter-title {
+  display: flex;
+  flex-direction: row;
+  white-space: nowrap;
+  margin-left: 0.8rem;
+}
+
+.chapter-filter-title > * {
+  overflow: hidden;
+}
+
+.chapter-filter-title .os-text {
+  flex: 1;
+  text-overflow: ellipsis;
+}
+
+.chapter-filter-title .os-divider {
+  margin: 0 0.4rem;
+}
+
+/* StyledDetailsContainer - one collapsible chapter */
+.chapter-filter-details {
+  width: 400px;
+  border-bottom: 1px solid #d5d5d5; /* theme.color.neutral.formBorder */
+  overflow: visible;
+}
+
+/* theme.breakpoints.mobileSmall */
+@media screen and (max-width: 30em) {
+  .chapter-filter-details {
+    width: 100%;
+  }
+}
+
+/* StyledSummaryButton - the chapter row that expands/collapses its sections */
+.chapter-filter-summary-button {
+  display: block;
+  width: 100%;
+  padding: 1rem 1.6rem;
+  text-align: left;
+}
+
+.chapter-filter-summary-button .chapter-filter-title {
+  float: left;
+  margin-left: 0;
+  text-align: left;
+}
+
+.chapter-filter-summary-button .filters-angle-icon {
+  float: right;
+}
+
+.chapter-filter-summary-button::after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+/* StyledSectionItem - a single selectable section (single-select mode) */
+.chapter-filter-section-item {
+  display: flex;
+  align-items: center;
+  height: 4rem;
+  width: 100%;
+  text-align: left;
+  font-size: 1.4rem;
+  color: #424242; /* theme.color.text.default */
+}
+
+.chapter-filter-section-item[aria-current="true"] {
+  color: #027eb5; /* linkColor */
+}
+
+.chapter-filter-section-item:hover,
+.chapter-filter-section-item:focus {
+  background-color: #f1f1f1; /* theme.color.neutral.pageBackground */
+  color: #0064a0; /* linkHover */
+}
+
+.chapter-filter-section-item .chapter-filter-title {
+  padding-left: 2.5rem;
+  width: 95%;
+}
+
+/* StyledChapterFilterItemWrapper - the collapsible body of a chapter */
+.chapter-filter-item-wrapper {
+  overflow: visible;
+}
+
+/* ChapterFilter container */
+.chapter-filter {
+  color: #424242; /* theme.color.text.default */
+  background: #fff; /* theme.color.white */
+  font-size: 1.4rem;
+
+  /* filters.dropdownContent.padding.topBottom, filters.dropdownContent.padding.sides */
+  padding: 0.8rem 1.6rem;
+  outline: none;
+  overflow: auto;
+  z-index: 1;
+}
+
+.chapter-filter .all-or-none {
+  margin: 0.8rem 0 0.8rem 0.8rem;
+}
+
+.chapter-filter .checkbox-label {
+  padding: 0.8rem;
+}
+
+.chapter-filter .color-indicator {
+  margin: 0 1.6rem 0 1.6rem;
+}
+
+.chapter-filter .chapter-filter-details:last-child {
+  border-bottom: none;
+}
+
+/* theme.breakpoints.mobileSmall */
+@media screen and (max-width: 30em) {
+  .chapter-filter {
+    /* mobileMarginSides * 2 */
+    width: calc(100vw - 1.6rem);
+  }
+}

--- a/src/app/content/components/popUp/ChapterFilter.spec.tsx
+++ b/src/app/content/components/popUp/ChapterFilter.spec.tsx
@@ -216,7 +216,7 @@ describe('ChapterFilter', () => {
         children: [{ id: 'testbook1-testpage3-uuid', title: 'page' }],
         section: { id: 'testbook1-testchapter2-uuid', title: 'chapter' },
       },
-    ]]);
+    ]]) as unknown as LocationFilters;
 
     const component = renderer.create(<TestContainer store={store}>
       <ChapterFilter
@@ -254,7 +254,7 @@ describe('ChapterFilter', () => {
         children: [{ id: 'testbook1-testpage3-uuid', title: 'page' }],
         section: { id: 'testbook1-testchapter2-uuid', title: 'chapter' },
       },
-    ]]);
+    ]]) as unknown as LocationFilters;
 
     const component = renderer.create(<TestContainer store={store}>
       <ChapterFilter
@@ -281,7 +281,7 @@ describe('ChapterFilter', () => {
         children: [section],
         section: { id: 'testbook1-testchapter2-uuid', title: 'chapter' },
       },
-    ]]);
+    ]]) as unknown as LocationFilters;
     const setFilters = jest.fn();
 
     const component = renderer.create(<TestContainer store={store}>

--- a/src/app/content/components/popUp/ChapterFilter.spec.tsx
+++ b/src/app/content/components/popUp/ChapterFilter.spec.tsx
@@ -216,7 +216,7 @@ describe('ChapterFilter', () => {
         children: [{ id: 'testbook1-testpage3-uuid', title: 'page' }],
         section: { id: 'testbook1-testchapter2-uuid', title: 'chapter' },
       },
-    ]]) as unknown as LocationFilters;
+    ]]) as LocationFilters;
 
     const component = renderer.create(<TestContainer store={store}>
       <ChapterFilter
@@ -254,7 +254,7 @@ describe('ChapterFilter', () => {
         children: [{ id: 'testbook1-testpage3-uuid', title: 'page' }],
         section: { id: 'testbook1-testchapter2-uuid', title: 'chapter' },
       },
-    ]]) as unknown as LocationFilters;
+    ]]) as LocationFilters;
 
     const component = renderer.create(<TestContainer store={store}>
       <ChapterFilter
@@ -281,7 +281,7 @@ describe('ChapterFilter', () => {
         children: [section],
         section: { id: 'testbook1-testchapter2-uuid', title: 'chapter' },
       },
-    ]]) as unknown as LocationFilters;
+    ]]) as LocationFilters;
     const setFilters = jest.fn();
 
     const component = renderer.create(<TestContainer store={store}>

--- a/src/app/content/components/popUp/ChapterFilter.tsx
+++ b/src/app/content/components/popUp/ChapterFilter.tsx
@@ -1,59 +1,28 @@
 import { HTMLElement } from '@openstax/types/lib.dom';
 import React from 'react';
 import { useIntl } from 'react-intl';
-import styled, { css } from 'styled-components/macro';
+import classNames from 'classnames';
 import AllOrNone from '../../../components/AllOrNone';
-import { PlainButton as PlainButtonBase } from '../../../components/Button';
+import { PlainButton } from '../../../components/Button';
 import Checkbox from '../../../components/Checkbox';
 import { useTrapTabNavigation } from '../../../reactUtils/focusUtils';
-import theme from '../../../theme';
-import { filters, mobileMarginSides } from '../../styles/PopupConstants';
 import { LinkedArchiveTreeNode } from '../../types';
 import { splitTitleParts } from '../../utils/archiveTreeUtils';
 import { AngleIcon, Fieldset } from './Filters';
 import { FiltersChange, LocationFilters } from './types';
-import { linkColor, linkHover } from '../../../components/Typography';
+import './ChapterFilter.css';
 
-// Wrap with styled() to make PlainButton compatible with component selectors
-const PlainButton = styled(PlainButtonBase)``;
+const Row = ({ children }: { children: React.ReactNode }) => (
+  <div className='chapter-filter-row'>{children}</div>
+);
 
-const Row = styled.div`
-  display: flex;
-  flex-direction: row;
-  ${theme.breakpoints.mobile(css`
-    flex-direction: column;
-    overflow: hidden;
-  `)}
-`;
+const Column = ({ children, ...props }: React.HTMLAttributes<HTMLElement>) => (
+  <ul className='chapter-filter-column' {...props}>{children}</ul>
+);
 
-const Column = styled.ul`
-  display: flex;
-  flex-direction: column;
-  overflow-x: hidden;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-`;
-
-const ChapterTitle = styled.span`
-  display: flex;
-  flex-direction: row;
-  white-space: nowrap;
-  margin-left: 0.8rem;
-
-  > * {
-    overflow: hidden;
-  }
-
-  .os-text {
-    flex: 1;
-    text-overflow: ellipsis;
-  }
-
-  .os-divider {
-    margin: 0 0.4rem;
-  }
-`;
+const ChapterTitle = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
+  <span className={classNames('chapter-filter-title', className)} {...props} />
+);
 
 const chunk = <T extends unknown>(sections: T[]) => {
   const cutoff = Math.max(20, Math.ceil(sections.length / 2));
@@ -65,7 +34,9 @@ interface ChapterFilterProps {
   className?: string;
   disabled?: boolean;
   locationFilters: LocationFilters;
-  locationFiltersWithContent: Map<string, LinkedArchiveTreeNode>;
+  // optional: practice questions filters always have children, so the
+  // "does this location have content" lookups below are never reached there
+  locationFiltersWithContent?: Map<string, LinkedArchiveTreeNode>;
   selectedLocationFilters: Set<string>;
   multiselect: boolean;
   setFilters: (filters: FiltersChange<LinkedArchiveTreeNode>) => void;
@@ -113,12 +84,18 @@ const ChapterFilter = (props: ChapterFilterProps) => {
   const hasFiltersWithChildren = Boolean(values.find((filter) => filter.children));
   const sectionChunks = hasFiltersWithChildren ? [values] : chunk(values);
 
-  return <div className={props.className} tabIndex={-1} id={props.id} ref={ref}>
+  return <div className={classNames('chapter-filter', props.className)} tabIndex={-1} id={props.id} ref={ref}>
     {props.multiselect
       ? (
         <AllOrNone
-          onNone={() => setSelectedChapters({ remove: Array.from(props.locationFiltersWithContent.values()), new: [] })}
-          onAll={() => setSelectedChapters({ remove: [], new: Array.from(props.locationFiltersWithContent.values()) })}
+          onNone={() => setSelectedChapters({
+            remove: Array.from(props.locationFiltersWithContent?.values() ?? []),
+            new: [],
+          })}
+          onAll={() => setSelectedChapters({
+            remove: [],
+            new: Array.from(props.locationFiltersWithContent?.values() ?? []),
+          })}
           disabled={props.disabled}
         />
       )
@@ -132,7 +109,7 @@ const ChapterFilter = (props: ChapterFilterProps) => {
             if (!children) {
               return <li key={section.id}><ChapterFilterItem
                 selected={props.selectedLocationFilters.has(section.id)}
-                disabled={props.disabled || !props.locationFiltersWithContent.has(section.id)}
+                disabled={props.disabled || !props.locationFiltersWithContent?.has(section.id)}
                 multiselect={Boolean(props.multiselect)}
                 title={section.title}
                 onChange={() => handleChange(section)}
@@ -213,95 +190,20 @@ const ChapterFilterItem = (props: ChapterFilterItemProps) => {
   </StyledSectionItem>;
 };
 
-export const StyledDetailsContainer = styled.div`
-  width: 400px;
-  border-bottom: 1px solid ${theme.color.neutral.formBorder};
-  overflow: visible;
-  ${theme.breakpoints.mobileSmall(css`
-    width: 100%;
-  `)}
-`;
+export const StyledDetailsContainer = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
+  <div className={classNames('chapter-filter-details', className)} {...props} />
+);
 
-export const StyledSummaryButton = styled(PlainButton)`
-  display: block;
-  width: 100%;
-  padding: 1rem 1.6rem;
-  text-align: left;
+export const StyledSummaryButton = ({ className, ...props }: React.ButtonHTMLAttributes<HTMLElement>) => (
+  <PlainButton className={classNames('chapter-filter-summary-button', className)} {...props} />
+);
 
-  ${ChapterTitle} {
-    float: left;
-    margin-left: 0;
-    text-align: left;
-  }
+export const StyledSectionItem = ({ className, ...props }: React.ButtonHTMLAttributes<HTMLElement>) => (
+  <PlainButton className={classNames('chapter-filter-section-item', className)} {...props} />
+);
 
-  ${AngleIcon} {
-    float: right;
-  }
+export const StyledChapterFilterItemWrapper = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
+  <div className={classNames('chapter-filter-item-wrapper', className)} {...props} />
+);
 
-  &::after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-`;
-
-export const StyledSectionItem = styled(PlainButton)`
-  display: flex;
-  align-items: center;
-  height: 4rem;
-  width: 100%;
-  text-align: left;
-  font-size: 1.4rem;
-  color: ${theme.color.text.default};
-
-  &[aria-current="true"] {
-    color: ${linkColor};
-  }
-
-  &:hover,
-  &:focus {
-    background-color: ${theme.color.neutral.pageBackground};
-    color: ${linkHover};
-  }
-
-  ${ChapterTitle} {
-    padding-left: 2.5rem;
-    width: 95%;
-  }
-`;
-
-export const StyledChapterFilterItemWrapper = styled.div`
-  overflow: visible;
-`;
-
-export default styled(ChapterFilter)`
-  color: ${theme.color.text.default};
-  background: ${theme.color.white};
-  font-size: 1.4rem;
-  padding: ${filters.dropdownContent.padding.topBottom}rem ${filters.dropdownContent.padding.sides}rem;
-  outline: none;
-  overflow: auto;
-  z-index: 1;
-
-  .all-or-none {
-    margin: 0.8rem 0 0.8rem 0.8rem;
-  }
-
-  .checkbox-label {
-    padding: 0.8rem;
-  }
-
-  .color-indicator {
-    margin: 0 1.6rem 0 1.6rem;
-  }
-
-  ${StyledDetailsContainer} {
-    &:last-child {
-      border-bottom: none;
-    }
-  }
-
-  ${theme.breakpoints.mobileSmall(css`
-    width: calc(100vw - ${mobileMarginSides * 2}rem);
-  `)}
-`;
+export default ChapterFilter;

--- a/src/app/content/components/popUp/ChapterFilter.tsx
+++ b/src/app/content/components/popUp/ChapterFilter.tsx
@@ -16,13 +16,18 @@ const Row = ({ children }: { children: React.ReactNode }) => (
   <div className='chapter-filter-row'>{children}</div>
 );
 
-const Column = ({ children, ...props }: React.HTMLAttributes<HTMLUListElement>) => (
-  <ul className='chapter-filter-column' {...props}>{children}</ul>
+const Column = ({ children, className, ...props }: React.HTMLAttributes<HTMLUListElement>) => (
+  <ul className={classNames('chapter-filter-column', className)} {...props}>{children}</ul>
 );
 
 const ChapterTitle = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
   <span className={classNames('chapter-filter-title', className)} {...props} />
 );
+
+// practice questions doesn't pass locationFiltersWithContent; its location
+// filters always have children, so the lookups that read it are never reached
+// there. Shared so the fallback doesn't allocate on every render.
+const noLocationFiltersWithContent: Map<string, LinkedArchiveTreeNode> = new Map();
 
 const chunk = <T extends unknown>(sections: T[]) => {
   const cutoff = Math.max(20, Math.ceil(sections.length / 2));
@@ -34,8 +39,6 @@ interface ChapterFilterProps {
   className?: string;
   disabled?: boolean;
   locationFilters: LocationFilters;
-  // optional: practice questions filters always have children, so the
-  // "does this location have content" lookups below are never reached there
   locationFiltersWithContent?: Map<string, LinkedArchiveTreeNode>;
   selectedLocationFilters: Set<string>;
   multiselect: boolean;
@@ -46,8 +49,9 @@ interface ChapterFilterProps {
 const ChapterFilter = (props: ChapterFilterProps) => {
   const [openChapterId, setOpenChapterId] = React.useState<string | null>(null);
   const intl = useIntl();
-  const ref = React.useRef<HTMLDivElement>(null);
-  useTrapTabNavigation(ref as React.MutableRefObject<HTMLElement | null>);
+  const locationFiltersWithContent = props.locationFiltersWithContent ?? noLocationFiltersWithContent;
+  const ref = React.useRef<HTMLElement>(null);
+  useTrapTabNavigation(ref);
 
   React.useEffect(() => {
     const selectedSectionId = Array.from(props.selectedLocationFilters).pop();
@@ -88,14 +92,8 @@ const ChapterFilter = (props: ChapterFilterProps) => {
     {props.multiselect
       ? (
         <AllOrNone
-          onNone={() => setSelectedChapters({
-            remove: Array.from(props.locationFiltersWithContent?.values() ?? []),
-            new: [],
-          })}
-          onAll={() => setSelectedChapters({
-            remove: [],
-            new: Array.from(props.locationFiltersWithContent?.values() ?? []),
-          })}
+          onNone={() => setSelectedChapters({ remove: Array.from(locationFiltersWithContent.values()), new: [] })}
+          onAll={() => setSelectedChapters({ remove: [], new: Array.from(locationFiltersWithContent.values()) })}
           disabled={props.disabled}
         />
       )
@@ -109,7 +107,7 @@ const ChapterFilter = (props: ChapterFilterProps) => {
             if (!children) {
               return <li key={section.id}><ChapterFilterItem
                 selected={props.selectedLocationFilters.has(section.id)}
-                disabled={props.disabled || !props.locationFiltersWithContent?.has(section.id)}
+                disabled={props.disabled || !locationFiltersWithContent.has(section.id)}
                 multiselect={Boolean(props.multiselect)}
                 title={section.title}
                 onChange={() => handleChange(section)}

--- a/src/app/content/components/popUp/ChapterFilter.tsx
+++ b/src/app/content/components/popUp/ChapterFilter.tsx
@@ -16,11 +16,11 @@ const Row = ({ children }: { children: React.ReactNode }) => (
   <div className='chapter-filter-row'>{children}</div>
 );
 
-const Column = ({ children, ...props }: React.HTMLAttributes<HTMLElement>) => (
+const Column = ({ children, ...props }: React.HTMLAttributes<HTMLUListElement>) => (
   <ul className='chapter-filter-column' {...props}>{children}</ul>
 );
 
-const ChapterTitle = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
+const ChapterTitle = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
   <span className={classNames('chapter-filter-title', className)} {...props} />
 );
 
@@ -46,8 +46,8 @@ interface ChapterFilterProps {
 const ChapterFilter = (props: ChapterFilterProps) => {
   const [openChapterId, setOpenChapterId] = React.useState<string | null>(null);
   const intl = useIntl();
-  const ref = React.useRef<HTMLElement>(null);
-  useTrapTabNavigation(ref);
+  const ref = React.useRef<HTMLDivElement>(null);
+  useTrapTabNavigation(ref as React.MutableRefObject<HTMLElement | null>);
 
   React.useEffect(() => {
     const selectedSectionId = Array.from(props.selectedLocationFilters).pop();
@@ -190,19 +190,19 @@ const ChapterFilterItem = (props: ChapterFilterItemProps) => {
   </StyledSectionItem>;
 };
 
-export const StyledDetailsContainer = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
+export const StyledDetailsContainer = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={classNames('chapter-filter-details', className)} {...props} />
 );
 
-export const StyledSummaryButton = ({ className, ...props }: React.ButtonHTMLAttributes<HTMLElement>) => (
+export const StyledSummaryButton = ({ className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
   <PlainButton className={classNames('chapter-filter-summary-button', className)} {...props} />
 );
 
-export const StyledSectionItem = ({ className, ...props }: React.ButtonHTMLAttributes<HTMLElement>) => (
+export const StyledSectionItem = ({ className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
   <PlainButton className={classNames('chapter-filter-section-item', className)} {...props} />
 );
 
-export const StyledChapterFilterItemWrapper = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
+export const StyledChapterFilterItemWrapper = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={classNames('chapter-filter-item-wrapper', className)} {...props} />
 );
 

--- a/src/app/content/components/popUp/ChapterFilter.tsx
+++ b/src/app/content/components/popUp/ChapterFilter.tsx
@@ -9,7 +9,7 @@ import { useTrapTabNavigation } from '../../../reactUtils/focusUtils';
 import { LinkedArchiveTreeNode } from '../../types';
 import { splitTitleParts } from '../../utils/archiveTreeUtils';
 import { AngleIcon, Fieldset } from './Filters';
-import { FiltersChange, LocationFilters } from './types';
+import { FiltersChange, LocationFilters, LocationFiltersWithChildren } from './types';
 import './ChapterFilter.css';
 
 const Row = ({ children }: { children: React.ReactNode }) => (
@@ -24,9 +24,8 @@ const ChapterTitle = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElem
   <span className={classNames('chapter-filter-title', className)} {...props} />
 );
 
-// practice questions doesn't pass locationFiltersWithContent; its location
-// filters always have children, so the lookups that read it are never reached
-// there. Shared so the fallback doesn't allocate on every render.
+// only reachable for the ChapterFilterWithoutContentProps shape below, where
+// nothing reads it. Shared so the fallback doesn't allocate on every render.
 const noLocationFiltersWithContent: Map<string, LinkedArchiveTreeNode> = new Map();
 
 const chunk = <T extends unknown>(sections: T[]) => {
@@ -34,17 +33,33 @@ const chunk = <T extends unknown>(sections: T[]) => {
   return [sections.slice(0, cutoff), sections.slice(cutoff)].filter((arr) => arr.length > 0);
 };
 
-interface ChapterFilterProps {
+interface ChapterFilterCommonProps {
   ariaLabelItemId?: string;
   className?: string;
   disabled?: boolean;
-  locationFilters: LocationFilters;
-  locationFiltersWithContent?: Map<string, LinkedArchiveTreeNode>;
   selectedLocationFilters: Set<string>;
-  multiselect: boolean;
   setFilters: (filters: FiltersChange<LinkedArchiveTreeNode>) => void;
   id: string;
 }
+
+// locationFiltersWithContent decides two things: what All/None dispatches, and
+// whether a childless filter is disabled. Callers that can hit either need it.
+interface ChapterFilterWithContentProps extends ChapterFilterCommonProps {
+  locationFilters: LocationFilters;
+  locationFiltersWithContent: Map<string, LinkedArchiveTreeNode>;
+  multiselect: boolean;
+}
+
+// practice questions hits neither: every one of its filters has children, and
+// single-select renders no All/None. Omitting the map is only allowed for that
+// exact shape so it can't silently disable filters somewhere else.
+interface ChapterFilterWithoutContentProps extends ChapterFilterCommonProps {
+  locationFilters: LocationFiltersWithChildren;
+  locationFiltersWithContent?: undefined;
+  multiselect: false;
+}
+
+type ChapterFilterProps = ChapterFilterWithContentProps | ChapterFilterWithoutContentProps;
 
 const ChapterFilter = (props: ChapterFilterProps) => {
   const [openChapterId, setOpenChapterId] = React.useState<string | null>(null);

--- a/src/app/content/components/popUp/ColorFilter.css
+++ b/src/app/content/components/popUp/ColorFilter.css
@@ -1,0 +1,49 @@
+/* ColorFilter styles - plain CSS version
+ *
+ * Values previously interpolated from theme.ts / PopupConstants.ts are inlined
+ * here with the original expression in a comment.
+ */
+
+/* ColorLabel - the highlight color name next to its swatch */
+.color-filter-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ColorFilter container */
+.color-filter {
+  background: #fff; /* theme.color.white */
+  display: flex;
+  flex-direction: column;
+  color: #424242; /* theme.color.text.default */
+  font-size: 1.4rem;
+
+  /* filters.dropdownContent.padding.topBottom, filters.dropdownContent.padding.sides */
+  padding: 0.8rem 1.6rem;
+  outline: none;
+  z-index: 1;
+  overflow: auto;
+}
+
+.color-filter .all-or-none {
+  margin: 0.8rem 0 0.8rem 0.8rem;
+}
+
+.color-filter .checkbox-label {
+  padding: 0.8rem;
+  text-transform: capitalize;
+}
+
+.color-filter .color-indicator {
+  margin: 0 1.6rem 0 1.6rem;
+}
+
+/* theme.breakpoints.mobileSmall */
+@media screen and (max-width: 30em) {
+  .color-filter {
+    /* mobileMarginSides * 2 */
+    width: calc(100vw - 1.6rem);
+  }
+}

--- a/src/app/content/components/popUp/ColorFilter.tsx
+++ b/src/app/content/components/popUp/ColorFilter.tsx
@@ -2,23 +2,19 @@ import { HighlightColorEnum } from '@openstax/highlighter/dist/api';
 import { HTMLElement } from '@openstax/types/lib.dom';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import styled, { css } from 'styled-components/macro';
+import classNames from 'classnames';
 import AllOrNone from '../../../components/AllOrNone';
 import Checkbox from '../../../components/Checkbox';
 import { useTrapTabNavigation } from '../../../reactUtils/focusUtils';
-import theme from '../../../theme';
 import { highlightStyles } from '../../constants';
 import ColorIndicator from '../../highlights/components/ColorIndicator';
-import { filters, mobileMarginSides } from '../../styles/PopupConstants';
 import { FiltersChange } from './types';
 import { Fieldset } from './Filters';
+import './ColorFilter.css';
 
-const ColorLabel = styled.span`
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
+const ColorLabel = ({ children }: { children: React.ReactNode }) => (
+  <span className='color-filter-label'>{children}</span>
+);
 export interface ColorFilterProps {
   className?: string;
   disabled?: boolean;
@@ -55,7 +51,7 @@ const ColorFilter = ({
     }
   };
 
-  return <div className={className} tabIndex={-1} id={id} ref={ref}>
+  return <div className={classNames('color-filter', className)} tabIndex={-1} id={id} ref={ref}>
     <AllOrNone
       onNone={() => setSelectedColors({ remove: Array.from(colorFiltersWithContent), new: [] })}
       onAll={() => setSelectedColors({ remove: [], new: Array.from(colorFiltersWithContent) })}
@@ -80,31 +76,4 @@ const ColorFilter = ({
   </div>;
 };
 
-export default styled(ColorFilter)`
-  background: ${theme.color.white};
-  display: flex;
-  flex-direction: column;
-  color: ${theme.color.text.default};
-  font-size: 1.4rem;
-  padding: ${filters.dropdownContent.padding.topBottom}rem ${filters.dropdownContent.padding.sides}rem;
-  outline: none;
-  z-index: 1;
-  overflow: auto;
-
-  .all-or-none {
-    margin: 0.8rem 0 0.8rem 0.8rem;
-  }
-
-  .checkbox-label {
-    padding: 0.8rem;
-    text-transform: capitalize;
-  }
-
-  .color-indicator {
-    margin: 0 1.6rem 0 1.6rem;
-  }
-
-  ${theme.breakpoints.mobileSmall(css`
-    width: calc(100vw - ${mobileMarginSides * 2}rem);
-  `)}
-`;
+export default ColorFilter;

--- a/src/app/content/components/popUp/Filters.css
+++ b/src/app/content/components/popUp/Filters.css
@@ -1,0 +1,139 @@
+/* popUp Filters styles - plain CSS version
+ *
+ * Values previously interpolated from theme.ts / PopupConstants.ts are inlined
+ * here with the original expression in a comment.
+ */
+
+/* AngleIcon - the up/down chevron in a filter dropdown toggle */
+.filters-angle-icon {
+  color: #5e6062; /* theme.color.primary.gray.base */
+  width: 1rem; /* filters.dropdownToggle.icon.width */
+  height: 2rem; /* filters.dropdownToggle.icon.height */
+  margin-left: 0.8rem;
+  padding-top: 0.2rem;
+}
+
+.filters-angle-icon.filters-angle-icon-up {
+  transform: rotate(180deg);
+  padding-top: 0;
+  padding-bottom: 0.2rem;
+}
+
+/* Fieldset - groups filter checkboxes behind a visually hidden legend */
+.filters-fieldset {
+  padding: 0;
+  border: none;
+  margin: 0;
+}
+
+/* hiddenButAccessible */
+.filters-fieldset legend {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Toggle - the button that opens a filter dropdown */
+.filters-toggle {
+  position: relative;
+  border-left: 0.1rem solid transparent; /* filters.border */
+  border-right: 0.1rem solid transparent; /* filters.border */
+}
+
+.filters-toggle.filters-toggle-open {
+  z-index: 2;
+  box-shadow: 0 0 0.6rem 0 rgba(0, 0, 0, 0.2);
+  clip-path: inset(0 -0.6rem 0 -0.6rem);
+  background-color: #fff; /* theme.color.white */
+  border-left: 0.1rem solid #d5d5d5; /* filters.border, theme.color.neutral.formBorder */
+  border-right: 0.1rem solid #d5d5d5; /* filters.border, theme.color.neutral.formBorder */
+}
+
+.filters-toggle > div {
+  /* filters.dropdownToggle.topBottom.desktop, filters.dropdownToggle.sides.desktop */
+  padding: 2rem 2.4rem;
+  outline: none;
+  color: #5e6062; /* theme.color.primary.gray.base */
+  font-size: 1.6rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+/* theme.breakpoints.mobile */
+@media screen and (max-width: 75em) {
+  .filters-toggle > div {
+    /* filters.dropdownToggle.topBottom.mobile, filters.dropdownToggle.sides.mobile */
+    padding: 1rem 1.6rem;
+  }
+}
+
+/* FiltersTopBar */
+.popup-filters-top-bar {
+  display: flex;
+  align-items: center;
+  overflow: visible;
+  width: 100%;
+}
+
+/* Filters - the bar the dropdowns and the applied-filters list live in */
+.popup-filters {
+  position: relative;
+  z-index: 2;
+  overflow: visible;
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  background: #fff; /* theme.color.neutral.base */
+  border-bottom: 0.1rem solid #d5d5d5; /* filters.border, theme.color.neutral.formBorder */
+}
+
+.popup-filters .dropdown-toggle {
+  font-weight: bold;
+}
+
+/* Dropdown renders .dropdown-wrapper on its outermost element */
+.popup-filters .dropdown-wrapper > *:not(.dropdown-toggle) {
+  top: calc(100% - 0.1rem); /* filters.border */
+  box-shadow: 0 0 0.6rem 0 rgba(0, 0, 0, 0.2);
+
+  /* filters.valueToSubstractFromVH.desktop */
+  max-height: calc(100vh - 26rem);
+}
+
+/* theme.breakpoints.mobile */
+@media screen and (max-width: 75em) {
+  .popup-filters .dropdown-wrapper > *:not(.dropdown-toggle) {
+    /* filters.valueToSubstractFromVH.mobile */
+    max-height: calc(100vh - 18.4rem);
+  }
+}
+
+/* theme.breakpoints.mobileSmall */
+@media screen and (max-width: 30em) {
+  .popup-filters .dropdown-wrapper {
+    position: initial;
+  }
+
+  .popup-filters .dropdown-wrapper > *:not(.dropdown-toggle) {
+    top: auto;
+    margin-top: -0.1rem; /* filters.border */
+  }
+}
+
+@media print {
+  .popup-filters {
+    padding-left: 0;
+  }
+
+  .popup-filters > *:not(.filters-list) {
+    display: none;
+  }
+}

--- a/src/app/content/components/popUp/Filters.tsx
+++ b/src/app/content/components/popUp/Filters.tsx
@@ -44,8 +44,7 @@ export const Fieldset = ({ className, ...props }: React.FieldsetHTMLAttributes<H
   <fieldset className={classNames('filters-fieldset', className)} {...props} />
 );
 
-interface ToggleProps {
-  className?: string;
+interface ToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
   showLabel?: boolean;
   toggleChildren?: JSX.Element;

--- a/src/app/content/components/popUp/Filters.tsx
+++ b/src/app/content/components/popUp/Filters.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
-import styled, { css } from 'styled-components/macro';
+import classNames from 'classnames';
 import { PlainButton } from '../../../components/Button';
 import Dropdown, { TabHiddenDropdownProps } from '../../../components/Dropdown';
-import theme, { hiddenButAccessible } from '../../../theme';
-import { filters } from '../../styles/PopupConstants';
+import './Filters.css';
 
 interface IconProps extends React.SVGAttributes<SVGSVGElement> {
   className?: string;
@@ -13,10 +12,8 @@ interface IconProps extends React.SVGAttributes<SVGSVGElement> {
 /**
  * Angle down icon for filter dropdowns.
  * SVG path from Font Awesome Free (https://fontawesome.com - MIT License)
- *
- * Note: Wrapped with styled() to enable styled-components component selector references
  */
-function AngleDownIconBase({ className, ...props }: IconProps) {
+function AngleDownIcon({ className, ...props }: IconProps) {
   return (
     <svg
       className={className}
@@ -32,106 +29,66 @@ function AngleDownIconBase({ className, ...props }: IconProps) {
   );
 }
 
-const AngleDownIcon = styled(AngleDownIconBase)``;
+interface AngleIconProps extends IconProps {
+  direction: 'up' | 'down';
+}
 
-export const AngleIcon = styled(AngleDownIcon)`
-  color: ${theme.color.primary.gray.base};
-  width: ${filters.dropdownToggle.icon.width}rem;
-  height: ${filters.dropdownToggle.icon.height}rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-  ${({ direction }: { direction: 'up' | 'down' }) => {
-    if (direction === 'up') {
-      return `
-        transform: rotate(180deg);
-        padding-top: 0;
-        padding-bottom: 0.2rem;
-      `;
-    }
-  }}
-`;
+export const AngleIcon = ({ className, direction, ...props }: AngleIconProps) => (
+  <AngleDownIcon
+    className={classNames('filters-angle-icon', { 'filters-angle-icon-up': direction === 'up' }, className)}
+    {...props}
+  />
+);
 
-export const Fieldset = styled.fieldset`
-  padding: 0;
-  border: none;
-  margin: 0;
-
-  legend {
-    ${hiddenButAccessible}
-  }
-`;
+export const Fieldset = ({ className, ...props }: React.FieldsetHTMLAttributes<HTMLFieldSetElement>) => (
+  <fieldset className={classNames('filters-fieldset', className)} {...props} />
+);
 
 interface ToggleProps {
+  className?: string;
   label: string;
-  showLabel: boolean;
+  showLabel?: boolean;
   toggleChildren?: JSX.Element;
-  isOpen: boolean;
+  isOpen?: boolean;
   ariaLabelId: string;
-  showAngleIcon: boolean;
+  showAngleIcon?: boolean;
   controlsId: string;
 }
-const Toggle = styled(
-  React.forwardRef<HTMLButtonElement, ToggleProps>(
-    (
-      {
-        label,
-        isOpen,
-        ariaLabelId,
-        showAngleIcon = true,
-        showLabel = true,
-        toggleChildren,
-        controlsId,
-        ...props
-      },
-      ref
-    ) => (
-      <PlainButton
-        ref={ref}
-        {...props}
-        aria-label={useIntl().formatMessage(
-          { id: ariaLabelId },
-          { filter: label }
-        )}
-        aria-expanded={isOpen}
-        aria-controls={controlsId}
-      >
-        <div tabIndex={-1}>
-          {showLabel && label}
-          {toggleChildren}
-          {showAngleIcon && <AngleIcon direction={isOpen ? 'up' : 'down'} />}
-        </div>
-      </PlainButton>
-    )
+
+const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(
+  (
+    {
+      className,
+      label,
+      isOpen,
+      ariaLabelId,
+      showAngleIcon = true,
+      showLabel = true,
+      toggleChildren,
+      controlsId,
+      ...props
+    },
+    ref
+  ) => (
+    <PlainButton
+      ref={ref}
+      {...props}
+      className={classNames('filters-toggle', { 'filters-toggle-open': isOpen }, className)}
+      aria-label={useIntl().formatMessage(
+        { id: ariaLabelId },
+        { filter: label }
+      )}
+      aria-expanded={isOpen}
+      aria-controls={controlsId}
+    >
+      <div tabIndex={-1}>
+        {showLabel && label}
+        {toggleChildren}
+        {showAngleIcon && <AngleIcon direction={isOpen ? 'up' : 'down'} />}
+      </div>
+    </PlainButton>
   )
-)`
-  position: relative;
-  border-left: ${filters.border}rem solid transparent;
-  border-right: ${filters.border}rem solid transparent;
-  ${(props: ToggleProps) => props.isOpen
-    ? css`
-      z-index: 2;
-      box-shadow: 0 0 0.6rem 0 rgba(0, 0, 0, 0.2);
-      clip-path: inset(0 -0.6rem 0px -0.6rem);
-      background-color: ${theme.color.white};
-      border-left: ${filters.border}rem solid ${theme.color.neutral.formBorder};
-      border-right: ${filters.border}rem solid ${theme.color.neutral.formBorder};
-    `
-    : null
-  }
-  > div {
-    padding: ${filters.dropdownToggle.topBottom.desktop}rem ${filters.dropdownToggle.sides.desktop}rem;
-    ${theme.breakpoints.mobile(css`
-      padding: ${filters.dropdownToggle.topBottom.mobile}rem ${filters.dropdownToggle.sides.mobile}rem;
-    `)}
-    outline: none;
-    color: ${theme.color.primary.gray.base};
-    font-size: 1.6rem;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-end;
-  }
-`;
+);
 
 type FilterDropdownProps = {
   label: string;
@@ -161,65 +118,18 @@ React.PropsWithChildren<FilterDropdownProps>) => (
   </Dropdown>
 );
 
-export const FiltersTopBar = styled.div`
-  display: flex;
-  align-items: center;
-  overflow: visible;
-  width: 100%;
-`;
+export const FiltersTopBar = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={classNames('popup-filters-top-bar', className)} {...props} />
+);
 
 interface Props {
   className?: string;
 }
 
 const Filters = ({className, children}: React.PropsWithChildren<Props>) => {
-  return <div className={className}>
+  return <div className={classNames('popup-filters', className)}>
     {children}
   </div>;
 };
 
-export default styled(Filters)`
-  position: relative;
-  z-index: 2;
-  overflow: visible;
-  display: flex;
-  flex-flow: row wrap;
-  align-items: center;
-  background: ${theme.color.neutral.base};
-  border-bottom: ${filters.border}rem solid ${theme.color.neutral.formBorder};
-  ${css`
-    .dropdown-toggle {
-      font-weight: bold;
-    }
-
-    ${Dropdown} {
-      & > *:not(.dropdown-toggle) {
-        top: calc(100% - ${filters.border}rem);
-        box-shadow: 0 0 0.6rem 0 rgba(0, 0, 0, 0.2);
-        max-height: calc(100vh - ${filters.valueToSubstractFromVH.desktop}rem);
-        ${theme.breakpoints.mobile(css`
-          max-height: calc(100vh - ${filters.valueToSubstractFromVH.mobile}rem);
-        `)}
-      }
-
-      ${theme.breakpoints.mobileSmall(css`
-        position: initial;
-
-        & > *:not(.dropdown-toggle) {
-          top: auto;
-          margin-top: -${filters.border}rem;
-        }
-      `)}
-    }
-  `}
-
-  @media print {
-    padding-left: 0;
-  }
-
-  ${css`
-    > *:not(.filters-list) {
-      @media print { display: none; }
-    }
-  `}
-`;
+export default Filters;

--- a/src/app/content/components/popUp/__snapshots__/ChapterFilter.spec.tsx.snap
+++ b/src/app/content/components/popUp/__snapshots__/ChapterFilter.spec.tsx.snap
@@ -1,119 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChapterFilter matches snapshot 1`] = `
-.c1 {
-  padding: 0;
-  border: none;
-  margin: 0;
-}
-
-.c1 legend {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  -webkit-clip: rect(0,0,0,0);
-  clip: rect(0,0,0,0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow-x: hidden;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  white-space: nowrap;
-  margin-left: 0.8rem;
-}
-
-.c4 > * {
-  overflow: hidden;
-}
-
-.c4 .os-text {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  text-overflow: ellipsis;
-}
-
-.c4 .os-divider {
-  margin: 0 0.4rem;
-}
-
-.c0 {
-  color: #424242;
-  background: #fff;
-  font-size: 1.4rem;
-  padding: 0.8rem 1.6rem;
-  outline: none;
-  overflow: auto;
-  z-index: 1;
-}
-
-.c0 .all-or-none {
-  margin: 0.8rem 0 0.8rem 0.8rem;
-}
-
-.c0 .checkbox-label {
-  padding: 0.8rem;
-}
-
-.c0 .color-indicator {
-  margin: 0 1.6rem 0 1.6rem;
-}
-
-.c0 .c5:last-child {
-  border-bottom: none;
-}
-
-@media screen and (max-width:75em) {
-  .c2 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    overflow: hidden;
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c0 {
-    width: calc(100vw - 1.6rem);
-  }
-}
-
 <div
-  className="c0"
+  className="chapter-filter"
   tabIndex={-1}
 >
   <div
@@ -151,17 +40,17 @@ exports[`ChapterFilter matches snapshot 1`] = `
     </button>
   </div>
   <fieldset
-    className="c1"
+    className="filters-fieldset"
   >
     <legend>
       Filter by chapters
     </legend>
     <div
-      className="c2"
+      className="chapter-filter-row"
     >
       <ul
         aria-label="Filter by chapters"
-        className="c3"
+        className="chapter-filter-column"
       >
         <li>
           <label
@@ -191,7 +80,7 @@ exports[`ChapterFilter matches snapshot 1`] = `
               </svg>
             </span>
             <span
-              className="c4"
+              className="chapter-filter-title"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<span class=\\"os-text\\">Test Page 1</span>",
@@ -228,7 +117,7 @@ exports[`ChapterFilter matches snapshot 1`] = `
               </svg>
             </span>
             <span
-              className="c4"
+              className="chapter-filter-title"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<span class=\\"os-number\\">1</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 1</span>",
@@ -265,7 +154,7 @@ exports[`ChapterFilter matches snapshot 1`] = `
               </svg>
             </span>
             <span
-              className="c4"
+              className="chapter-filter-title"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<span class=\\"os-number\\">1</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 1.1</span>",
@@ -302,7 +191,7 @@ exports[`ChapterFilter matches snapshot 1`] = `
               </svg>
             </span>
             <span
-              className="c4"
+              className="chapter-filter-title"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<span class=\\"os-number\\">2</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 2</span>",
@@ -339,7 +228,7 @@ exports[`ChapterFilter matches snapshot 1`] = `
               </svg>
             </span>
             <span
-              className="c4"
+              className="chapter-filter-title"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<span class=\\"os-number\\">3</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 3</span>",
@@ -376,7 +265,7 @@ exports[`ChapterFilter matches snapshot 1`] = `
               </svg>
             </span>
             <span
-              className="c4"
+              className="chapter-filter-title"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<span class=\\"os-number\\">4</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 4</span>",
@@ -413,7 +302,7 @@ exports[`ChapterFilter matches snapshot 1`] = `
               </svg>
             </span>
             <span
-              className="c4"
+              className="chapter-filter-title"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<span class=\\"os-number\\">10</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 5</span>",
@@ -450,7 +339,7 @@ exports[`ChapterFilter matches snapshot 1`] = `
               </svg>
             </span>
             <span
-              className="c4"
+              className="chapter-filter-title"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<span class=\\"os-number\\">12</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 6</span>",
@@ -487,7 +376,7 @@ exports[`ChapterFilter matches snapshot 1`] = `
               </svg>
             </span>
             <span
-              className="c4"
+              className="chapter-filter-title"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<span class=\\"os-number\\">A</span><span class=\\"os-divider\\"> | </span><span class=\\"os-text\\">Atomic Masses</span>",
@@ -524,7 +413,7 @@ exports[`ChapterFilter matches snapshot 1`] = `
               </svg>
             </span>
             <span
-              className="c4"
+              className="chapter-filter-title"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<span class=\\"os-number\\">D</span><span class=\\"os-divider\\"> | </span><span class=\\"os-text\\">Glossary of Key Symbols and Notation</span>",
@@ -561,7 +450,7 @@ exports[`ChapterFilter matches snapshot 1`] = `
               </svg>
             </span>
             <span
-              className="c4"
+              className="chapter-filter-title"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<span class=\\"os-text\\">Test Page for Generic Styles</span>",

--- a/src/app/content/components/popUp/__snapshots__/ColorFilter.spec.tsx.snap
+++ b/src/app/content/components/popUp/__snapshots__/ColorFilter.spec.tsx.snap
@@ -1,72 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorFilter matches snapshot 1`] = `
-.c1 {
-  padding: 0;
-  border: none;
-  margin: 0;
-}
-
-.c1 legend {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  -webkit-clip: rect(0,0,0,0);
-  clip: rect(0,0,0,0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.c2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.c0 {
-  background: #fff;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  color: #424242;
-  font-size: 1.4rem;
-  padding: 0.8rem 1.6rem;
-  outline: none;
-  z-index: 1;
-  overflow: auto;
-}
-
-.c0 .all-or-none {
-  margin: 0.8rem 0 0.8rem 0.8rem;
-}
-
-.c0 .checkbox-label {
-  padding: 0.8rem;
-  text-transform: capitalize;
-}
-
-.c0 .color-indicator {
-  margin: 0 1.6rem 0 1.6rem;
-}
-
-@media screen and (max-width:30em) {
-  .c0 {
-    width: calc(100vw - 1.6rem);
-  }
-}
-
 <div
-  className="c0"
+  className="color-filter"
   id="color-filter"
   tabIndex={-1}
 >
@@ -105,7 +41,7 @@ exports[`ColorFilter matches snapshot 1`] = `
     </button>
   </div>
   <fieldset
-    className="c1"
+    className="filters-fieldset"
   >
     <legend>
       Filter by colors
@@ -165,7 +101,7 @@ exports[`ColorFilter matches snapshot 1`] = `
         />
       </div>
       <span
-        className="c2"
+        className="color-filter-label"
       >
         yellow
       </span>
@@ -225,7 +161,7 @@ exports[`ColorFilter matches snapshot 1`] = `
         />
       </div>
       <span
-        className="c2"
+        className="color-filter-label"
       >
         green
       </span>
@@ -285,7 +221,7 @@ exports[`ColorFilter matches snapshot 1`] = `
         />
       </div>
       <span
-        className="c2"
+        className="color-filter-label"
       >
         blue
       </span>
@@ -345,7 +281,7 @@ exports[`ColorFilter matches snapshot 1`] = `
         />
       </div>
       <span
-        className="c2"
+        className="color-filter-label"
       >
         purple
       </span>
@@ -405,7 +341,7 @@ exports[`ColorFilter matches snapshot 1`] = `
         />
       </div>
       <span
-        className="c2"
+        className="color-filter-label"
       >
         pink
       </span>

--- a/src/app/content/components/popUp/__snapshots__/Filters.spec.tsx.snap
+++ b/src/app/content/components/popUp/__snapshots__/Filters.spec.tsx.snap
@@ -1,133 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Filters matches snapshot 1`] = `
-.c4 {
-  color: #5e6062;
-  width: 1rem;
-  height: 2rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-}
-
-.c3 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-}
-
-.c3 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: visible;
-  width: 100%;
-}
-
-.c0 {
-  position: relative;
-  z-index: 2;
-  overflow: visible;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #fff;
-  border-bottom: 0.1rem solid #d5d5d5;
-}
-
-.c0 .dropdown-toggle {
-  font-weight: bold;
-}
-
-.c0 .c2 > *:not(.dropdown-toggle) {
-  top: calc(100% - 0.1rem);
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  max-height: calc(100vh - 26rem);
-}
-
-@media screen and (max-width:75em) {
-  .c3 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    max-height: calc(100vh - 18.4rem);
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c0 .c2 {
-    position: initial;
-  }
-
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    top: auto;
-    margin-top: -0.1rem;
-  }
-}
-
-@media print {
-  .c0 {
-    padding-left: 0;
-  }
-}
-
-@media print {
-  .c0 > *:not(.filters-list) {
-    display: none;
-  }
-}
-
 <div
-  className="c0"
+  className="popup-filters"
 >
   <div
-    className="c1"
+    className="popup-filters-top-bar"
   >
     <div
-      className="dropdown-wrapper c2 "
+      className="dropdown-wrapper"
     >
       <button
         aria-controls="summary-filter-chapter"
         aria-expanded={false}
         aria-label="Filter highlights by Chapter"
-        className="plain-button c3 dropdown-toggle"
+        className="plain-button filters-toggle dropdown-toggle"
         data-analytics-label="Filter highlights by Chapter"
         onClick={[Function]}
       >
@@ -137,8 +24,7 @@ exports[`Filters matches snapshot 1`] = `
           Chapter
           <svg
             aria-hidden="true"
-            className="c4"
-            direction="down"
+            className="filters-angle-icon"
             viewBox="0 0 320 512"
           >
             <path
@@ -150,13 +36,13 @@ exports[`Filters matches snapshot 1`] = `
       </button>
     </div>
     <div
-      className="dropdown-wrapper c2 "
+      className="dropdown-wrapper"
     >
       <button
         aria-controls="summary-filter-color"
         aria-expanded={false}
         aria-label="Filter highlights by Color"
-        className="plain-button c3 dropdown-toggle"
+        className="plain-button filters-toggle dropdown-toggle"
         data-analytics-label="Filter highlights by Color"
         onClick={[Function]}
       >
@@ -166,8 +52,7 @@ exports[`Filters matches snapshot 1`] = `
           Color
           <svg
             aria-hidden="true"
-            className="c4"
-            direction="down"
+            className="filters-angle-icon"
             viewBox="0 0 320 512"
           >
             <path
@@ -446,187 +331,20 @@ exports[`Filters matches snapshot 1`] = `
 `;
 
 exports[`Filters matches snapshot when open color filters 1`] = `
-.c4 {
-  color: #5e6062;
-  width: 1rem;
-  height: 2rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-}
-
-.c6 {
-  color: #5e6062;
-  width: 1rem;
-  height: 2rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  padding-top: 0;
-  padding-bottom: 0.2rem;
-}
-
-.c3 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-}
-
-.c3 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c5 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-  z-index: 2;
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  -webkit-clip-path: inset(0 -0.6rem 0px -0.6rem);
-  clip-path: inset(0 -0.6rem 0px -0.6rem);
-  background-color: #fff;
-  border-left: 0.1rem solid #d5d5d5;
-  border-right: 0.1rem solid #d5d5d5;
-}
-
-.c5 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: visible;
-  width: 100%;
-}
-
-.c0 {
-  position: relative;
-  z-index: 2;
-  overflow: visible;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #fff;
-  border-bottom: 0.1rem solid #d5d5d5;
-}
-
-.c0 .dropdown-toggle {
-  font-weight: bold;
-}
-
-.c0 .c2 > *:not(.dropdown-toggle) {
-  top: calc(100% - 0.1rem);
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  max-height: calc(100vh - 26rem);
-}
-
-@media screen and (max-width:75em) {
-  .c3 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c5 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    max-height: calc(100vh - 18.4rem);
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c0 .c2 {
-    position: initial;
-  }
-
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    top: auto;
-    margin-top: -0.1rem;
-  }
-}
-
-@media print {
-  .c0 {
-    padding-left: 0;
-  }
-}
-
-@media print {
-  .c0 > *:not(.filters-list) {
-    display: none;
-  }
-}
-
 <div
-  className="c0"
+  className="popup-filters"
 >
   <div
-    className="c1"
+    className="popup-filters-top-bar"
   >
     <div
-      className="dropdown-wrapper c2 "
+      className="dropdown-wrapper"
     >
       <button
         aria-controls="summary-filter-chapter"
         aria-expanded={false}
         aria-label="Filter highlights by Chapter"
-        className="plain-button c3 dropdown-toggle"
+        className="plain-button filters-toggle dropdown-toggle"
         data-analytics-label="Filter highlights by Chapter"
         onClick={[Function]}
       >
@@ -636,8 +354,7 @@ exports[`Filters matches snapshot when open color filters 1`] = `
           Chapter
           <svg
             aria-hidden="true"
-            className="c4"
-            direction="down"
+            className="filters-angle-icon"
             viewBox="0 0 320 512"
           >
             <path
@@ -649,13 +366,13 @@ exports[`Filters matches snapshot when open color filters 1`] = `
       </button>
     </div>
     <div
-      className="dropdown-wrapper c2 "
+      className="dropdown-wrapper"
     >
       <button
         aria-controls="summary-filter-color"
         aria-expanded={true}
         aria-label="Filter highlights by Color"
-        className="plain-button c5 dropdown-toggle"
+        className="plain-button filters-toggle filters-toggle-open dropdown-toggle"
         data-analytics-label="Filter highlights by Color"
         onClick={[Function]}
       >
@@ -665,8 +382,7 @@ exports[`Filters matches snapshot when open color filters 1`] = `
           Color
           <svg
             aria-hidden="true"
-            className="c6"
-            direction="up"
+            className="filters-angle-icon filters-angle-icon-up"
             viewBox="0 0 320 512"
           >
             <path

--- a/src/app/content/highlights/components/SummaryPopup/__snapshots__/ContextMenu.spec.tsx.snap
+++ b/src/app/content/highlights/components/SummaryPopup/__snapshots__/ContextMenu.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`ContextMenu match snapshot when closed 1`] = `
   }
 >
   <div
-    className="dropdown-wrapper "
+    className="dropdown-wrapper"
     data-dropdown={true}
   >
     <button
@@ -54,7 +54,7 @@ exports[`ContextMenu match snapshot when open 1`] = `
   }
 >
   <div
-    className="dropdown-wrapper "
+    className="dropdown-wrapper"
     data-dropdown={true}
   >
     <button

--- a/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
+++ b/src/app/content/highlights/components/SummaryPopup/__snapshots__/Filters.spec.tsx.snap
@@ -1,260 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Filters matches snapshot and renders proper aria labels 1`] = `
-.c4 {
-  color: #5e6062;
-  width: 1rem;
-  height: 2rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  padding-top: 0;
-  padding-bottom: 0.2rem;
-}
-
-.c6 {
-  padding: 0;
-  border: none;
-  margin: 0;
-}
-
-.c6 legend {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  -webkit-clip: rect(0,0,0,0);
-  clip: rect(0,0,0,0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.c3 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-  z-index: 2;
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  -webkit-clip-path: inset(0 -0.6rem 0px -0.6rem);
-  clip-path: inset(0 -0.6rem 0px -0.6rem);
-  background-color: #fff;
-  border-left: 0.1rem solid #d5d5d5;
-  border-right: 0.1rem solid #d5d5d5;
-}
-
-.c3 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: visible;
-  width: 100%;
-}
-
-.c0 {
-  position: relative;
-  z-index: 2;
-  overflow: visible;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #fff;
-  border-bottom: 0.1rem solid #d5d5d5;
-}
-
-.c0 .dropdown-toggle {
-  font-weight: bold;
-}
-
-.c0 .c2 > *:not(.dropdown-toggle) {
-  top: calc(100% - 0.1rem);
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  max-height: calc(100vh - 26rem);
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.c5 {
-  color: #424242;
-  background: #fff;
-  font-size: 1.4rem;
-  padding: 0.8rem 1.6rem;
-  outline: none;
-  overflow: auto;
-  z-index: 1;
-}
-
-.c5 .all-or-none {
-  margin: 0.8rem 0 0.8rem 0.8rem;
-}
-
-.c5 .checkbox-label {
-  padding: 0.8rem;
-}
-
-.c5 .color-indicator {
-  margin: 0 1.6rem 0 1.6rem;
-}
-
-.c5 .c10:last-child {
-  border-bottom: none;
-}
-
-.c9 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.c8 {
-  background: #fff;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  color: #424242;
-  font-size: 1.4rem;
-  padding: 0.8rem 1.6rem;
-  outline: none;
-  z-index: 1;
-  overflow: auto;
-}
-
-.c8 .all-or-none {
-  margin: 0.8rem 0 0.8rem 0.8rem;
-}
-
-.c8 .checkbox-label {
-  padding: 0.8rem;
-  text-transform: capitalize;
-}
-
-.c8 .color-indicator {
-  margin: 0 1.6rem 0 1.6rem;
-}
-
-@media screen and (max-width:75em) {
-  .c3 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    max-height: calc(100vh - 18.4rem);
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c0 .c2 {
-    position: initial;
-  }
-
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    top: auto;
-    margin-top: -0.1rem;
-  }
-}
-
-@media print {
-  .c0 {
-    padding-left: 0;
-  }
-}
-
-@media print {
-  .c0 > *:not(.filters-list) {
-    display: none;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c7 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    overflow: hidden;
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c5 {
-    width: calc(100vw - 1.6rem);
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c8 {
-    width: calc(100vw - 1.6rem);
-  }
-}
-
 <div
-  className="c0"
+  className="popup-filters"
 >
   <div
-    className="c1"
+    className="popup-filters-top-bar"
   >
     <div
-      className="dropdown-wrapper c2 "
+      className="dropdown-wrapper"
     >
       <button
         aria-controls="summary-filter-chapter"
         aria-expanded={true}
         aria-label="Filter highlights by Chapter"
-        className="plain-button c3 dropdown-toggle"
+        className="plain-button filters-toggle filters-toggle-open dropdown-toggle"
         data-analytics-label="Filter highlights by Chapter"
         onClick={[Function]}
       >
@@ -264,8 +24,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
           Chapter
           <svg
             aria-hidden="true"
-            className="c4"
-            direction="up"
+            className="filters-angle-icon filters-angle-icon-up"
             viewBox="0 0 320 512"
           >
             <path
@@ -279,7 +38,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
         className="dropdown-menu"
       >
         <div
-          className="c5"
+          className="chapter-filter"
           id="summary-filter-chapter"
           tabIndex={-1}
         >
@@ -318,26 +77,26 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
             </button>
           </div>
           <fieldset
-            className="c6"
+            className="filters-fieldset"
           >
             <legend>
               Filter by chapters
             </legend>
             <div
-              className="c7"
+              className="chapter-filter-row"
             />
           </fieldset>
         </div>
       </div>
     </div>
     <div
-      className="dropdown-wrapper c2 "
+      className="dropdown-wrapper"
     >
       <button
         aria-controls="summary-filter-color"
         aria-expanded={true}
         aria-label="Filter highlights by Color"
-        className="plain-button c3 dropdown-toggle"
+        className="plain-button filters-toggle filters-toggle-open dropdown-toggle"
         data-analytics-label="Filter highlights by Color"
         onClick={[Function]}
       >
@@ -347,8 +106,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
           Color
           <svg
             aria-hidden="true"
-            className="c4"
-            direction="up"
+            className="filters-angle-icon filters-angle-icon-up"
             viewBox="0 0 320 512"
           >
             <path
@@ -362,7 +120,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
         className="dropdown-menu"
       >
         <div
-          className="c8"
+          className="color-filter"
           id="summary-filter-color"
           tabIndex={-1}
         >
@@ -401,7 +159,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
             </button>
           </div>
           <fieldset
-            className="c6"
+            className="filters-fieldset"
           >
             <legend>
               Filter by colors
@@ -461,7 +219,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 />
               </div>
               <span
-                className="c9"
+                className="color-filter-label"
               >
                 yellow
               </span>
@@ -521,7 +279,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 />
               </div>
               <span
-                className="c9"
+                className="color-filter-label"
               >
                 green
               </span>
@@ -581,7 +339,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 />
               </div>
               <span
-                className="c9"
+                className="color-filter-label"
               >
                 blue
               </span>
@@ -641,7 +399,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 />
               </div>
               <span
-                className="c9"
+                className="color-filter-label"
               >
                 purple
               </span>
@@ -701,7 +459,7 @@ exports[`Filters matches snapshot and renders proper aria labels 1`] = `
                 />
               </div>
               <span
-                className="c9"
+                className="color-filter-label"
               >
                 pink
               </span>

--- a/src/app/content/practiceQuestions/components/Filters.tsx
+++ b/src/app/content/practiceQuestions/components/Filters.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import ChapterFilter from '../../components/popUp/ChapterFilter';
 import Filters, { FilterDropdown, FiltersTopBar } from '../../components/popUp/Filters';
 import { FiltersChange } from '../../components/popUp/types';
-import { LinkedArchiveTreeSection } from '../../types';
+import { LinkedArchiveTreeNode, LinkedArchiveTreeSection } from '../../types';
 import { setSelectedSection } from '../actions';
 import * as selectors from '../selectors';
 import './Filters.css';
@@ -13,14 +13,16 @@ export default () => {
   const locationFilters = useSelector(selectors.practiceQuestionsLocationFilters);
   const selectedSection = useSelector(selectors.selectedSection);
   const dispatch = useDispatch();
-  const setFilters = React.useCallback((change: FiltersChange<LinkedArchiveTreeSection>) => {
+  const setFilters = React.useCallback((change: FiltersChange<LinkedArchiveTreeNode>) => {
     const clickedSection = change.new.pop();
     if (!clickedSection) {
       // user clicked on the selected section
       setOpen(false);
       return;
     }
-    dispatch(setSelectedSection(clickedSection));
+    // practice questions location filters always have children, so ChapterFilter
+    // only ever hands back one of those children, which is a section
+    dispatch(setSelectedSection(clickedSection as LinkedArchiveTreeSection));
     setOpen(false);
   }, [dispatch]);
   const selectedLocationFilters = React.useMemo(

--- a/src/app/content/practiceQuestions/components/__snapshots__/Filters.spec.tsx.snap
+++ b/src/app/content/practiceQuestions/components/__snapshots__/Filters.spec.tsx.snap
@@ -1,133 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Filters ChapterFilter matches snapshot when it is closed 1`] = `
-.c4 {
-  color: #5e6062;
-  width: 1rem;
-  height: 2rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-}
-
-.c3 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-}
-
-.c3 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: visible;
-  width: 100%;
-}
-
-.c0 {
-  position: relative;
-  z-index: 2;
-  overflow: visible;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #fff;
-  border-bottom: 0.1rem solid #d5d5d5;
-}
-
-.c0 .dropdown-toggle {
-  font-weight: bold;
-}
-
-.c0 .c2 > *:not(.dropdown-toggle) {
-  top: calc(100% - 0.1rem);
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  max-height: calc(100vh - 26rem);
-}
-
-@media screen and (max-width:75em) {
-  .c3 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    max-height: calc(100vh - 18.4rem);
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c0 .c2 {
-    position: initial;
-  }
-
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    top: auto;
-    margin-top: -0.1rem;
-  }
-}
-
-@media print {
-  .c0 {
-    padding-left: 0;
-  }
-}
-
-@media print {
-  .c0 > *:not(.filters-list) {
-    display: none;
-  }
-}
-
 <div
-  className="c0"
+  className="popup-filters"
 >
   <div
-    className="c1"
+    className="popup-filters-top-bar"
   >
     <div
-      className="dropdown-wrapper c2 "
+      className="dropdown-wrapper"
     >
       <button
         aria-controls="practice-filter-chapter"
         aria-expanded={false}
         aria-label="Select Practice Questions by Chapter & Section"
-        className="plain-button c3 dropdown-toggle"
+        className="plain-button filters-toggle dropdown-toggle"
         data-analytics-label="Filter PQ by Chapter & Section"
         onClick={[Function]}
       >
@@ -137,8 +24,7 @@ exports[`Filters ChapterFilter matches snapshot when it is closed 1`] = `
           Chapter & Section
           <svg
             aria-hidden="true"
-            className="c4"
-            direction="down"
+            className="filters-angle-icon"
             viewBox="0 0 320 512"
           >
             <path
@@ -154,334 +40,20 @@ exports[`Filters ChapterFilter matches snapshot when it is closed 1`] = `
 `;
 
 exports[`Filters ChapterFilter matches snapshot when open with selected section 1`] = `
-.c15 {
-  color: #5e6062;
-  width: 1rem;
-  height: 2rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-}
-
-.c5 {
-  color: #5e6062;
-  width: 1rem;
-  height: 2rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  padding-top: 0;
-  padding-bottom: 0.2rem;
-}
-
-.c7 {
-  padding: 0;
-  border: none;
-  margin: 0;
-}
-
-.c7 legend {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  -webkit-clip: rect(0,0,0,0);
-  clip: rect(0,0,0,0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.c3 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-  z-index: 2;
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  -webkit-clip-path: inset(0 -0.6rem 0px -0.6rem);
-  clip-path: inset(0 -0.6rem 0px -0.6rem);
-  background-color: #fff;
-  border-left: 0.1rem solid #d5d5d5;
-  border-right: 0.1rem solid #d5d5d5;
-}
-
-.c3 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: visible;
-  width: 100%;
-}
-
-.c0 {
-  position: relative;
-  z-index: 2;
-  overflow: visible;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #fff;
-  border-bottom: 0.1rem solid #d5d5d5;
-}
-
-.c0 .dropdown-toggle {
-  font-weight: bold;
-}
-
-.c0 .c2 > *:not(.dropdown-toggle) {
-  top: calc(100% - 0.1rem);
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  max-height: calc(100vh - 26rem);
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow-x: hidden;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  white-space: nowrap;
-  margin-left: 0.8rem;
-}
-
-.c14 > * {
-  overflow: hidden;
-}
-
-.c14 .os-text {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  text-overflow: ellipsis;
-}
-
-.c14 .os-divider {
-  margin: 0 0.4rem;
-}
-
-.c11 {
-  width: 400px;
-  border-bottom: 1px solid #d5d5d5;
-  overflow: visible;
-}
-
-.c12 {
-  display: block;
-  width: 100%;
-  padding: 1rem 1.6rem;
-  text-align: left;
-}
-
-.c12 .c13 {
-  float: left;
-  margin-left: 0;
-  text-align: left;
-}
-
-.c12 .c4 {
-  float: right;
-}
-
-.c12::after {
-  content: "";
-  display: table;
-  clear: both;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 4rem;
-  width: 100%;
-  text-align: left;
-  font-size: 1.4rem;
-  color: #424242;
-}
-
-.c17[aria-current="true"] {
-  color: #027EB5;
-}
-
-.c17:hover,
-.c17:focus {
-  background-color: #f1f1f1;
-  color: #0064A0;
-}
-
-.c17 .c13 {
-  padding-left: 2.5rem;
-  width: 95%;
-}
-
-.c16 {
-  overflow: visible;
-}
-
-.c6 {
-  color: #424242;
-  background: #fff;
-  font-size: 1.4rem;
-  padding: 0.8rem 1.6rem;
-  outline: none;
-  overflow: auto;
-  z-index: 1;
-}
-
-.c6 .all-or-none {
-  margin: 0.8rem 0 0.8rem 0.8rem;
-}
-
-.c6 .checkbox-label {
-  padding: 0.8rem;
-}
-
-.c6 .color-indicator {
-  margin: 0 1.6rem 0 1.6rem;
-}
-
-.c6 .c10:last-child {
-  border-bottom: none;
-}
-
-@media screen and (max-width:75em) {
-  .c3 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    max-height: calc(100vh - 18.4rem);
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c0 .c2 {
-    position: initial;
-  }
-
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    top: auto;
-    margin-top: -0.1rem;
-  }
-}
-
-@media print {
-  .c0 {
-    padding-left: 0;
-  }
-}
-
-@media print {
-  .c0 > *:not(.filters-list) {
-    display: none;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c8 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    overflow: hidden;
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c11 {
-    width: 100%;
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c6 {
-    width: calc(100vw - 1.6rem);
-  }
-}
-
 <div
-  className="c0"
+  className="popup-filters"
 >
   <div
-    className="c1"
+    className="popup-filters-top-bar"
   >
     <div
-      className="dropdown-wrapper c2 "
+      className="dropdown-wrapper"
     >
       <button
         aria-controls="practice-filter-chapter"
         aria-expanded={true}
         aria-label="Select Practice Questions by Chapter & Section"
-        className="plain-button c3 dropdown-toggle"
+        className="plain-button filters-toggle filters-toggle-open dropdown-toggle"
         data-analytics-label="Filter PQ by Chapter & Section"
         onClick={[Function]}
       >
@@ -491,8 +63,7 @@ exports[`Filters ChapterFilter matches snapshot when open with selected section 
           Chapter & Section
           <svg
             aria-hidden="true"
-            className="c4 c5"
-            direction="up"
+            className="filters-angle-icon filters-angle-icon-up"
             viewBox="0 0 320 512"
           >
             <path
@@ -506,35 +77,35 @@ exports[`Filters ChapterFilter matches snapshot when open with selected section 
         className="dropdown-menu"
       >
         <div
-          className="c6 practice-questions-chapter-filters"
+          className="chapter-filter practice-questions-chapter-filters"
           id="practice-filter-chapter"
           tabIndex={-1}
         >
           <fieldset
-            className="c7"
+            className="filters-fieldset"
           >
             <legend>
               Filter by chapters
             </legend>
             <div
-              className="c8"
+              className="chapter-filter-row"
             >
               <ul
                 aria-label="Filter by chapters"
-                className="c9"
+                className="chapter-filter-column"
               >
                 <li>
                   <div
-                    className="c10 c11"
+                    className="chapter-filter-details"
                   >
                     <button
                       aria-controls="practice-filter-chapter-content-testbook1-testchapter1-uuid"
                       aria-expanded={false}
-                      className="plain-button c12"
+                      className="plain-button chapter-filter-summary-button"
                       onClick={[Function]}
                     >
                       <span
-                        className="c13 c14"
+                        className="chapter-filter-title"
                         dangerouslySetInnerHTML={
                           Object {
                             "__html": "chapterId",
@@ -543,8 +114,7 @@ exports[`Filters ChapterFilter matches snapshot when open with selected section 
                       />
                       <svg
                         aria-hidden="true"
-                        className="c4 c15"
-                        direction="down"
+                        className="filters-angle-icon"
                         viewBox="0 0 320 512"
                       >
                         <path
@@ -555,18 +125,18 @@ exports[`Filters ChapterFilter matches snapshot when open with selected section 
                     </button>
                     <div
                       aria-hidden={true}
-                      className="c16"
+                      className="chapter-filter-item-wrapper"
                       hidden={true}
                       id="practice-filter-chapter-content-testbook1-testchapter1-uuid"
                     >
                       <button
                         aria-label="Select Practice Questions by  section1"
-                        className="plain-button c17"
+                        className="plain-button chapter-filter-section-item"
                         data-analytics-label="Filter PQ by  section1"
                         onClick={[Function]}
                       >
                         <span
-                          className="c13 c14"
+                          className="chapter-filter-title"
                           dangerouslySetInnerHTML={
                             Object {
                               "__html": "section1",
@@ -576,12 +146,12 @@ exports[`Filters ChapterFilter matches snapshot when open with selected section 
                       </button>
                       <button
                         aria-label="Select Practice Questions by  section2"
-                        className="plain-button c17"
+                        className="plain-button chapter-filter-section-item"
                         data-analytics-label="Filter PQ by  section2"
                         onClick={[Function]}
                       >
                         <span
-                          className="c13 c14"
+                          className="chapter-filter-title"
                           dangerouslySetInnerHTML={
                             Object {
                               "__html": "section2",
@@ -594,16 +164,16 @@ exports[`Filters ChapterFilter matches snapshot when open with selected section 
                 </li>
                 <li>
                   <div
-                    className="c10 c11"
+                    className="chapter-filter-details"
                   >
                     <button
                       aria-controls="practice-filter-chapter-content-testbook1-testchapter2-uuid"
                       aria-expanded={true}
-                      className="plain-button c12"
+                      className="plain-button chapter-filter-summary-button"
                       onClick={[Function]}
                     >
                       <span
-                        className="c13 c14"
+                        className="chapter-filter-title"
                         dangerouslySetInnerHTML={
                           Object {
                             "__html": "chapterId2",
@@ -612,8 +182,7 @@ exports[`Filters ChapterFilter matches snapshot when open with selected section 
                       />
                       <svg
                         aria-hidden="true"
-                        className="c4 c5"
-                        direction="up"
+                        className="filters-angle-icon filters-angle-icon-up"
                         viewBox="0 0 320 512"
                       >
                         <path
@@ -624,19 +193,19 @@ exports[`Filters ChapterFilter matches snapshot when open with selected section 
                     </button>
                     <div
                       aria-hidden={false}
-                      className="c16"
+                      className="chapter-filter-item-wrapper"
                       hidden={false}
                       id="practice-filter-chapter-content-testbook1-testchapter2-uuid"
                     >
                       <button
                         aria-current="true"
                         aria-label="Select Practice Questions by  section21"
-                        className="plain-button c17"
+                        className="plain-button chapter-filter-section-item"
                         data-analytics-label="Filter PQ by  section21"
                         onClick={[Function]}
                       >
                         <span
-                          className="c13 c14"
+                          className="chapter-filter-title"
                           dangerouslySetInnerHTML={
                             Object {
                               "__html": "section21",
@@ -658,334 +227,20 @@ exports[`Filters ChapterFilter matches snapshot when open with selected section 
 `;
 
 exports[`Filters ChapterFilter matches snapshot when open without selected section 1`] = `
-.c15 {
-  color: #5e6062;
-  width: 1rem;
-  height: 2rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-}
-
-.c5 {
-  color: #5e6062;
-  width: 1rem;
-  height: 2rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  padding-top: 0;
-  padding-bottom: 0.2rem;
-}
-
-.c7 {
-  padding: 0;
-  border: none;
-  margin: 0;
-}
-
-.c7 legend {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  -webkit-clip: rect(0,0,0,0);
-  clip: rect(0,0,0,0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.c3 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-  z-index: 2;
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  -webkit-clip-path: inset(0 -0.6rem 0px -0.6rem);
-  clip-path: inset(0 -0.6rem 0px -0.6rem);
-  background-color: #fff;
-  border-left: 0.1rem solid #d5d5d5;
-  border-right: 0.1rem solid #d5d5d5;
-}
-
-.c3 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: visible;
-  width: 100%;
-}
-
-.c0 {
-  position: relative;
-  z-index: 2;
-  overflow: visible;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #fff;
-  border-bottom: 0.1rem solid #d5d5d5;
-}
-
-.c0 .dropdown-toggle {
-  font-weight: bold;
-}
-
-.c0 .c2 > *:not(.dropdown-toggle) {
-  top: calc(100% - 0.1rem);
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  max-height: calc(100vh - 26rem);
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow-x: hidden;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  white-space: nowrap;
-  margin-left: 0.8rem;
-}
-
-.c14 > * {
-  overflow: hidden;
-}
-
-.c14 .os-text {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  text-overflow: ellipsis;
-}
-
-.c14 .os-divider {
-  margin: 0 0.4rem;
-}
-
-.c11 {
-  width: 400px;
-  border-bottom: 1px solid #d5d5d5;
-  overflow: visible;
-}
-
-.c12 {
-  display: block;
-  width: 100%;
-  padding: 1rem 1.6rem;
-  text-align: left;
-}
-
-.c12 .c13 {
-  float: left;
-  margin-left: 0;
-  text-align: left;
-}
-
-.c12 .c4 {
-  float: right;
-}
-
-.c12::after {
-  content: "";
-  display: table;
-  clear: both;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 4rem;
-  width: 100%;
-  text-align: left;
-  font-size: 1.4rem;
-  color: #424242;
-}
-
-.c17[aria-current="true"] {
-  color: #027EB5;
-}
-
-.c17:hover,
-.c17:focus {
-  background-color: #f1f1f1;
-  color: #0064A0;
-}
-
-.c17 .c13 {
-  padding-left: 2.5rem;
-  width: 95%;
-}
-
-.c16 {
-  overflow: visible;
-}
-
-.c6 {
-  color: #424242;
-  background: #fff;
-  font-size: 1.4rem;
-  padding: 0.8rem 1.6rem;
-  outline: none;
-  overflow: auto;
-  z-index: 1;
-}
-
-.c6 .all-or-none {
-  margin: 0.8rem 0 0.8rem 0.8rem;
-}
-
-.c6 .checkbox-label {
-  padding: 0.8rem;
-}
-
-.c6 .color-indicator {
-  margin: 0 1.6rem 0 1.6rem;
-}
-
-.c6 .c10:last-child {
-  border-bottom: none;
-}
-
-@media screen and (max-width:75em) {
-  .c3 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    max-height: calc(100vh - 18.4rem);
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c0 .c2 {
-    position: initial;
-  }
-
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    top: auto;
-    margin-top: -0.1rem;
-  }
-}
-
-@media print {
-  .c0 {
-    padding-left: 0;
-  }
-}
-
-@media print {
-  .c0 > *:not(.filters-list) {
-    display: none;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c8 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    overflow: hidden;
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c11 {
-    width: 100%;
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c6 {
-    width: calc(100vw - 1.6rem);
-  }
-}
-
 <div
-  className="c0"
+  className="popup-filters"
 >
   <div
-    className="c1"
+    className="popup-filters-top-bar"
   >
     <div
-      className="dropdown-wrapper c2 "
+      className="dropdown-wrapper"
     >
       <button
         aria-controls="practice-filter-chapter"
         aria-expanded={true}
         aria-label="Select Practice Questions by Chapter & Section"
-        className="plain-button c3 dropdown-toggle"
+        className="plain-button filters-toggle filters-toggle-open dropdown-toggle"
         data-analytics-label="Filter PQ by Chapter & Section"
         onClick={[Function]}
       >
@@ -995,8 +250,7 @@ exports[`Filters ChapterFilter matches snapshot when open without selected secti
           Chapter & Section
           <svg
             aria-hidden="true"
-            className="c4 c5"
-            direction="up"
+            className="filters-angle-icon filters-angle-icon-up"
             viewBox="0 0 320 512"
           >
             <path
@@ -1010,35 +264,35 @@ exports[`Filters ChapterFilter matches snapshot when open without selected secti
         className="dropdown-menu"
       >
         <div
-          className="c6 practice-questions-chapter-filters"
+          className="chapter-filter practice-questions-chapter-filters"
           id="practice-filter-chapter"
           tabIndex={-1}
         >
           <fieldset
-            className="c7"
+            className="filters-fieldset"
           >
             <legend>
               Filter by chapters
             </legend>
             <div
-              className="c8"
+              className="chapter-filter-row"
             >
               <ul
                 aria-label="Filter by chapters"
-                className="c9"
+                className="chapter-filter-column"
               >
                 <li>
                   <div
-                    className="c10 c11"
+                    className="chapter-filter-details"
                   >
                     <button
                       aria-controls="practice-filter-chapter-content-testbook1-testchapter1-uuid"
                       aria-expanded={false}
-                      className="plain-button c12"
+                      className="plain-button chapter-filter-summary-button"
                       onClick={[Function]}
                     >
                       <span
-                        className="c13 c14"
+                        className="chapter-filter-title"
                         dangerouslySetInnerHTML={
                           Object {
                             "__html": "chapterId",
@@ -1047,8 +301,7 @@ exports[`Filters ChapterFilter matches snapshot when open without selected secti
                       />
                       <svg
                         aria-hidden="true"
-                        className="c4 c15"
-                        direction="down"
+                        className="filters-angle-icon"
                         viewBox="0 0 320 512"
                       >
                         <path
@@ -1059,18 +312,18 @@ exports[`Filters ChapterFilter matches snapshot when open without selected secti
                     </button>
                     <div
                       aria-hidden={true}
-                      className="c16"
+                      className="chapter-filter-item-wrapper"
                       hidden={true}
                       id="practice-filter-chapter-content-testbook1-testchapter1-uuid"
                     >
                       <button
                         aria-label="Select Practice Questions by  section1"
-                        className="plain-button c17"
+                        className="plain-button chapter-filter-section-item"
                         data-analytics-label="Filter PQ by  section1"
                         onClick={[Function]}
                       >
                         <span
-                          className="c13 c14"
+                          className="chapter-filter-title"
                           dangerouslySetInnerHTML={
                             Object {
                               "__html": "section1",
@@ -1080,12 +333,12 @@ exports[`Filters ChapterFilter matches snapshot when open without selected secti
                       </button>
                       <button
                         aria-label="Select Practice Questions by  section2"
-                        className="plain-button c17"
+                        className="plain-button chapter-filter-section-item"
                         data-analytics-label="Filter PQ by  section2"
                         onClick={[Function]}
                       >
                         <span
-                          className="c13 c14"
+                          className="chapter-filter-title"
                           dangerouslySetInnerHTML={
                             Object {
                               "__html": "section2",
@@ -1098,16 +351,16 @@ exports[`Filters ChapterFilter matches snapshot when open without selected secti
                 </li>
                 <li>
                   <div
-                    className="c10 c11"
+                    className="chapter-filter-details"
                   >
                     <button
                       aria-controls="practice-filter-chapter-content-testbook1-testchapter2-uuid"
                       aria-expanded={false}
-                      className="plain-button c12"
+                      className="plain-button chapter-filter-summary-button"
                       onClick={[Function]}
                     >
                       <span
-                        className="c13 c14"
+                        className="chapter-filter-title"
                         dangerouslySetInnerHTML={
                           Object {
                             "__html": "chapterId2",
@@ -1116,8 +369,7 @@ exports[`Filters ChapterFilter matches snapshot when open without selected secti
                       />
                       <svg
                         aria-hidden="true"
-                        className="c4 c15"
-                        direction="down"
+                        className="filters-angle-icon"
                         viewBox="0 0 320 512"
                       >
                         <path
@@ -1128,18 +380,18 @@ exports[`Filters ChapterFilter matches snapshot when open without selected secti
                     </button>
                     <div
                       aria-hidden={true}
-                      className="c16"
+                      className="chapter-filter-item-wrapper"
                       hidden={true}
                       id="practice-filter-chapter-content-testbook1-testchapter2-uuid"
                     >
                       <button
                         aria-label="Select Practice Questions by  section21"
-                        className="plain-button c17"
+                        className="plain-button chapter-filter-section-item"
                         data-analytics-label="Filter PQ by  section21"
                         onClick={[Function]}
                       >
                         <span
-                          className="c13 c14"
+                          className="chapter-filter-title"
                           dangerouslySetInnerHTML={
                             Object {
                               "__html": "section21",

--- a/src/app/content/practiceQuestions/components/__snapshots__/PracticeQuestionsPopup.spec.tsx.snap
+++ b/src/app/content/practiceQuestions/components/__snapshots__/PracticeQuestionsPopup.spec.tsx.snap
@@ -3,119 +3,6 @@
 exports[`PracticeQuestions doesn't render practice questions modal if it is closed 1`] = `null`;
 
 exports[`PracticeQuestions renders practice questions modal if it is open 1`] = `
-.c4 {
-  color: #5e6062;
-  width: 1rem;
-  height: 2rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-}
-
-.c3 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-}
-
-.c3 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: visible;
-  width: 100%;
-}
-
-.c0 {
-  position: relative;
-  z-index: 2;
-  overflow: visible;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #fff;
-  border-bottom: 0.1rem solid #d5d5d5;
-}
-
-.c0 .dropdown-toggle {
-  font-weight: bold;
-}
-
-.c0 .c2 > *:not(.dropdown-toggle) {
-  top: calc(100% - 0.1rem);
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  max-height: calc(100vh - 26rem);
-}
-
-@media screen and (max-width:75em) {
-  .c3 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    max-height: calc(100vh - 18.4rem);
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c0 .c2 {
-    position: initial;
-  }
-
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    top: auto;
-    margin-top: -0.1rem;
-  }
-}
-
-@media print {
-  .c0 {
-    padding-left: 0;
-  }
-}
-
-@media print {
-  .c0 > *:not(.filters-list) {
-    display: none;
-  }
-}
-
 <div
   aria-labelledby="modal-title"
   aria-modal="true"
@@ -226,19 +113,19 @@ exports[`PracticeQuestions renders practice questions modal if it is open 1`] = 
       }
     >
       <div
-        className="c0"
+        className="popup-filters"
       >
         <div
-          className="c1"
+          className="popup-filters-top-bar"
         >
           <div
-            className="dropdown-wrapper c2 "
+            className="dropdown-wrapper"
           >
             <button
               aria-controls="practice-filter-chapter"
               aria-expanded={false}
               aria-label="Select Practice Questions by Chapter & Section"
-              className="plain-button c3 dropdown-toggle"
+              className="plain-button filters-toggle dropdown-toggle"
               data-analytics-label="Filter PQ by Chapter & Section"
               onClick={[Function]}
             >
@@ -248,8 +135,7 @@ exports[`PracticeQuestions renders practice questions modal if it is open 1`] = 
                 Chapter & Section
                 <svg
                   aria-hidden="true"
-                  className="c4"
-                  direction="down"
+                  className="filters-angle-icon"
                   viewBox="0 0 320 512"
                 >
                   <path

--- a/src/app/content/studyGuides/components/__snapshots__/Filters.spec.tsx.snap
+++ b/src/app/content/studyGuides/components/__snapshots__/Filters.spec.tsx.snap
@@ -1,301 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = `
-.c4 {
-  color: #5e6062;
-  width: 1rem;
-  height: 2rem;
-  margin-left: 0.8rem;
-  padding-top: 0.2rem;
-  -webkit-transform: rotate(180deg);
-  -ms-transform: rotate(180deg);
-  transform: rotate(180deg);
-  padding-top: 0;
-  padding-bottom: 0.2rem;
-}
-
-.c6 {
-  padding: 0;
-  border: none;
-  margin: 0;
-}
-
-.c6 legend {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  -webkit-clip: rect(0,0,0,0);
-  clip: rect(0,0,0,0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.c3 {
-  position: relative;
-  border-left: 0.1rem solid transparent;
-  border-right: 0.1rem solid transparent;
-  z-index: 2;
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  -webkit-clip-path: inset(0 -0.6rem 0px -0.6rem);
-  clip-path: inset(0 -0.6rem 0px -0.6rem);
-  background-color: #fff;
-  border-left: 0.1rem solid #d5d5d5;
-  border-right: 0.1rem solid #d5d5d5;
-}
-
-.c3 > div {
-  padding: 2rem 2.4rem;
-  outline: none;
-  color: #5e6062;
-  font-size: 1.6rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: visible;
-  width: 100%;
-}
-
-.c0 {
-  position: relative;
-  z-index: 2;
-  overflow: visible;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #fff;
-  border-bottom: 0.1rem solid #d5d5d5;
-}
-
-.c0 .dropdown-toggle {
-  font-weight: bold;
-}
-
-.c0 .c2 > *:not(.dropdown-toggle) {
-  top: calc(100% - 0.1rem);
-  box-shadow: 0 0 0.6rem 0 rgba(0,0,0,0.2);
-  max-height: calc(100vh - 26rem);
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow-x: hidden;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  white-space: nowrap;
-  margin-left: 0.8rem;
-}
-
-.c9 > * {
-  overflow: hidden;
-}
-
-.c9 .os-text {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  text-overflow: ellipsis;
-}
-
-.c9 .os-divider {
-  margin: 0 0.4rem;
-}
-
-.c5 {
-  color: #424242;
-  background: #fff;
-  font-size: 1.4rem;
-  padding: 0.8rem 1.6rem;
-  outline: none;
-  overflow: auto;
-  z-index: 1;
-}
-
-.c5 .all-or-none {
-  margin: 0.8rem 0 0.8rem 0.8rem;
-}
-
-.c5 .checkbox-label {
-  padding: 0.8rem;
-}
-
-.c5 .color-indicator {
-  margin: 0 1.6rem 0 1.6rem;
-}
-
-.c5 .c12:last-child {
-  border-bottom: none;
-}
-
-.c11 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.c10 {
-  background: #fff;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  color: #424242;
-  font-size: 1.4rem;
-  padding: 0.8rem 1.6rem;
-  outline: none;
-  z-index: 1;
-  overflow: auto;
-}
-
-.c10 .all-or-none {
-  margin: 0.8rem 0 0.8rem 0.8rem;
-}
-
-.c10 .checkbox-label {
-  padding: 0.8rem;
-  text-transform: capitalize;
-}
-
-.c10 .color-indicator {
-  margin: 0 1.6rem 0 1.6rem;
-}
-
-@media screen and (max-width:75em) {
-  .c3 > div {
-    padding: 1rem 1.6rem;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    max-height: calc(100vh - 18.4rem);
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c0 .c2 {
-    position: initial;
-  }
-
-  .c0 .c2 > *:not(.dropdown-toggle) {
-    top: auto;
-    margin-top: -0.1rem;
-  }
-}
-
-@media print {
-  .c0 {
-    padding-left: 0;
-  }
-}
-
-@media print {
-  .c0 > *:not(.filters-list) {
-    display: none;
-  }
-}
-
-@media screen and (max-width:75em) {
-  .c7 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    overflow: hidden;
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c5 {
-    width: calc(100vw - 1.6rem);
-  }
-}
-
-@media screen and (max-width:30em) {
-  .c10 {
-    width: calc(100vw - 1.6rem);
-  }
-}
-
 <div
-  className="c0"
+  className="popup-filters"
 >
   <div
-    className="c1"
+    className="popup-filters-top-bar"
   >
     <div
-      className="dropdown-wrapper c2 "
+      className="dropdown-wrapper"
     >
       <button
         aria-controls="guide-filter-chapter"
         aria-expanded={true}
         aria-label="Filter study guides by Chapter"
-        className="plain-button c3 dropdown-toggle"
+        className="plain-button filters-toggle filters-toggle-open dropdown-toggle"
         data-analytics-label="Filter study guides by Chapter"
         onClick={[Function]}
       >
@@ -305,8 +24,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
           Chapter
           <svg
             aria-hidden="true"
-            className="c4"
-            direction="up"
+            className="filters-angle-icon filters-angle-icon-up"
             viewBox="0 0 320 512"
           >
             <path
@@ -320,7 +38,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
         className="dropdown-menu"
       >
         <div
-          className="c5"
+          className="chapter-filter"
           id="guide-filter-chapter"
           tabIndex={-1}
         >
@@ -361,17 +79,17 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
             </button>
           </div>
           <fieldset
-            className="c6"
+            className="filters-fieldset"
           >
             <legend>
               Filter by chapters
             </legend>
             <div
-              className="c7"
+              className="chapter-filter-row"
             >
               <ul
                 aria-label="Filter by chapters"
-                className="c8"
+                className="chapter-filter-column"
               >
                 <li>
                   <label
@@ -401,7 +119,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                       </svg>
                     </span>
                     <span
-                      className="c9"
+                      className="chapter-filter-title"
                       dangerouslySetInnerHTML={
                         Object {
                           "__html": "<span class=\\"os-number\\">1</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 1</span>",
@@ -438,7 +156,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                       </svg>
                     </span>
                     <span
-                      className="c9"
+                      className="chapter-filter-title"
                       dangerouslySetInnerHTML={
                         Object {
                           "__html": "<span class=\\"os-number\\">1</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 1.1</span>",
@@ -475,7 +193,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                       </svg>
                     </span>
                     <span
-                      className="c9"
+                      className="chapter-filter-title"
                       dangerouslySetInnerHTML={
                         Object {
                           "__html": "<span class=\\"os-number\\">2</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 2</span>",
@@ -512,7 +230,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                       </svg>
                     </span>
                     <span
-                      className="c9"
+                      className="chapter-filter-title"
                       dangerouslySetInnerHTML={
                         Object {
                           "__html": "<span class=\\"os-number\\">3</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 3</span>",
@@ -549,7 +267,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                       </svg>
                     </span>
                     <span
-                      className="c9"
+                      className="chapter-filter-title"
                       dangerouslySetInnerHTML={
                         Object {
                           "__html": "<span class=\\"os-number\\">4</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 4</span>",
@@ -586,7 +304,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                       </svg>
                     </span>
                     <span
-                      className="c9"
+                      className="chapter-filter-title"
                       dangerouslySetInnerHTML={
                         Object {
                           "__html": "<span class=\\"os-number\\">10</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 5</span>",
@@ -623,7 +341,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                       </svg>
                     </span>
                     <span
-                      className="c9"
+                      className="chapter-filter-title"
                       dangerouslySetInnerHTML={
                         Object {
                           "__html": "<span class=\\"os-number\\">12</span><span class=\\"os-divider\\"> </span><span class=\\"os-text\\">Test Chapter 6</span>",
@@ -639,13 +357,13 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
       </div>
     </div>
     <div
-      className="dropdown-wrapper c2 "
+      className="dropdown-wrapper"
     >
       <button
         aria-controls="guide-filter-color"
         aria-expanded={true}
         aria-label="Filter study guides by Color"
-        className="plain-button c3 dropdown-toggle"
+        className="plain-button filters-toggle filters-toggle-open dropdown-toggle"
         data-analytics-label="Filter study guides by Color"
         onClick={[Function]}
       >
@@ -655,8 +373,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
           Color
           <svg
             aria-hidden="true"
-            className="c4"
-            direction="up"
+            className="filters-angle-icon filters-angle-icon-up"
             viewBox="0 0 320 512"
           >
             <path
@@ -670,7 +387,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
         className="dropdown-menu"
       >
         <div
-          className="c10 study-guides-color-filter"
+          className="color-filter study-guides-color-filter"
           id="guide-filter-color"
           tabIndex={-1}
         >
@@ -711,7 +428,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
             </button>
           </div>
           <fieldset
-            className="c6"
+            className="filters-fieldset"
           >
             <legend>
               Filter by colors
@@ -771,7 +488,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 />
               </div>
               <span
-                className="c11"
+                className="color-filter-label"
               >
                 Key Terms
               </span>
@@ -831,7 +548,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 />
               </div>
               <span
-                className="c11"
+                className="color-filter-label"
               >
                 Connections & Relationships
               </span>
@@ -891,7 +608,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 />
               </div>
               <span
-                className="c11"
+                className="color-filter-label"
               >
                 Important Concepts
               </span>
@@ -951,7 +668,7 @@ exports[`Filters matches snapshot with UTG banner open (opened initially) 1`] = 
                 />
               </div>
               <span
-                className="c11"
+                className="color-filter-label"
               >
                 Enrichment
               </span>

--- a/src/app/content/styles/PopupConstants.ts
+++ b/src/app/content/styles/PopupConstants.ts
@@ -15,7 +15,6 @@ export const desktopPopupWidth = 74.4;
 export const filters = {
   border: 0.1,
   dropdownContent: {
-    minimumWhiteSpace: 3.2,
     padding: {
       sides: 1.6,
       topBottom: 0.8,
@@ -34,17 +33,5 @@ export const filters = {
       desktop: 2,
       mobile: 1,
     },
-  },
-  get valueToSubstractFromVH() {
-    const desktopPaddingAndHeader = headerHeight + topBottomMargin;
-    const mobilePaddingAndHeader = headerHeight + (mobileMarginTopBottom * 2);
-    const buttonDesktopHeight = (this.dropdownToggle.topBottom.desktop * 2) + this.dropdownToggle.icon.height;
-    const buttonMobileHeight = (this.dropdownToggle.topBottom.mobile * 2) + this.dropdownToggle.icon.height;
-    return {
-      desktop: this.dropdownContent.minimumWhiteSpace + desktopPaddingAndHeader + buttonDesktopHeight,
-      mobile: Number(
-        this.dropdownContent.minimumWhiteSpace + mobilePaddingAndHeader + buttonMobileHeight
-      ).toFixed(1),
-    };
   },
 };

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -181,11 +181,6 @@ export default {
     mobileMediumBreak,
     mobileMediumQuery,
     mobileQuery,
-    mobileSmall: (style: FlattenSimpleInterpolation) => css`
-      @media screen and ${mobileSmallQuery} {
-        ${style}
-      }
-    `,
     mobileSmallBreak,
     mobileSmallQuery,
   },


### PR DESCRIPTION
## Summary

Migrates the three remaining popUp filter components off styled-components and onto plain CSS, per Option A / PR 2 ("Migrate Popup/Filter Components").

**Stacked on** `phase-7.4c-remove-empty-wrappers` (#3116) — review/merge that first.
**Jira**: [CORE-2285](https://openstax.atlassian.net/browse/CORE-2285)

> Note: the original Option A plan listed 4 files here. `FiltersList.tsx` was already migrated in 7.4c, so this is 3.

## Changes

### `src/app/content/components/popUp/Filters.tsx` → `Filters.css`

| was | now |
| --- | --- |
| `AngleDownIconBase` + empty `styled()` wrapper | one `AngleDownIcon` function component |
| `AngleIcon` (`styled(AngleDownIcon)` + `direction` interpolation) | `.filters-angle-icon` / `.filters-angle-icon-up` |
| `Fieldset` (`styled.fieldset`) | `.filters-fieldset` (+ `legend` gets the inlined `hiddenButAccessible` block) |
| `Toggle` (`styled(forwardRef(...))` + `isOpen` interpolation) | `.filters-toggle` / `.filters-toggle-open` |
| `FiltersTopBar` (`styled.div`) | `.popup-filters-top-bar` |
| default `styled(Filters)` | `.popup-filters` |

### `src/app/content/components/popUp/ChapterFilter.tsx` → `ChapterFilter.css`

`PlainButton` empty wrapper, `Row`, `Column`, `ChapterTitle`, `StyledDetailsContainer`, `StyledSummaryButton`, `StyledSectionItem`, `StyledChapterFilterItemWrapper`, and the default wrapper → `.chapter-filter-*` / `.chapter-filter`.

### `src/app/content/components/popUp/ColorFilter.tsx` → `ColorFilter.css`

`ColorLabel` and the default wrapper → `.color-filter-label` / `.color-filter`.

### `src/app/components/Dropdown.tsx` — bonus

`Filters.tsx` held the **last** `${Dropdown}` interpolation in the codebase. With that gone, the empty `styled(DropdownBase)` wrapper left over from 7.4c has no remaining consumer, so `Dropdown.tsx` drops styled-components too. Called out separately because it's outside the three files named in the plan — happy to split it out if you'd rather.

## Component-selector → class-selector mapping

Every interpolation kept its original specificity, so cascade behaviour is unchanged:

| interpolation | selector | specificity |
| --- | --- | --- |
| `${ChapterTitle}` inside `StyledSummaryButton` / `StyledSectionItem` | `.chapter-filter-summary-button .chapter-filter-title`, `.chapter-filter-section-item .chapter-filter-title` | 0,2,0 (was 0,2,0) |
| `${AngleIcon}` inside `StyledSummaryButton` | `.chapter-filter-summary-button .filters-angle-icon` | 0,2,0 |
| `${StyledDetailsContainer}` inside `ChapterFilter` | `.chapter-filter .chapter-filter-details:last-child` | 0,2,0 |
| `${Dropdown}` inside `Filters` | `.popup-filters .dropdown-wrapper > *:not(.dropdown-toggle)` | 0,3,0 (was 0,3,0) |

`.dropdown-menu { top: calc(100% + 0.4rem) }` in `Dropdown.css` is 0,1,0, so the 0,3,0 rule above still wins the same way the styled-components rule did — this one doesn't depend on injection order.

Existing overrides that used doubled-class specificity to beat styled-components still work:
- `.practice-questions-chapter-filters.practice-questions-chapter-filters { padding: 0 }` (0,2,0) still beats `.chapter-filter` (0,1,0).
- `.study-guides-color-filter { min-width: 29rem }` sets a different property than `.color-filter`'s `width`, so no interaction.

## Type fallout

Dropping the `styled()` wrappers restored strict prop checking and surfaced three latent mismatches that styled-components' types were masking:

1. **`ChapterFilter.locationFiltersWithContent` is now conditionally optional.** Practice questions never passed it. That was safe only by accident: `getPracticeQuestionsLocationFilters` returns `LocationFiltersWithChildren`, so every PQ filter has children and the `!children` branch that reads the map is unreachable, and PQ is `multiselect={false}` so the `AllOrNone` branch is skipped too. Under the old types this was a missing required prop that would have thrown if either branch were ever reached. `ChapterFilterProps` is now a union: omission is permitted only for the PQ shape (`LocationFiltersWithChildren` + `multiselect: false`), and the map is required otherwise, so no future caller can omit it into a state where All/None dispatches empty changes or every leaf renders disabled. The component resolves it once against a shared empty `Map` rather than using `?.` at each read site.
2. **`practiceQuestions/Filters.tsx` `setFilters`** was typed `FiltersChange<LinkedArchiveTreeSection>` against a prop declared `FiltersChange<LinkedArchiveTreeNode>`. Widened to the node type with a narrowing cast at the `setSelectedSection` dispatch, where the value is genuinely one of the section children.
3. **`ChapterFilter.spec.tsx`** location-filter fixtures now carry `as unknown as LocationFilters`, matching the cast already used at the top of that file (`new Map() as LocationFilters`).

## Testing

- `eslint src && tsc` — clean
- `stylelint` (both `.tsx` and `.css` configs) — clean on the new files
- `test:unit` — **240 suites / 1918 tests pass**
- 18 snapshots updated: class-name changes only, no DOM structure changes. The one non-class difference is that the invalid `direction="down"` attribute the old `AngleIcon` leaked onto its `<svg>` is gone.

**No e2e fixture changes needed.** None of the remaining `[class*=...]` Playwright locators reference the components touched here — the eight broken ones (`HighlightOuterWrapper`, `HighlightsWrapper`, `TruncatedText`, `TextArea`, `StyledTreeItemContent`, `BookBanner`, `SummaryTitle`, `styled__PlainButton`) are the same pre-existing set flagged as out of scope in #3116.

## Remaining after this PR

6 files still import styled-components, which is exactly Option A's PR 3:

- `src/app/components/DynamicContentStyles.tsx` (`createGlobalStyle`)
- `src/app/components/Footer/SocialIcons.tsx`
- `src/app/content/components/NudgeStudyTools/styles.ts`
- `src/app/content/components/Toolbar/styled.tsx`
- `src/app/content/components/Topbar/styled.tsx`
- `src/app/theme.ts` (theme definition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CORE-2285]: https://openstax.atlassian.net/browse/CORE-2285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
