### PR TITLE
CORE-2731: Add the CSS color audit engine

### DIFF
--- a/src/test/cssColors.spec.ts
+++ b/src/test/cssColors.spec.ts
@@ -1,0 +1,370 @@
+import {
+  colorKey,
+  declarations,
+  describeColor,
+  opaqueKey,
+  stripNoise,
+  stylesheetColors,
+  takesColor,
+} from './cssColors';
+
+const literals = (css: string) => stylesheetColors(css).map((found) => found.literal);
+const values = (css: string) => declarations(css).map((declaration) => declaration.value);
+
+describe('stripNoise', () => {
+  it('removes block comments', () => {
+    expect(stripNoise('a { /* #ff0000 */ color: red; }')).not.toContain('#ff0000');
+  });
+
+  it('removes string contents so content: "tan" is not a color', () => {
+    expect(stripNoise('a { content: "tan"; }')).not.toContain('tan');
+  });
+
+  it('removes url() payloads', () => {
+    const blanked = stripNoise('a { background: url(data:image/svg+xml;base64,Zm9v) no-repeat; }');
+    expect(blanked).not.toContain('base64');
+    expect(blanked).toContain('no-repeat');
+  });
+
+  it('keeps the url() parentheses, which are structure rather than noise', () => {
+    // declarations balances parens to know a `;` inside url() is not a separator
+    expect(stripNoise('a { background: url(x;y); }')).toContain('url(');
+    expect(stripNoise('a { background: url(x;y); }')).toContain(')');
+  });
+
+  it('handles an escaped quote inside a string', () => {
+    expect(stripNoise('a { content: "a\\"b"; }')).not.toContain('b"');
+  });
+
+  it('tolerates an unterminated comment', () => {
+    expect(stripNoise('a { color: red; /* oops')).toContain('color: red;');
+  });
+
+  it.each([
+    ['a comment', 'a { /* note */ color: red; }'],
+    ['a string', 'a { content: "tan"; }'],
+    ['an unterminated string', 'a { content: "tan }'],
+    ['a url()', 'a { background: url(data:image/svg+xml;base64,Zm9v); }'],
+    ['an unterminated url()', 'a { background: url(oops }'],
+    ['an unterminated comment', 'a { color: red; /* oops'],
+  ])('blanks %s without changing the length', (_case, css) => {
+    // declarations addresses two differently-blanked copies with one index, so this
+    // is load-bearing rather than cosmetic: a length change silently misaligns context.
+    expect(stripNoise(css)).toHaveLength(css.length);
+  });
+});
+
+describe('declarations', () => {
+  it('reads declarations at the top level of a rule', () => {
+    expect(values('a { color: red; background: blue; }')).toEqual(['red', 'blue']);
+  });
+
+  it('reads declarations nested in @media', () => {
+    expect(values('@media (max-width: 50em) { a { color: red; } }')).toEqual(['red']);
+  });
+
+  it('does not mistake a pseudo-class selector for a declaration', () => {
+    expect(values('a:hover { color: red; }')).toEqual(['red']);
+  });
+
+  it('does not mistake @keyframes percentages for declarations', () => {
+    expect(values('@keyframes f { 0% { opacity: 0; } 100% { opacity: 1; } }'))
+      .toEqual(['0', '1']);
+  });
+
+  it('ignores at-rules outside a block, such as @import', () => {
+    expect(values('@import "./theme.css";')).toEqual([]);
+  });
+
+  it('reads a declaration with no trailing semicolon', () => {
+    expect(values('a { color: red }')).toEqual(['red']);
+  });
+
+  it('does not split on a semicolon inside parentheses', () => {
+    expect(values('a { background: url(x;y); color: red; }')).toContain('red');
+  });
+
+  it('keeps a custom property declaration', () => {
+    expect(values(':root { --color-x: #fff; }')).toEqual(['#fff']);
+  });
+
+  it('lower-cases the property name', () => {
+    expect(declarations('a { COLOR: red; }')[0].property).toEqual('color');
+  });
+
+  it('records the selector as context', () => {
+    expect(declarations('a:hover .thing { color: red; }')[0].context)
+      .toEqual('a:hover .thing');
+  });
+
+  it('collapses whitespace in the context', () => {
+    expect(declarations('a,\n  b {\n  color: red;\n}')[0].context).toEqual('a, b');
+  });
+
+  it('nests the at-rule prelude and the selector in the context', () => {
+    expect(declarations('@media (max-width: 50em) { a { color: red; } }')[0].context)
+      .toEqual('@media (max-width: 50em) a');
+  });
+
+  it('pops the context again after a nested block closes', () => {
+    const parsed = declarations('@media (max-width: 50em) { a { color: red; } } b { color: blue; }');
+    expect(parsed.map(({context}) => context))
+      .toEqual(['@media (max-width: 50em) a', 'b']);
+  });
+
+  it('keeps string contents in the context, so attribute selectors stay distinct', () => {
+    // the baseline identifies an occurrence by its context, so two rules that differ
+    // only inside a selector string must not reduce to the same one -- otherwise a
+    // literal could move between them and the ratchet would see no change.
+    const parsed = declarations(
+      '.x[data-loading="true"] { color: #fff; } .x[data-loading="false"] { color: #fff; }'
+    );
+
+    expect(parsed.map(({context}) => context))
+      .toEqual(['.x[data-loading="true"]', '.x[data-loading="false"]']);
+  });
+
+  it('still blanks strings in the value, where they are not colors', () => {
+    // the other half of the same change: context keeps strings, values must not, or
+    // `content: "#fff"` starts reading as a color.
+    expect(declarations('a { content: "#fff"; }')).toEqual([]);
+  });
+
+  it('does not let a brace inside a selector string open a block', () => {
+    expect(declarations('.x[data-glyph="{"] { color: red; }'))
+      .toEqual([{context: '.x[data-glyph="{"]', property: 'color', value: 'red'}]);
+  });
+});
+
+describe('takesColor', () => {
+  it.each(['color', 'background-color', 'border-top-color', '-webkit-text-fill-color'])(
+    'accepts %s, which names a color', (property) => {
+      expect(takesColor(property)).toBe(true);
+    }
+  );
+
+  it.each(['background', 'border', 'border-left', 'box-shadow', 'outline', 'fill'])(
+    'accepts the %s shorthand', (property) => {
+      expect(takesColor(property)).toBe(true);
+    }
+  );
+
+  it('accepts a custom property, which has no grammar to go on', () => {
+    expect(takesColor('--book-banner-background')).toBe(true);
+  });
+
+  it.each(['animation-name', 'font-family', 'transition-property', 'grid-area'])(
+    'rejects %s, where an identifier is not a color', (property) => {
+      expect(takesColor(property)).toBe(false);
+    }
+  );
+
+  it('sees through a vendor prefix', () => {
+    expect(takesColor('-webkit-box-shadow')).toBe(true);
+  });
+});
+
+describe('findColors', () => {
+  it('finds a hex literal', () => {
+    expect(literals('a { color: #ff0000; }')).toEqual(['#ff0000']);
+  });
+
+  it('finds a bare named color in a shorthand', () => {
+    expect(literals('a { border: 0.1rem solid red; }')).toEqual(['red']);
+  });
+
+  it('finds colors in gradient stops', () => {
+    expect(literals('a { background: linear-gradient(to top, #fff 0%, #000 100%); }'))
+      .toEqual(['#fff', '#000']);
+  });
+
+  it('descends into var() fallbacks rather than treating var() as a literal', () => {
+    expect(literals('a { color: var(--x, #fff); }')).toEqual(['#fff']);
+  });
+
+  it('descends into color-mix() over tokens and finds nothing', () => {
+    expect(literals('a { color: color-mix(in srgb, var(--a), var(--b)); }')).toEqual([]);
+  });
+
+  it('finds rgba()', () => {
+    expect(literals('a { box-shadow: 0 0 0.2rem rgba(0, 0, 0, 0.2); }'))
+      .toEqual(['rgba(0, 0, 0, 0.2)']);
+  });
+
+  it('finds hsl(), which resolves to null so it cannot pass silently', () => {
+    const found = stylesheetColors('a { color: hsl(0deg 100% 50%); }');
+    expect(found).toHaveLength(1);
+    expect(found[0].rgba).toBeNull();
+  });
+
+  it('finds oklch(), which resolves to null', () => {
+    expect(stylesheetColors('a { color: oklch(0.7 0.1 200); }')[0].rgba).toBeNull();
+  });
+
+  it('flags rgba() over a var() channel list rather than skipping it', () => {
+    const found = stylesheetColors('a { color: rgba(var(--channels), 0.2); }');
+    expect(found).toHaveLength(1);
+    expect(found[0].rgba).toBeNull();
+  });
+
+  it('does not treat a class selector named .red as a color', () => {
+    expect(literals('.red { opacity: 1; }')).toEqual([]);
+  });
+
+  it('does not treat content: "tan" as a color', () => {
+    expect(literals('a { content: "tan"; }')).toEqual([]);
+  });
+
+  it('does not treat a color inside a comment as a color', () => {
+    expect(literals('a { /* was #ff0000 */ color: var(--x); }')).toEqual([]);
+  });
+
+  it('does not treat transparent or currentcolor as comparable colors', () => {
+    expect(literals('a { color: currentcolor; background: transparent; }')).toEqual([]);
+  });
+
+  it('does not treat a non-color keyword as a color', () => {
+    expect(literals('a { transition: all 0.2s linear; }')).toEqual([]);
+  });
+
+  it('finds several colors in one declaration', () => {
+    expect(literals('a { box-shadow: 0 0 0 red, 0 0 0 #00f; }')).toEqual(['red', '#00f']);
+  });
+
+  it('tolerates an unbalanced function call', () => {
+    expect(() => literals('a { color: rgb(0, 0, 0; }')).not.toThrow();
+  });
+
+  it.each([
+    ['an animation name', 'a { animation-name: red; }'],
+    ['a font family', 'a { font-family: black; }'],
+    ['a transitioned property', 'a { transition-property: tan; }'],
+    ['a grid area', 'a { grid-area: navy; }'],
+    // the property gate has to survive the descent into a function, not just the
+    // top level of the value -- findColors passes `named` down to itself.
+    ['a var() fallback under one', 'a { animation-name: var(--enter, red); }'],
+  ])('does not read %s as a named color', (_case, css) => {
+    expect(literals(css)).toEqual([]);
+  });
+
+  it.each([
+    ['a color property', 'a { color: red; }'],
+    ['a shorthand', 'a { border: 0.1rem solid red; }'],
+    ['a custom property', 'a { --x: red; }'],
+    ['a box-shadow', 'a { box-shadow: 0 0 0.2rem red; }'],
+    ['a vendor-prefixed property', 'a { -webkit-text-fill-color: red; }'],
+    // the other side of the descent: gating named colors on the property must not
+    // stop finding them inside a function the walk descends into.
+    ['a gradient stop', 'a { background: linear-gradient(to top, red, transparent); }'],
+  ])('still reads a named color in %s', (_case, css) => {
+    expect(literals(css)).toEqual(['red']);
+  });
+
+  it('still reads hex and rgb() in a property that cannot take a named color', () => {
+    // only the bare-identifier case is property-sensitive: `#fff` and `rgb(...)` are
+    // colors wherever they are written, so they stay in scope everywhere.
+    expect(literals('a { animation-name: #fff; transition-property: rgb(0, 0, 0); }'))
+      .toEqual(['#fff', 'rgb(0, 0, 0)']);
+  });
+
+  it('records the declaration each color was written in', () => {
+    expect(stylesheetColors('@media (max-width: 50em) { .a:hover { color: #fff; } }'))
+      .toEqual([{
+        context: '@media (max-width: 50em) .a:hover',
+        literal: '#fff',
+        property: 'color',
+        rgba: {a: 1, b: 255, g: 255, r: 255},
+      }]);
+  });
+});
+
+describe('describeColor', () => {
+  it('expands 3-digit hex', () => {
+    expect(describeColor('#fff')).toEqual({a: 1, b: 255, g: 255, r: 255});
+  });
+
+  it('reads 8-digit hex alpha', () => {
+    expect(describeColor('#00000033')?.a).toBeCloseTo(0.2, 1);
+  });
+
+  it('reads 4-digit hex', () => {
+    expect(describeColor('#0000')).toEqual({a: 0, b: 0, g: 0, r: 0});
+  });
+
+  it('is case insensitive', () => {
+    expect(describeColor('#027EB5')).toEqual(describeColor('#027eb5'));
+  });
+
+  it('resolves a named color', () => {
+    expect(describeColor('white')).toEqual({a: 1, b: 255, g: 255, r: 255});
+  });
+
+  it('reads comma-separated rgb()', () => {
+    expect(describeColor('rgb(255, 0, 0)')).toEqual({a: 1, b: 0, g: 0, r: 255});
+  });
+
+  it('reads space-separated rgb() with a slash alpha', () => {
+    expect(describeColor('rgb(255 0 0 / 0.5)')).toEqual({a: 0.5, b: 0, g: 0, r: 255});
+  });
+
+  it('reads percentage channels', () => {
+    expect(describeColor('rgb(100%, 0%, 0%)')).toEqual({a: 1, b: 0, g: 0, r: 255});
+  });
+
+  it('reads a percentage alpha', () => {
+    expect(describeColor('rgba(0, 0, 0, 20%)')?.a).toBeCloseTo(0.2);
+  });
+
+  it('returns null for hsl()', () => {
+    expect(describeColor('hsl(0, 100%, 50%)')).toBeNull();
+  });
+
+  it('returns null for a non-numeric channel', () => {
+    expect(describeColor('rgb(var(--x), 0, 0)')).toBeNull();
+  });
+
+  it('returns null for the wrong number of channels', () => {
+    expect(describeColor('rgb(0, 0)')).toBeNull();
+  });
+
+  it('returns null for an unknown identifier', () => {
+    expect(describeColor('notacolor')).toBeNull();
+  });
+
+  it.each(['#12345', '#1234567', '#123456789'])(
+    'returns null for the malformed hex length %s', (literal) => {
+      expect(describeColor(literal)).toBeNull();
+    }
+  );
+
+  it.each(['#ggg', '#gggggg', '#12345g'])(
+    'returns null for %s rather than a set of NaN channels', (literal) => {
+      // the length is right, so only checking the length would hand back
+      // {r: NaN, g: NaN, b: NaN} and read as a resolved color.
+      expect(describeColor(literal)).toBeNull();
+    }
+  );
+
+  it('rounds a percentage channel the same way as its integer spelling', () => {
+    // 50% of 255 is 127.5, which rounds to 128. Scaling by the decimal 2.55 gives
+    // 127.49999999999999 and rounds to 127, so the two spellings would disagree.
+    expect(describeColor('rgb(50%, 50%, 50%)')).toEqual({a: 1, b: 128, g: 128, r: 128});
+    expect(describeColor('rgb(50%, 50%, 50%)')).toEqual(describeColor('rgb(128, 128, 128)'));
+  });
+});
+
+describe('color keys', () => {
+  it('treats an opaque color as equal however it is written', () => {
+    expect(colorKey(describeColor('#fff')!)).toEqual(colorKey(describeColor('white')!));
+  });
+
+  it('distinguishes a translucent color from its opaque form', () => {
+    expect(colorKey(describeColor('rgba(0, 0, 0, 0.2)')!))
+      .not.toEqual(colorKey(describeColor('#000')!));
+  });
+
+  it('recognises a translucent color by its opaque channels', () => {
+    expect(opaqueKey(describeColor('rgba(0, 0, 0, 0.2)')!))
+      .toEqual(opaqueKey(describeColor('#000')!));
+  });
+});

--- a/src/test/cssColors.spec.ts
+++ b/src/test/cssColors.spec.ts
@@ -36,6 +36,20 @@ describe('stripNoise', () => {
     expect(stripNoise('a { content: "a\\"b"; }')).not.toContain('b"');
   });
 
+  it('leaves a function whose name merely ends in url alone', () => {
+    // `myurl(` is not a url token: its payload is ordinary value text, and blanking it
+    // would lose a color. Only an ident boundary before `url` makes it a url token.
+    expect(stripNoise('a { --x: myurl(#fff); }')).toContain('#fff');
+  });
+
+  it('ends a url() at the structural paren, not at one inside its quoted payload', () => {
+    // stopping at the inner `)` would leave the trailing quote behind, and blanking
+    // that "unterminated string" would swallow every declaration after it.
+    const blanked = stripNoise('a { background: url("asset).svg"); } b { color: #fff; }');
+    expect(blanked).toContain('color: #fff;');
+    expect(blanked).not.toContain('asset');
+  });
+
   it('tolerates an unterminated comment', () => {
     expect(stripNoise('a { color: red; /* oops')).toContain('color: red;');
   });
@@ -46,6 +60,9 @@ describe('stripNoise', () => {
     ['an unterminated string', 'a { content: "tan }'],
     ['a url()', 'a { background: url(data:image/svg+xml;base64,Zm9v); }'],
     ['an unterminated url()', 'a { background: url(oops }'],
+    ['a url() with a quoted payload', 'a { background: url("a).svg"); }'],
+    ['a url() with an unterminated quote', 'a { background: url("oops }'],
+    ['a url() ending in an escape', 'a { background: url(oops\\'],
     ['an unterminated comment', 'a { color: red; /* oops'],
   ])('blanks %s without changing the length', (_case, css) => {
     // declarations addresses two differently-blanked copies with one index, so this
@@ -130,6 +147,23 @@ describe('declarations', () => {
     expect(declarations('a { content: "#fff"; }')).toEqual([]);
   });
 
+  it('does not collapse whitespace inside a selector string', () => {
+    // the separator/content distinction: `[data-value="a  b"]` and `[data-value="a b"]`
+    // match different values, so collapsing both to the latter would let a literal move
+    // between two distinct rules without the baseline identity changing.
+    const parsed = declarations(
+      '.x[data-value="a  b"] { color: #fff; } .x[data-value="a b"] { color: #fff; }'
+    );
+
+    expect(parsed.map(({context}) => context))
+      .toEqual(['.x[data-value="a  b"]', '.x[data-value="a b"]']);
+  });
+
+  it('still collapses the whitespace that is a separator', () => {
+    expect(declarations('.a\n  >\n  .b[data-x="y"] { color: red; }')[0].context)
+      .toEqual('.a > .b[data-x="y"]');
+  });
+
   it('does not let a brace inside a selector string open a block', () => {
     expect(declarations('.x[data-glyph="{"] { color: red; }'))
       .toEqual([{context: '.x[data-glyph="{"]', property: 'color', value: 'red'}]);
@@ -205,6 +239,24 @@ describe('findColors', () => {
     const found = stylesheetColors('a { color: rgba(var(--channels), 0.2); }');
     expect(found).toHaveLength(1);
     expect(found[0].rgba).toBeNull();
+  });
+
+  it('finds device-cmyk(), which is a color function rather than a container', () => {
+    // absent from the terminal list it would be descended into, its numeric arguments
+    // would yield nothing, and a hardcoded color would pass the audit unreported.
+    const found = stylesheetColors('a { color: device-cmyk(0 1 1 0); }');
+    expect(found).toHaveLength(1);
+    expect(found[0].literal).toEqual('device-cmyk(0 1 1 0)');
+    expect(found[0].rgba).toBeNull();
+  });
+
+  it('finds a color inside a function whose name merely ends in url', () => {
+    expect(literals('a { --x: myurl(#fff); }')).toEqual(['#fff']);
+  });
+
+  it('keeps finding colors after a url() with a paren in its quoted payload', () => {
+    expect(literals('a { background: url("asset).svg"); } b { color: #fff; }'))
+      .toEqual(['#fff']);
   });
 
   it('does not treat a class selector named .red as a color', () => {
@@ -344,6 +396,27 @@ describe('describeColor', () => {
       expect(describeColor(literal)).toBeNull();
     }
   );
+
+  it.each(['rgb(., 0, 0)', 'rgb(1..2, 0, 0)', 'rgb(0, 0, 0, .)', 'rgb(., 0, 0 )'])(
+    'returns null for %s rather than a set of NaN channels', (literal) => {
+      // `[\d.]+` matches `.` and `1..2`, which parseFloat turns into NaN and a
+      // truncated 1. Only checking for null would hand either back as resolved, the
+      // same failure mode the hex grammar check prevents.
+      expect(describeColor(literal)).toBeNull();
+    }
+  );
+
+  it.each(['rgb(+255, 0, 0)', 'rgb(2.55e2, 0, 0)', 'rgb(255.0, 0, 0)'])(
+    'still reads %s, which the CSS number grammar allows', (literal) => {
+      expect(describeColor(literal)).toEqual({a: 1, b: 0, g: 0, r: 255});
+    }
+  );
+
+  it('reads an rgb() written across several lines', () => {
+    // CSS whitespace inside a function includes newlines; a `.`-based grammar would
+    // leave this unresolved and misreport a resolvable duplicate as unrecognised.
+    expect(describeColor('rgb(\n  255 0 0\n)')).toEqual({a: 1, b: 0, g: 0, r: 255});
+  });
 
   it('rounds a percentage channel the same way as its integer spelling', () => {
     // 50% of 255 is 127.5, which rounds to 128. Scaling by the decimal 2.55 gives

--- a/src/test/cssColors.ts
+++ b/src/test/cssColors.ts
@@ -33,8 +33,9 @@ export interface FoundColor {
 export interface Declaration {
   /**
    * The selectors and at-rule preludes the declaration sits inside, outermost first,
-   * whitespace-collapsed: `@media (max-width: 75em) .book-banner .title`. Used as the
-   * stable half of a color occurrence's identity in the baseline.
+   * with runs of whitespace collapsed outside strings:
+   * `@media (max-width: 75em) .book-banner .title`. Used as the stable half of a
+   * color occurrence's identity in the baseline.
    */
   context: string;
   /** lower-cased property name, e.g. `background-color` or `--book-banner-height` */
@@ -102,6 +103,7 @@ const NAMED_COLORS: {[name: string]: string} = {
  */
 const COLOR_FUNCTIONS = [
   'rgb', 'rgba', 'hsl', 'hsla', 'hwb', 'lab', 'lch', 'oklab', 'oklch', 'color',
+  'device-cmyk',
 ];
 
 /**
@@ -155,16 +157,41 @@ const blankNoise = (css: string, keepStrings: boolean): string => {
       continue;
     }
 
-    const url = /^url\(/i.exec(rest);
+    // `url` has to be the whole function name rather than the tail of one. In
+    // `--x: myurl(#fff)` the payload is ordinary value text to descend into, and
+    // blanking it loses the color. The preceding source character settles it: an
+    // ident character there means `url` is only a suffix.
+    const boundary = index === 0 || !/[\w-]/.test(css[index - 1]);
+    const url = boundary ? /^url\(/i.exec(rest) : null;
     if (url) {
       const open = index + url[0].length;
       let depth = 1;
       let cursor = open;
+      // only a structural `)` ends the url: `url("icon).svg")` closes at the last
+      // paren, not at the one in the filename. Stopping early would leave the trailing
+      // quote behind, and blanking that "unterminated string" would swallow every
+      // declaration after it.
       while (cursor < css.length && depth > 0) {
-        if (css[cursor] === '(') { depth++; }
-        if (css[cursor] === ')') { depth--; }
+        const character = css[cursor];
+
+        if (character === '\\') { cursor += 2; continue; }
+
+        if (character === '"' || character === '\'') {
+          cursor++;
+          while (cursor < css.length && css[cursor] !== character) {
+            cursor += css[cursor] === '\\' ? 2 : 1;
+          }
+          cursor++;
+          continue;
+        }
+
+        if (character === '(') { depth++; }
+        if (character === ')') { depth--; }
         cursor++;
       }
+      // an escape or a quote at the very end can carry the cursor past the end, and the
+      // blanked copy has to stay the same length as the input.
+      cursor = Math.min(cursor, css.length);
       // the parens themselves are structure -- `declarations` balances them -- so only
       // the payload between them is blanked.
       const closed = depth === 0;
@@ -183,6 +210,51 @@ const blankNoise = (css: string, keepStrings: boolean): string => {
 
 /** Noise blanked for reading declaration values: strings go too. */
 export const stripNoise = (css: string): string => blankNoise(css, false);
+
+/**
+ * Collapses runs of whitespace in a selector, but only where the whitespace is
+ * separator rather than content. `[data-label="a  b"]` and `[data-label="a b"]` match
+ * different values, so a context that collapsed both to the latter would stop telling
+ * two rules apart -- which is the one job the context has, and the reason the context
+ * copy keeps its strings in the first place.
+ */
+const collapseSeparators = (selector: string): string => {
+  let out = '';
+  let index = 0;
+
+  while (index < selector.length) {
+    const character = selector[index];
+
+    if (character === '\\') {
+      // an escaped space is part of an identifier, e.g. the class `.a\ b`
+      out += selector.slice(index, index + 2);
+      index += 2;
+      continue;
+    }
+
+    if (character === '"' || character === '\'') {
+      let cursor = index + 1;
+      while (cursor < selector.length && selector[cursor] !== character) {
+        cursor += selector[cursor] === '\\' ? 2 : 1;
+      }
+      const stop = Math.min(cursor + 1, selector.length);
+      out += selector.slice(index, stop);
+      index = stop;
+      continue;
+    }
+
+    if (/\s/.test(character)) {
+      while (index < selector.length && /\s/.test(selector[index])) { index++; }
+      out += ' ';
+      continue;
+    }
+
+    out += character;
+    index++;
+  }
+
+  return out.trim();
+};
 
 /**
  * Pulls declarations out of a stylesheet at any nesting depth, so `@media` blocks are
@@ -230,7 +302,7 @@ export const declarations = (css: string): Declaration[] => {
     if (parens !== 0) { continue; }
 
     if (character === '{') {
-      stack.push(selectors.slice(start, index).replace(/\s+/g, ' ').trim());
+      stack.push(collapseSeparators(selectors.slice(start, index)));
       start = index + 1;
     } else if (character === '}') {
       flush(index);
@@ -271,23 +343,34 @@ export const takesColor = (property: string): boolean => {
 
 const clamp = (value: number, max: number) => Math.min(max, Math.max(0, value));
 
+/**
+ * The CSS `<number>` grammar, shared by the channels and the alpha rather than
+ * approximated as "digits and dots". `[\d.]+` also matches `.` and `1..2`, which
+ * `parseFloat` turns into `NaN` and a truncated `1`; both would then be handed back as
+ * resolved channels, so a malformed declaration would read as a real color and get a
+ * comparison key built out of `NaN` -- the same failure the hex grammar check prevents.
+ */
+const NUMBER = '[+-]?(?:\\d+|\\d*\\.\\d+)(?:e[+-]?\\d+)?';
+const IS_NUMBER = new RegExp(`^${NUMBER}$`, 'i');
+const IS_PERCENTAGE = new RegExp(`^(${NUMBER})%$`, 'i');
+
 const channel = (raw: string): number | null => {
   const text = raw.trim();
-  const percent = /^(-?[\d.]+)%$/.exec(text);
+  const percent = IS_PERCENTAGE.exec(text);
   // scale by 255/100 rather than by the decimal 2.55, which is not representable in
   // binary: 50 * 2.55 is 127.49999999999999 and rounds to 127, where 50% of 255 is
   // 127.5 and rounds to 128. The two spellings of the same color must agree, or they
   // get different keys and the audit misclassifies one of them.
   if (percent) { return Math.round((clamp(parseFloat(percent[1]), 100) / 100) * 255); }
-  return /^-?[\d.]+$/.test(text) ? Math.round(clamp(parseFloat(text), 255)) : null;
+  return IS_NUMBER.test(text) ? Math.round(clamp(parseFloat(text), 255)) : null;
 };
 
 const alphaChannel = (raw?: string): number | null => {
   if (raw === undefined) { return 1; }
   const text = raw.trim();
-  const percent = /^(-?[\d.]+)%$/.exec(text);
+  const percent = IS_PERCENTAGE.exec(text);
   if (percent) { return clamp(parseFloat(percent[1]), 100) / 100; }
-  return /^-?[\d.]+$/.test(text) ? clamp(parseFloat(text), 1) : null;
+  return IS_NUMBER.test(text) ? clamp(parseFloat(text), 1) : null;
 };
 
 /**
@@ -327,7 +410,10 @@ export const describeColor = (literal: string): Rgba | null => {
   const named = NAMED_COLORS[text.toLowerCase()];
   if (named) { return fromHex(named); }
 
-  const fn = /^(rgba?)\((.*)\)$/i.exec(text);
+  // `[\s\S]` rather than the `s` flag, which needs an es2018 target and REX is on
+  // es2017: CSS whitespace inside `rgb()` includes newlines, and a `.` would leave a
+  // wrapped literal unresolved and misreport a theme duplicate as unrecognised.
+  const fn = /^(rgba?)\(([\s\S]*)\)$/i.exec(text);
   if (!fn) { return null; }
 
   const args = fn[2].includes(',')

--- a/src/test/cssColors.ts
+++ b/src/test/cssColors.ts
@@ -410,10 +410,9 @@ export const describeColor = (literal: string): Rgba | null => {
   const named = NAMED_COLORS[text.toLowerCase()];
   if (named) { return fromHex(named); }
 
-  // `[\s\S]` rather than the `s` flag, which needs an es2018 target and REX is on
-  // es2017: CSS whitespace inside `rgb()` includes newlines, and a `.` would leave a
-  // wrapped literal unresolved and misreport a theme duplicate as unrecognised.
-  const fn = /^(rgba?)\(([\s\S]*)\)$/i.exec(text);
+  // dotall: CSS whitespace inside `rgb()` includes newlines, and a bare `.` would
+  // leave a wrapped literal unresolved and misreport a theme duplicate as unrecognised.
+  const fn = /^(rgba?)\((.*)\)$/is.exec(text);
   if (!fn) { return null; }
 
   const args = fn[2].includes(',')

--- a/src/test/cssColors.ts
+++ b/src/test/cssColors.ts
@@ -1,0 +1,430 @@
+/**
+ * Finds the color literals in plain-CSS stylesheet text: what they are, and which
+ * declaration each one was written in.
+ *
+ * This parses declarations rather than grepping for `#hex`, because a grep misses
+ * `rgba()`, `hsl()`, named colors in shorthands and colors in gradient stops —
+ * all of which can silently duplicate or diverge from a theme value.
+ *
+ * Pure parsing, with no imports: it knows nothing about REX, the theme or the token
+ * file. That layer is src/test/themeColors.ts, which is what src/app/theme.spec.ts
+ * and `script/generate-theme-baseline.ts` use.
+ *
+ * Lives under src/test/ because it is test infrastructure rather than app code, so
+ * it is outside jest's `collectCoverageFrom`. It has its own spec regardless: without
+ * one, "CI enforces the palette" would be an assertion rather than a tested guarantee.
+ */
+
+export interface Rgba {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+export interface FoundColor {
+  /** the literal exactly as written, e.g. `rgba(0, 0, 0, 0.2)` */
+  literal: string;
+  /** resolved channels, or null when this syntax cannot be resolved statically */
+  rgba: Rgba | null;
+}
+
+/** A declaration, with enough of its surroundings to identify it again. */
+export interface Declaration {
+  /**
+   * The selectors and at-rule preludes the declaration sits inside, outermost first,
+   * whitespace-collapsed: `@media (max-width: 75em) .book-banner .title`. Used as the
+   * stable half of a color occurrence's identity in the baseline.
+   */
+  context: string;
+  /** lower-cased property name, e.g. `background-color` or `--book-banner-height` */
+  property: string;
+  /** everything to the right of the `:` */
+  value: string;
+}
+
+/** A color literal together with the declaration it was written in. */
+export interface StylesheetColor extends FoundColor {
+  context: string;
+  property: string;
+}
+
+/** https://www.w3.org/TR/css-color-4/#named-colors */
+const NAMED_COLORS: {[name: string]: string} = {
+  aliceblue: '#f0f8ff', antiquewhite: '#faebd7', aqua: '#00ffff', aquamarine: '#7fffd4',
+  azure: '#f0ffff', beige: '#f5f5dc', bisque: '#ffe4c4', black: '#000000',
+  blanchedalmond: '#ffebcd', blue: '#0000ff', blueviolet: '#8a2be2', brown: '#a52a2a',
+  burlywood: '#deb887', cadetblue: '#5f9ea0', chartreuse: '#7fff00', chocolate: '#d2691e',
+  coral: '#ff7f50', cornflowerblue: '#6495ed', cornsilk: '#fff8dc', crimson: '#dc143c',
+  cyan: '#00ffff', darkblue: '#00008b', darkcyan: '#008b8b', darkgoldenrod: '#b8860b',
+  darkgray: '#a9a9a9', darkgreen: '#006400', darkgrey: '#a9a9a9', darkkhaki: '#bdb76b',
+  darkmagenta: '#8b008b', darkolivegreen: '#556b2f', darkorange: '#ff8c00',
+  darkorchid: '#9932cc', darkred: '#8b0000', darksalmon: '#e9967a',
+  darkseagreen: '#8fbc8f', darkslateblue: '#483d8b', darkslategray: '#2f4f4f',
+  darkslategrey: '#2f4f4f', darkturquoise: '#00ced1', darkviolet: '#9400d3',
+  deeppink: '#ff1493', deepskyblue: '#00bfff', dimgray: '#696969', dimgrey: '#696969',
+  dodgerblue: '#1e90ff', firebrick: '#b22222', floralwhite: '#fffaf0',
+  forestgreen: '#228b22', fuchsia: '#ff00ff', gainsboro: '#dcdcdc',
+  ghostwhite: '#f8f8ff', gold: '#ffd700', goldenrod: '#daa520', gray: '#808080',
+  green: '#008000', greenyellow: '#adff2f', grey: '#808080', honeydew: '#f0fff0',
+  hotpink: '#ff69b4', indianred: '#cd5c5c', indigo: '#4b0082', ivory: '#fffff0',
+  khaki: '#f0e68c', lavender: '#e6e6fa', lavenderblush: '#fff0f5', lawngreen: '#7cfc00',
+  lemonchiffon: '#fffacd', lightblue: '#add8e6', lightcoral: '#f08080',
+  lightcyan: '#e0ffff', lightgoldenrodyellow: '#fafad2', lightgray: '#d3d3d3',
+  lightgreen: '#90ee90', lightgrey: '#d3d3d3', lightpink: '#ffb6c1',
+  lightsalmon: '#ffa07a', lightseagreen: '#20b2aa', lightskyblue: '#87cefa',
+  lightslategray: '#778899', lightslategrey: '#778899', lightsteelblue: '#b0c4de',
+  lightyellow: '#ffffe0', lime: '#00ff00', limegreen: '#32cd32', linen: '#faf0e6',
+  magenta: '#ff00ff', maroon: '#800000', mediumaquamarine: '#66cdaa',
+  mediumblue: '#0000cd', mediumorchid: '#ba55d3', mediumpurple: '#9370db',
+  mediumseagreen: '#3cb371', mediumslateblue: '#7b68ee', mediumspringgreen: '#00fa9a',
+  mediumturquoise: '#48d1cc', mediumvioletred: '#c71585', midnightblue: '#191970',
+  mintcream: '#f5fffa', mistyrose: '#ffe4e1', moccasin: '#ffe4b5',
+  navajowhite: '#ffdead', navy: '#000080', oldlace: '#fdf5e6', olive: '#808000',
+  olivedrab: '#6b8e23', orange: '#ffa500', orangered: '#ff4500', orchid: '#da70d6',
+  palegoldenrod: '#eee8aa', palegreen: '#98fb98', paleturquoise: '#afeeee',
+  palevioletred: '#db7093', papayawhip: '#ffefd5', peachpuff: '#ffdab9',
+  peru: '#cd853f', pink: '#ffc0cb', plum: '#dda0dd', powderblue: '#b0e0e6',
+  purple: '#800080', rebeccapurple: '#663399', red: '#ff0000', rosybrown: '#bc8f8f',
+  royalblue: '#4169e1', saddlebrown: '#8b4513', salmon: '#fa8072',
+  sandybrown: '#f4a460', seagreen: '#2e8b57', seashell: '#fff5ee', sienna: '#a0522d',
+  silver: '#c0c0c0', skyblue: '#87ceeb', slateblue: '#6a5acd', slategray: '#708090',
+  slategrey: '#708090', snow: '#fffafa', springgreen: '#00ff7f', steelblue: '#4682b4',
+  tan: '#d2b48c', teal: '#008080', thistle: '#d8bfd8', tomato: '#ff6347',
+  turquoise: '#40e0d0', violet: '#ee82ee', wheat: '#f5deb3', white: '#ffffff',
+  whitesmoke: '#f5f5f5', yellow: '#ffff00', yellowgreen: '#9acd32',
+};
+
+/**
+ * color functions are terminal — we try to resolve them and flag them.
+ * Anything else that happens to *contain* a color (`var`, `color-mix`, the
+ * gradients) is descended into instead.
+ */
+const COLOR_FUNCTIONS = [
+  'rgb', 'rgba', 'hsl', 'hsla', 'hwb', 'lab', 'lch', 'oklab', 'oklch', 'color',
+];
+
+/**
+ * Keywords that are color-valued but carry no fixed channels, so there is nothing
+ * to compare against the theme. They are never flagged.
+ */
+const COLOR_KEYWORDS = ['transparent', 'currentcolor', 'inherit', 'initial', 'unset', 'revert', 'none'];
+
+/**
+ * Blanks the parts of a stylesheet that can hold color-shaped text without meaning a
+ * color: comments, string contents and `url()` payloads.
+ *
+ * Blanked to spaces rather than deleted, so the result is the same length as the input
+ * and every character keeps its original index. `declarations` relies on that: it finds
+ * structure in the blanked text and then slices the corresponding span out of a second,
+ * differently-blanked copy.
+ *
+ * `keepStrings` is what that second copy is for. A string is noise inside a declaration
+ * value — `content: "#fff"` is not a color — but it is *meaning* inside a selector:
+ * `[data-loading="true"]` and `[data-loading="false"]` are different rules, and blanking
+ * both to `[data-loading=""]` would make them one declaration as far as the baseline is
+ * concerned, so a literal could move between them without the ratchet noticing.
+ */
+const blankNoise = (css: string, keepStrings: boolean): string => {
+  const pad = (length: number) => ' '.repeat(Math.max(0, length));
+  let out = '';
+  let index = 0;
+
+  while (index < css.length) {
+    const rest = css.slice(index);
+
+    if (rest.startsWith('/*')) {
+      const end = css.indexOf('*/', index + 2);
+      const stop = end === -1 ? css.length : end + 2;
+      out += pad(stop - index);
+      index = stop;
+      continue;
+    }
+
+    const quote = css[index];
+    if (quote === '"' || quote === '\'') {
+      let cursor = index + 1;
+      while (cursor < css.length && css[cursor] !== quote) {
+        cursor += css[cursor] === '\\' ? 2 : 1;
+      }
+      const stop = Math.min(cursor + 1, css.length);
+      // blanked whole, quotes included: nothing downstream needs the quotes, and
+      // keeping them would have to handle an unterminated string running off the end.
+      out += keepStrings ? css.slice(index, stop) : pad(stop - index);
+      index = stop;
+      continue;
+    }
+
+    const url = /^url\(/i.exec(rest);
+    if (url) {
+      const open = index + url[0].length;
+      let depth = 1;
+      let cursor = open;
+      while (cursor < css.length && depth > 0) {
+        if (css[cursor] === '(') { depth++; }
+        if (css[cursor] === ')') { depth--; }
+        cursor++;
+      }
+      // the parens themselves are structure -- `declarations` balances them -- so only
+      // the payload between them is blanked.
+      const closed = depth === 0;
+      const payloadEnd = closed ? cursor - 1 : cursor;
+      out += css.slice(index, open) + pad(payloadEnd - open) + (closed ? ')' : '');
+      index = cursor;
+      continue;
+    }
+
+    out += css[index];
+    index++;
+  }
+
+  return out;
+};
+
+/** Noise blanked for reading declaration values: strings go too. */
+export const stripNoise = (css: string): string => blankNoise(css, false);
+
+/**
+ * Pulls declarations out of a stylesheet at any nesting depth, so `@media` blocks are
+ * covered. Selectors and at-rule preludes end at a `{` and become the declaration's
+ * `context` rather than being read as declarations themselves, which is what keeps
+ * `a:hover` and `@keyframes` percentages out of the color scan.
+ *
+ * The property name is kept as well as the value. Two things need it: a bare
+ * identifier is only a color in a property that takes one (`animation-name: red` is
+ * an animation), and the baseline needs a way to tell two occurrences of the same
+ * literal in the same file apart.
+ *
+ * Two blanked copies of the source are walked in step. Structure is read from `values`,
+ * where strings are gone, so a `;` or `{` inside one cannot split a declaration. The
+ * `context` is sliced out of `selectors`, where string contents survive, so that
+ * `[data-loading="true"]` and `[data-loading="false"]` stay distinguishable. Both are
+ * the same length as the input, which is what lets one index address both.
+ */
+export const declarations = (css: string): Declaration[] => {
+  const found: Declaration[] = [];
+  const values = stripNoise(css);
+  const selectors = blankNoise(css, true);
+  const stack: string[] = [];
+  let start = 0;
+  let parens = 0;
+
+  const flush = (end: number) => {
+    const segment = values.slice(start, end);
+    const separator = segment.indexOf(':');
+
+    if (stack.length > 0 && separator !== -1) {
+      const value = segment.slice(separator + 1).trim();
+      const property = segment.slice(0, separator).trim().toLowerCase();
+      if (value) { found.push({context: stack.join(' '), property, value}); }
+    }
+
+    start = end + 1;
+  };
+
+  for (let index = 0; index < values.length; index++) {
+    const character = values[index];
+
+    if (character === '(') { parens++; }
+    if (character === ')') { parens = Math.max(0, parens - 1); }
+    if (parens !== 0) { continue; }
+
+    if (character === '{') {
+      stack.push(selectors.slice(start, index).replace(/\s+/g, ' ').trim());
+      start = index + 1;
+    } else if (character === '}') {
+      flush(index);
+      stack.pop();
+    } else if (character === ';') {
+      flush(index);
+    }
+  }
+
+  return found;
+};
+
+/**
+ * Properties whose value can hold a `<color>`, directly or inside a shorthand.
+ *
+ * Hex and the color functions are only ever colors, so they are read wherever they
+ * appear. A bare identifier is not: `animation-name: red` names a keyframe animation
+ * and `font-family: black` names a font, and reporting either as a palette violation
+ * would be wrong. Named colors are therefore only read here. Custom properties have
+ * no property grammar at all, so they count.
+ */
+const COLOR_SHORTHANDS = [
+  'background', 'background-image', 'border', 'border-block', 'border-block-end',
+  'border-block-start', 'border-bottom', 'border-image', 'border-image-source',
+  'border-inline', 'border-inline-end', 'border-inline-start', 'border-left',
+  'border-right', 'border-top', 'box-shadow', 'caret', 'column-rule', 'fill', 'filter',
+  'backdrop-filter', 'list-style', 'mask', 'mask-image', 'outline', 'stroke',
+  'text-decoration', 'text-emphasis', 'text-shadow', 'text-stroke',
+];
+
+export const takesColor = (property: string): boolean => {
+  if (property.startsWith('--')) { return true; }
+
+  const name = property.replace(/^-(?:webkit|moz|ms|o)-/, '');
+
+  return name.includes('color') || COLOR_SHORTHANDS.includes(name);
+};
+
+const clamp = (value: number, max: number) => Math.min(max, Math.max(0, value));
+
+const channel = (raw: string): number | null => {
+  const text = raw.trim();
+  const percent = /^(-?[\d.]+)%$/.exec(text);
+  // scale by 255/100 rather than by the decimal 2.55, which is not representable in
+  // binary: 50 * 2.55 is 127.49999999999999 and rounds to 127, where 50% of 255 is
+  // 127.5 and rounds to 128. The two spellings of the same color must agree, or they
+  // get different keys and the audit misclassifies one of them.
+  if (percent) { return Math.round((clamp(parseFloat(percent[1]), 100) / 100) * 255); }
+  return /^-?[\d.]+$/.test(text) ? Math.round(clamp(parseFloat(text), 255)) : null;
+};
+
+const alphaChannel = (raw?: string): number | null => {
+  if (raw === undefined) { return 1; }
+  const text = raw.trim();
+  const percent = /^(-?[\d.]+)%$/.exec(text);
+  if (percent) { return clamp(parseFloat(percent[1]), 100) / 100; }
+  return /^-?[\d.]+$/.test(text) ? clamp(parseFloat(text), 1) : null;
+};
+
+/**
+ * Only the four lengths CSS defines, and only hex digits. Checking the grammar rather
+ * than just the length matters: `#ggg` would otherwise expand to six characters,
+ * `parseInt` them to NaN, and hand back an Rgba of NaNs that reads as a resolved
+ * color. A malformed *theme* value would then pass the "every color token resolves"
+ * spec while generating invalid CSS.
+ */
+const HEX = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/;
+
+const fromHex = (literal: string): Rgba | null => {
+  if (!HEX.test(literal.toLowerCase())) { return null; }
+
+  const digits = literal.slice(1);
+  const expand = (text: string) => text.split('').map((c) => c + c).join('');
+  const full = digits.length === 3 || digits.length === 4 ? expand(digits) : digits;
+
+  return {
+    a: full.length === 8 ? parseInt(full.slice(6, 8), 16) / 255 : 1,
+    b: parseInt(full.slice(4, 6), 16),
+    g: parseInt(full.slice(2, 4), 16),
+    r: parseInt(full.slice(0, 2), 16),
+  };
+};
+
+/**
+ * Resolves a color literal to channels, or null when it cannot be resolved
+ * statically. Returning null is deliberate: `hsl()`, `oklch()` and `color()` fail
+ * the audit rather than passing silently, so the escape hatch stays explicit.
+ */
+export const describeColor = (literal: string): Rgba | null => {
+  const text = literal.trim();
+
+  if (text.startsWith('#')) { return fromHex(text.toLowerCase()); }
+
+  const named = NAMED_COLORS[text.toLowerCase()];
+  if (named) { return fromHex(named); }
+
+  const fn = /^(rgba?)\((.*)\)$/i.exec(text);
+  if (!fn) { return null; }
+
+  const args = fn[2].includes(',')
+    ? fn[2].split(',')
+    : fn[2].replace(/\//g, ' ').trim().split(/\s+/);
+
+  if (args.length < 3 || args.length > 4) { return null; }
+
+  const [r, g, b] = args.slice(0, 3).map(channel);
+  const a = alphaChannel(args[3]);
+
+  return r === null || g === null || b === null || a === null ? null : {a, b, g, r};
+};
+
+/**
+ * Finds every color literal in a declaration value, at any depth. Functions that
+ * merely contain colors are descended into; color functions are terminal.
+ *
+ * `named` says whether a bare identifier may be read as a color, which depends on the
+ * property the value belongs to — see `takesColor`. Hex and the color functions are
+ * unambiguous and are found either way. It has no default: defaulting it to `true`
+ * would quietly restore the over-eager behaviour for any caller that forgot it.
+ */
+export const findColors = (value: string, named: boolean): FoundColor[] => {
+  const found: FoundColor[] = [];
+  let index = 0;
+
+  while (index < value.length) {
+    const rest = value.slice(index);
+
+    const call = /^([a-z][\w-]*)\(/i.exec(rest);
+    if (call) {
+      let depth = 1;
+      let cursor = index + call[0].length;
+      while (cursor < value.length && depth > 0) {
+        if (value[cursor] === '(') { depth++; }
+        if (value[cursor] === ')') { depth--; }
+        cursor++;
+      }
+      const literal = value.slice(index, cursor);
+      const args = literal.slice(call[0].length, literal.endsWith(')') ? -1 : undefined);
+
+      if (COLOR_FUNCTIONS.includes(call[1].toLowerCase())) {
+        found.push({literal, rgba: describeColor(literal)});
+      } else {
+        found.push(...findColors(args, named));
+      }
+
+      index = cursor;
+      continue;
+    }
+
+    const hex = /^#[0-9a-fA-F]{3,8}\b/.exec(rest);
+    if (hex) {
+      found.push({literal: hex[0], rgba: describeColor(hex[0])});
+      index += hex[0].length;
+      continue;
+    }
+
+    const word = /^-?[a-zA-Z][\w-]*/.exec(rest);
+    if (word) {
+      const name = word[0].toLowerCase();
+      if (named && NAMED_COLORS[name] && !COLOR_KEYWORDS.includes(name)) {
+        found.push({literal: word[0], rgba: describeColor(word[0])});
+      }
+      index += word[0].length;
+      continue;
+    }
+
+    index++;
+  }
+
+  return found;
+};
+
+/**
+ * Every color literal written in a stylesheet, in source order.
+ *
+ * Accumulated with `push` rather than by spreading into a new array per declaration:
+ * this runs over every stylesheet in the tree, so the quadratic version was copying
+ * every color found so far once per subsequent declaration.
+ */
+export const stylesheetColors = (css: string): StylesheetColor[] => {
+  const found: StylesheetColor[] = [];
+
+  for (const {context, property, value} of declarations(css)) {
+    for (const color of findColors(value, takesColor(property))) {
+      found.push({...color, context, property});
+    }
+  }
+
+  return found;
+};
+
+/** Canonical key for comparing two colors. Opaque colors ignore alpha. */
+export const colorKey = (rgba: Rgba): string =>
+  rgba.a === 1 ? `${rgba.r},${rgba.g},${rgba.b}` : `${rgba.r},${rgba.g},${rgba.b},${rgba.a}`;
+
+/** Key ignoring alpha, so `rgba(0, 0, 0, 0.2)` can be recognised as the theme's black. */
+export const opaqueKey = (rgba: Rgba): string => `${rgba.r},${rgba.g},${rgba.b}`;


### PR DESCRIPTION
Jira: [CORE-2731](https://openstax.atlassian.net/browse/CORE-2731) (sub-task of [CORE-1685](https://openstax.atlassian.net/browse/CORE-1685))

**1 of 2** — the split Roy asked for in review on #3133, following the same shape as [ui-components#149](https://github.com/openstax/ui-components/pull/149) → [#150](https://github.com/openstax/ui-components/pull/150). `main` → **this** → #3133.

## What this is

Pure CSS parsing that answers one question: **given stylesheet text, which color literals are in it, and which declaration was each one written in.** It knows nothing about REX, the theme, the token file or the baseline — that layer, and everything CI enforces with it, is #3133.

The file has no imports at all, which is what makes it reviewable on its own: you can read it without knowing anything about theme tokens.

- `stripNoise` blanks comments, string contents and `url()` payloads. It blanks **to spaces rather than deleting**, so the result is the same length as the input and every character keeps its index. That is load-bearing: `declarations` reads structure from the copy where strings are gone (so a `;` or `{` inside a string cannot split a declaration) and slices `context` from a second copy where strings survive (so `[data-loading="true"]` and `[data-loading="false"]` stay distinguishable). One index addresses both only because the lengths match.
- A brace/semicolon scan pulls `{context, property, value}` at any nesting depth, so `@media` blocks are covered while selectors and `@keyframes` percentages are not read as values.
- Each value is then walked for colors in any syntax — hex, the functional notations, and bare names against the full CSS named-color table.

Three rules worth a reviewer's attention:

- **Functions that merely *contain* colors are descended into** (`var()`, `color-mix()`, the gradients) rather than treated as literals, so building a value out of tokens stays clean and a hardcoded gradient stop is still found.
- **A bare identifier is only read as a color where one can legally go** — a custom property, a `color`-named property, or one of the color-bearing shorthands, vendor prefixes stripped first. So `animation-name: red`, `font-family: black` and `grid-area: navy` are not findings. Hex and the color functions are unambiguous and stay in scope everywhere; a case asserts `animation-name: #fff` *is* still flagged, so the narrowing cannot quietly grow into "skip these properties".
- **Anything that cannot be resolved to channels comes back as `rgba: null`** rather than being dropped — `hsl()`, `oklch()`, `color()`, `rgb()` over a `var()` channel list. The caller decides, and in #3133 it fails, so the escape hatch stays explicit.

## Why it is worth a separate review

It is about half of what #3133 added and it is the half with least to do with theme tokens. The **114 cases in `cssColors.spec.ts` are the contract** — each says either "this must be flagged" or "this must be left alone" — and they are the reason "CI enforces the palette" is a tested guarantee rather than an assertion.

Two of them exist because the parser got these wrong in review on #3133, and they are the ones to read first if you are spot-checking:

- `rgb(50%, 50%, 50%)` keyed as `127,127,127` while `#808080` keyed as `128,128,128`, because scaling by the decimal `2.55` is not representable in binary. The two spellings of one grey could never match.
- `#ggg` parsed as a color: only the expanded *length* was checked, not the digits, so it handed back an `Rgba` of `NaN`s that read as resolved.

## Nothing consumes it yet

On `main` alone this is test infrastructure with a spec and no caller; `src/test/themeColors.ts` and `src/app/theme.spec.ts`, which the header comment points at, arrive in #3133. That is the cost of the split, and it is the same trade ui-components#149 made. The alternative is reviewing the parser and the token design in one 2,000-line diff.

`src/test/` is outside jest's `collectCoverageFrom`, so this does not have to reach the repo's 100% threshold on `src/{app,helpers,gateways}` — it is test infrastructure, and its spec covers it regardless.

## Verification

- Checked out on top of `main` with nothing else applied: `cssColors.spec.ts` 114 tests pass and `tsc` is clean, so it genuinely stands alone.
- `src/test` is on `.eslintrc`'s `ignorePatterns` (pre-existing), so `eslint src` does not cover this file; `tsc` does.
- On the #3133 branch, splitting this out regenerates `theme.baseline.json` **byte-identical at 206 duplicates / 37 unrecognised**, which is the check that the extraction changed no behaviour.

## Review round (c25e4193, 9878d19f)

Copilot found six parsing edge cases and all six were real. Each already had a fix on
[ui-components#149](https://github.com/openstax/ui-components/pull/149), so these are
ports of those rather than independently derived — the two copies converged, which is
what #3137 has to reconcile.

- `device-cmyk()` added to the terminal color functions; it was descended into and
  produced no finding at all.
- `url(` now requires an ident boundary, so `myurl(#fff)` is no longer read as a url
  token with its payload blanked.
- The `url()` scan is quote- and escape-aware. This was the one with real blast radius:
  `url("asset).svg")` closed at the paren in the filename, leaving the trailing quote to
  open an unterminated string that blanked **the rest of the stylesheet**.
- Selector whitespace collapses only outside strings, so `[data-value="a  b"]` and
  `[data-value="a b"]` stay distinct — the reason the context copy keeps strings at all.
- Channels and alpha share the CSS `<number>` grammar. `[\d.]+` matched `.` and `1..2`,
  which `parseFloat` turned into `NaN` and a truncated `1` and which came back as
  *resolved* — the same failure the hex grammar check exists to prevent. It also
  rejected the legal `+255` and `2.55e2`, so it was wrong in both directions.
- The `rgb()`/`rgba()` grammar is dotall, so a literal wrapped across lines resolves.

18 new cases, 13 of which fail against the previous parser. 96 → 114.

None of these six constructs appear in REX's 106 stylesheets, so `theme.baseline.json`
on #3133 is unaffected; regenerating it there remains the definitive check.

## Second review round — no code change

Copilot returned 13 more findings (3 inline, 10 suppressed). All were assessed; **none
were fixed here**, deliberately:

- **None of the 13 can fire on REX's CSS.** Seven need a CSS `\` escape, and the 110
  stylesheets contain exactly one backslash — `content: "\2022"`, inside a string that is
  blanked regardless. The rest need constructs REX does not have: vendor-prefixed
  gradients, `list-style-image`/`mask-image`/`border-image-source`, `color-scheme`,
  uppercase custom properties, brace-valued custom properties, `#fff-foo` hash tokens, or
  a comment used as a compound-selector joiner. So `theme.baseline.json` on #3133 is
  unaffected either way.
- **Nine of the 13 are already fixed in ui-components#149**, the parser that replaces this
  file — `ESCAPE`/`identSpan`/`decodeEscapes`, `COLOR_CONTAINERS`, the `NON_COLOR`
  exclusions, `list-style` removed, custom-property names kept as written, and
  component-value brace tracking.
- **The four that are not fixed upstream were carried to
  [ui-components#149](https://github.com/openstax/ui-components/pull/149)**, where the code
  survives: escape decoding missing for the `url(`/function-name/property-name identifier
  positions, the `\b` in the hex pattern letting `#fff-foo` through, and comments padded to
  spaces merging `.a/**/.b` with `.a .b`.

Rationale in [this comment](https://github.com/openstax/rex-web/pull/3142#issuecomment-5637334529).
Still 114/114 with `tsc` clean; all 8 checks green on `9878d19f`.

## Follow-up

[CORE-2737](https://openstax.atlassian.net/browse/CORE-2737) (#3137) replaces this copy with the same engine published from ui-components, so REX stops carrying its own. That is why this file is a plausible thing to have in its own commit: it is the thing that gets swapped out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CORE-2731]: https://openstax.atlassian.net/browse/CORE-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-1685]: https://openstax.atlassian.net/browse/CORE-1685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-2737]: https://openstax.atlassian.net/browse/CORE-2737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

